### PR TITLE
Adds a word for 'bone'.

### DIFF
--- a/english/english-pandunia.md
+++ b/english/english-pandunia.md
@@ -147,6 +147,7 @@ boat (ship)   : bote
 body   : badan  
 Bolivia   : bolivia  
 bomb   : bomba  
+bone (skeleton)   : hadi  
 book   : buku  
 booking (reservation)   : buking  
 border (edge, rim, fringe)   : kenar  

--- a/english/pandunia-english.md
+++ b/english/pandunia-english.md
@@ -327,6 +327,7 @@ guru : guru (mentor)
 
 ha : have  
 habar : news  
+hadi : bone (skeleton)
 haha : laugh  
 hai : still (yet)  
 haide : let's  


### PR DESCRIPTION
Taken from Hindi हड्डी, it seems to be the best direct fit for Pandunia's pronunciations.

This is probably done wrong and is half intended to be a bath of fire to help me figure out what's up, but this was one word that was bothering me as missing from vocab.

A major competitor is 'koist', found across near all of Eastern Europe, as well as 'fupa' which can be found in multiple Bantu languages.

I was first learning towards 'fupa', but put this up as-is for input from others. 