### PR TITLE
madyar -> madyaria

### DIFF
--- a/engli/engli-pandunia.md
+++ b/engli/engli-pandunia.md
@@ -1005,7 +1005,7 @@ humor : yumor
 humorist : yumoriste  
 humorous (comical, funny) : yumori  
 hundred (##) : hon  
-Hungary : madyar  
+Hungary : madyaria  
 hurry (hasten) : yala  
 hurt (pain) : tung  
 hurt : paxa  

--- a/engli/pandunia-engli.md
+++ b/engli/pandunia-engli.md
@@ -1221,7 +1221,7 @@ madagasi : Malagasy
 madagasia : Madagascar  
 made : matter (substance)  
 madi : material  
-madyar : Hungary  
+madyaria : Hungary  
 mafan : trouble (disturbance, bother)  
 mafana : bother  
 mager : magician (sorcerer)  

--- a/polski/pandunia-polski.md
+++ b/polski/pandunia-polski.md
@@ -1186,7 +1186,7 @@ madagasi : madagaskarski; malagaski
 madagasia : Madagaskar  
 made : materia, substancja  
 madi : materialny  
-madyar : Węgry  
+madyaria : Węgry  
 mafan : problem, kłopot, zakłócenie  
 mafana : przeszkodzić, przeszkadzać, robić kłopot  
 mager : magik, czarownik  

--- a/polski/polski-pandunia.md
+++ b/polski/polski-pandunia.md
@@ -2199,7 +2199,7 @@ wóz, wózek : kar
 wątpliwość, zwątpienie, niewiara, niedowierzanie, nieufność : dute  
 wąż : serpe  
 węgiel : karbon  
-Węgry : madyar  
+Węgry : madyaria  
 węzeł, zupeł : node  
 władać, panować, rządzić jako imperator : impera  
 władca : sultaner  

--- a/suomi/pandunia-suomi.md
+++ b/suomi/pandunia-suomi.md
@@ -1219,7 +1219,7 @@ madagasi : malagassi
 madagasia : Madagaskar  
 made : aine (materia)  
 madi : aineellinen (materiaalinen)  
-madyar : Unkari  
+madyaria : Unkari  
 mafan : vaiva (haitta)  
 mafana : vaivata  
 mager : taikuri  

--- a/suomi/suomi-pandunia.md
+++ b/suomi/suomi-pandunia.md
@@ -2164,7 +2164,7 @@ ulostaa (kakata) : kaka
 uloste (kakka) : kake  
 ulvoa : ulula  
 ulvonta : ulul  
-Unkari : madyar  
+Unkari : madyaria  
 upea (hieno) : kul  
 upea (mahtava) : super  
 uraani : uranium  


### PR DESCRIPTION
In Hungarian, "magyar" is an adjective or nominalized adjective, and the country's name literally translates to "Hungarian-country", analogous to e.g. "deutsch" and "Deutschland". "madyar" should be the root for related words then.