### PR TITLE
uza nasmedi kitabe pa dexnam

### DIFF
--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -89,6 +89,7 @@ amen:i|ameni||||certain (sure)||seguro|||||||||||||certa|varma|pewny (pewien)
 amen:o|ameno|||ara:(ʾāmin), tur:amin,emin, heb:hbo:אמן, ell:ἀμήν (ámén), eng:deu:fra:pol:spa:amen, zho:阿门 (āmén), kor:아멘 (amen), jpn:アーメン (āmen)|certainly (surely, amen)|sûrement|seguramente (amén)|||||||||||||certe|varmasti (totisesti, aamen)|na pewno (z pewnością, amen)
 Amerik:e|Amerike|||eng:America, spa:por:América, rus:Америка (Amerika), tur:swa:may:Amerika, ara:أمريكا‎ (ʾamrīkā), hin:अमेरिका (amerikā), ben:আমেরিকা (amerika), jpn:アメリカ (amerika)|America (continent)|Amérique|América|||||||||||||Ameriko|Amerikka|Ameryka (kontynent)
 amerik:i|ameriki||||American|américain|americano|||||||||||||amerika|amerikkalainen|amerykański
+Amerik:i Samoa:|Ameriki Samoa|desh|AS||American Samoa||Samoa Americana|||||||||||||||Amerykańska Samoa
 amerik.em|amerikem|mate|Am||americium||americio|||||||||||||americio|amerikium|ameryk
 amir:|amir|||ara: أَمْر‎ (ʾamr), fas: امر‎ (amr), tur:emir, swa:amri, hau:umarni + eng:admiral, fra:amiral, spa:por:emir rus:эмир (emir)|order (command)||orden (mando, comando)|||||||||||amri|emir|ordono|käsky (komento)|rozkaz, komenda
 amir:a|amira||||order (issue a command)||mandar (ordenar)|||||||||||||ordoni|käskeä (komentaa)|rozkazać, rozkazywać, zakomendować
@@ -146,9 +147,9 @@ anus:|anus|||eng:fra:anus, por:ânus, spa:ano, deu:Anus, rus:анус (anus), tu
 anus:i|anusi||||anal||anal|||||||||||||anusa|anaalinen|analny, odbytni
 apel:|apel|biw||eng:apple, deu:Apfel, may:apel, ben:আেপল (apôl), zul:ihhabhula|apple|pomme|manzana|maçã|яблоко|تُفَّاح‎|苹果|林檎|||सेब||apel (epal)|tofaa|elma|pomo|omena|jabłko
 apel.sos:|apelsos||||applesauce|compote de pommes|compota de manzanas|purê de maçã|яблочное пюре||||||||||||omenasose|sos jabłkowy
-Aphaz:ia|Aphazia|desh|||Abkhazia||abjazia||Абхазия||||||||||||Abhaasia|Abchazja
 aplik:a|aplika||||apply (put to use for a purpose)|appliquer|emplear (aplicar)|usar|||运用||||प्रयोग में लाना||||kullanmak||soveltaa|zastosować, stosować
 aplik:e|aplike|||eng:fra:application, spa:aplicación, por:aplicação, pol:aplikacja|application||aplicación||||||||||||||sovellus|zastosowanie, aplikacja
+Apsni:|Apsni|desh|||Abkhazia||abjazia||Абхазия||||||||||||Abhaasia|Abchazja
 ar:|ar|||eng:area, por:spa:área, pol:areał, fra:aire|area (extent of surface)|aire (superficie)|área (superficie)||площадь||面积|||||||||areo|ala (pinta-ala)|pole, powierzchnia
 ar:ia|aria||||area (region)||área (zona, región)|||||辺||||||||ejo|alue (seutu)|powierzchnia, region, teren
 arab,o.babul:|arabobabul|biw|Vachellia nilotica||babul tree (thorny acacia)||goma arábiga||акация нильская||阿拉伯金合欢|||||||||||akacja arabska
@@ -157,7 +158,7 @@ aran:|aran|biw|Araneae|fra:araignee, por:aranha, spa:araña, eng:arachnid|spider
 aran.fob:ia|aranfobia||||arachnophobia|arachnophobie|aracnofobia|||||||||||||araneofobio|araknofobia (hämähäkkikammo)|arachnofobia
 aran.net:e|arannete||||spiderweb (cobweb)|toile d'araignée|||||||||||||||hämähäkinverkko|pajęczyna
 arbuz:e|arbuze|biw|Citrullus lanatus|rus:арбуз (arbuz), pol:arbuz, tur:karpuz, ell:καρπούζι (karpuzi), hin:तरबूज़ (tarbūz), ben:তরমুজ (tôrmuj)|watermelon|pastèque|sandía (patilla)|melancia|арбуз||西瓜||||तरबूज||semangka||karpuz|akvomelono|vesimeloni|arbuz
-Arcah:ia|Arcahia|desh|||Artsakh||Artsaj|||||||||||||||Abchazja
+Arcah:|Arcah|desh|||Artsakh||Artsaj|||||||||||||||Abchazja
 argent:e|argente|mate|Ag|por:ita:argento, fra:argent, may:argentum|silver|argent|plata|prata|||银|銀|||||perak (argentum)|||arĝento|hopea|srebro
 Argentina:|Argentina|desh|AR||Argentina|Argentine|Argentina|||||||||||||Argentino|Argentiina|Argentyna
 argon:|argon|mate|Ar||argon|argon|argón|||||||||||||argono|argon|argon
@@ -197,7 +198,7 @@ at.ion:|ation||||action|action|acción|ação|действие (акция)||行
 at.iv:a|ativa||||activate (enable, turn on, trigger)||||||||||||||||panna toimintaan|aktywować (włączyć, uruchomić)
 at.iv:i|ativi||||active (on, enabled)|actif|activo|ativo|активный (деятельный)||活性|活動的|||||||aktif|agema|toimelias (aktiivinen)|aktywny (włączony, uruchomiony)
 ata:|ata*|||fra:atte, por:ata, ben:আতা (ata), tgl:atis, som:aat|sugar-apple (sweetsop)||anón (ates, saramuyo)|||||||||||||||jabłko cukrowe
-Athina:|Athina|shefocite|||Athens|Athènes|Atenas|Atenas|Афины|اتينا‎|雅典|アテネ|||एथेंस|||Athene|Atina|Ateno|Ateena|
+Atina:|Atina|shefocite|||Athens|Athènes|Atenas|Atenas|Афины|اتينا‎|雅典|アテネ|||एथेंस|||Athene|Atina|Ateno|Ateena|
 Atlant:i Hay:|Atlanti Hay|||eng:Atlantic, spa:Atlántico, por:Atlântico, rus:Атлантический океан (Atlanticheskyy okean), swa:Atlantiki|Atlantic Ocean||océano Atlántico||||||||||||||Atlantin valtameri|Ocean Atlantycki
 atlant.o.kad:e|atlantokade|biw|Gadus morhua||Atlantic cod|morue de l'Atlantique|bacalao común|bacalhau-do-atlântico|Атлантическая треска||大西洋鱈|タイセイヨウダラ||||||||||dorsz atlantycki
 atlant.o.salmon:|atlantosalmon|biw|Salmo salar||Atlantic salmon|saumon altentique|salmón del Atlántico||Атлантический лосось (сёмга)||大西洋鮭|タイセイヨウサケ|||||salmon Atlantik|||||łosoś atlantycki
@@ -217,13 +218,13 @@ avar:|avar|||ara: عَوَارِيَّة‎ (ʿawāriyya), eng:(nautical) averag
 avar:a|avara||||harm (damage)||dañar||||||||||||||vahingoittaa (vaurioittaa)|
 avar:i|avari||||damaged (corrupt)||dañado||||||||||||||vaurioitunut|
 avar.an:i|avarani||||harmful (damaging)||dañino (perjudicial)|||||||||||||damaĝa|vahingollinen (vaurioittava)|krzywdzący (szkodliwy)
-avgan:i|avgani||||Afghan|afghan|afgano|afegão|афганский||||||अफगानी|||||afgana|afgaani|afgański
-avgan.istan:|Avganistan|desh|AF||Afghanistan|Afghanistan|Afganistán|Afeganistão|Афганистан||阿富汗|アフガニスタン|아프가니스탄||अफ़्ग़ानिस्तान||Afghanistan||Afganistan|Afganujo, Afganio|Afganistan|Afganistan
+afgan:i|afgani||||Afghan|afghan|afgano|afegão|афганский||||||अफगानी|||||afgana|afgaani|afgański
+Afgan.istan:|Afganistan|desh|AF||Afghanistan|Afghanistan|Afganistán|Afeganistão|Афганистан||阿富汗|アフガニスタン|아프가니스탄||अफ़्ग़ानिस्तान||Afghanistan||Afganistan|Afganujo, Afganio|Afganistan|Afganistan
 awakat:e|awakate|biw||nah:ahuakatl, spa:aguacate, por:abacate, tgl:abokado, jpn:アボカド (abokado), kor:아보카도 (abokado), fra:avocat, pol:awokado, kon:zavoká|avocado||aguacate|||||||||||||avokado|avokado|awokado
 Axur:|Axur|shefocite|||Assur||Assur (Ashur)||||||||||||||Assur|Aszur
 Axur:ia|Axuria|||akk:(aššur), ara:(aššur), hin:अश्शूर (aśśūr), fas:(āšūr)|Assyria||Asiria||||||||||||||Assyria|Asyria
 ay:|ay|||spa:ay, por:ai, fra:aïe, zho:哎 (ai), kor:아야 (aya), fas:(ây), rus:ай (ay)|ouch (ow, alas)|aïe!|ay!|ai!||||||||||||aj (alas)|ai! (au!)|aj!, ał!
-Azer:ia|Azeria|desh|AZ||Azerbaijan||Azerbaiyán||||||||||||||Azerbaidžan|Azerbejdżan
+Azerbaijan:|Azerbaijan|desh|AZ||Azerbaijan||Azerbaiyán||||||||||||||Azerbaidžan|Azerbejdżan
 B|B||||B|B|B|B|B|B|B|B|B|B|B|B|B|B|B|B|B|B
 bab:e|babe|||may:bab, ara:urd:fas:(bāb)|chapter (section)|chapitre|capítulo (sección)||глава||章|||||||||ĉapitro|luku (kirjan osa)|rozdział, sekcja
 babuc:e|babuce|||ara: بَابُوج‎ (bābūj), spa:babucha, fra:babouche, eng:babouche|slipper|pantoufle (babouche)|chinelo (pantufa)|||||||||||||pantoflo|tohveli|kapeć (papeć, bambosz)
@@ -288,9 +289,9 @@ bard:e|barde|||fra:barbe, spa:por:barba, deu:Bart, eng:beard, rus:борода (
 bark:a|barka|||hau:barka, may:berkah, tur:tebrik, fas:(tabrik), ara:urd:(mubārak), yor:alubarika|congratulate (bless)|féliciter|felicitar|||||||||||||gratuli|onnitella (siunata)|gratulować; błogosławić
 bark:e!|barke!||||congratulations! (blessing)||¡Felicitaciones!||||||||||||||onneksi olkoon!|gratulacje!
 barkok:e|barkoke|frute||ara:(barqūq), pa:albaricoque, fra:abricot, rus:абрикос (abrikos), tgl:albarikoke|apricot|abricot|albaricoque|damasco (abricó)|абрикос||杏子||||ख़ूबानी|খুবানি|||kayısı (zerdali)|abrikoto|aprikoosi|morela
+Bart:e|Barte|desh|IN||India||India|||||||||||||Baratio|Intia|Indie
 bart:i|barti|||hin:भारतीय (bhārtīy), urd:(bhārtīy), mar:(bhārtīya), tel:(bhāratīya)|Indian||indio (hindú)|||||||||||||Barata|intialainen|Indyjski
 Bart:i Hay:|Barti Hay||||Indian Ocean||océano Índico||||||||||||||Intian valtameri|Ocean Indyjski
-Bart:ia|Bartia|desh|IN||India||India|||||||||||||Baratio|Intia|Indie
 barud:e|barude|||ara:fas:urd:(bārūd), hin:बारूद (bārūd), pnb:ਬਾਰੂਦ (bārūd), swa:baruti, tur:barut, bul:барут (barut)|gunpowder||pólvora|||||||||||||pulvo|ruuti|proch strzelniczy
 barx:e|barxe|||hin:बारिश (bāriś), ben:বৃষ্টি (briśṭi), tur:baran|rain (precipitation)|pluie|lluvia|chuva|дождь|مطر‎|雨|雨|비|mưa|बारिश (वर्षा)|বৃষ্টি|hujan|mvua|yağmur (baran)|pluvo|sade|deszcz
 barx:i|barxi||||rainy|pluvieux|lluvioso (pluvioso)|chuvoso (pluvioso)|дождливый||多雨||||बरसाती||||yağmurlu|pluva|sateinen|deszczowy
@@ -340,7 +341,7 @@ bek.er:ia|bekeria||||bakery||panadería|||||||||||||bakejo|leipomo|piekarnia
 bek.o.pot:e|bekopote||||terracotta|terre cuite|terracota|terracota|терракота||陶瓦|テラコッタ||||||||||terakota
 bel:|bel|unomete|B||bel (unit)||belio||||||||||||||beli (B)|bel
 bel:|bel|||fas: بیل‎ (bil), tur:bel, hin:बेलचा (belcā), ben:বেলচা (bēlacā), fra:pelle|shovel (spade, scoop)|pelle|pala|pá|лопата||铲|シャベル (スコップ)|||||||||lapio|łopata (szpadel)
-Bel.o.rus:ia|Belorusia|desh|BY||Belarus||Belarús|||||||||||||Belorusio|Valkovenäjä|Białoruś
+Belarus:|Belarus|desh|BY||Belarus||Belarús|||||||||||||Belorusio|Valkovenäjä|Białoruś
 Belg:ia|Belgia|desh|BE||Belgium||Bélgica|||||||||||||Belgio|Belgia|Belgia
 Beliz:e|Belize|desh|BZ||Belize||Belice|||||||||||||Beliceo|Belize|Belize
 benc:e|bence|||eng:bench, swa:benchi, hin:बेंच (bẽc), jpn:ベンチ (benchi), kor:벤치 (benchi)|bench||banco (silla)|||||||||||||benko|penkki|ławka
@@ -392,7 +393,7 @@ boikot:e|boikote|||eng:fra:boycott, spa:boicot, por:boicote, jpn:ボイコット
 bok:e|boke|||spa:por:boca|mouth||boca|||||||||||||buŝo|suu|usta
 bol:|bol|||eng:ball, spa:por:may:tgl:bola, tha:บอล (bɔl), jpn:ボール (bōru), kor:볼 (bol), khm:បាល់ (bal), ben:বল (bôl), deu:Ball, fra:boule,balle|ball|balle (boule)|bola|bola|шар|كورة|球|玉 (球)||||गोला||bola|mpira|pilko|pallo|piłka
 Bolgar:ia|Bolgaria|desh|BG||Bulgaria||Bulgaria|||||||||||||Bulgario|Bulgaria|Bułgaria
-Boliv:ia|Bolivia||||Bolivia||Bolivia|||||||||||||Bolivio|Bolivia|Boliwia
+Boliv:ia|Bolivia|desh|BO||Bolivia||Bolivia|||||||||||||Bolivio|Bolivia|Boliwia
 bomb:e|bombe|||pol:por:spa:tur:bomba, rus:бомба (bomba), deu:fra:bombe, fas:(bomb), eng:bomb, ben:বোমা (boma), hin:बम (bam), urd:(bam), jpn:ボム (bomu), kor:봄 (bom), may:bom|bomb|bombe|bomba|bomba|бомба||炸弹||||बम||bom||bomba|bombo|pommi|bomba
 bon:i|boni|||fra:bon, por:bom, spa:bueno, + khm:បុណ្យ (bon), tha:บุญ (bun), tel:పుణ్యము (puṇyamu)|good|bon|bueno|bom|хороший|حَسَن|好|良い|||अच्छा||bagus|mzuri||bona|hyvä|dobry
 bon:i zar:|boni zar||||good luck||buena suerte||||||||||||||hyvä onni (tuuri, säkä, lykky)|dobry los, szczęście
@@ -406,7 +407,7 @@ bor:i|bori|||eng:bored, spa:aburrido, hin:(bhorī)|bored||aburrido|||||||||||||e
 bor:ia|boria||27 emotions||boredom||aburrimiento||||||||बोरियत|||||enuo|tylsyys (pitkästys)|nuda (znudzenie)
 bor.em:|borem|mate|Bh||bohrium||bohrio|||||||||||||borio|bohrium|bohr
 boron:|boron|mate|B||boron||boro|||||||||||||boro|boori|bor
-Bosn:ia|Bosnia|desh|BA||Bosnia and Herzegovina||Bosnia y Herzegovina||||||||||||||Bosnia ja Hertsegovina|Bośnia i Harcegowina
+Bosn:ia w:a Herzegovina:|Bosnia wa Herzegovina|desh|BA||Bosnia and Herzegovina||Bosnia y Herzegovina||||||||||||||Bosnia ja Hertsegovina|Bośnia i Harcegowina
 bot:a|bota||||sail||navegar (ir en bote)|||||||||||||boatumi|veneillä|żeglować (płynąć)
 bot.el:|botel|||eng:bottle, fra:bouteille, spa:botella, por:botelha, rus:бутылка (butylka), hin:बोतल (botal), ben:বোতল (botôl), may:botol|bottle|bouteille|botella|garrafa (botelha)|бутылка||瓶|瓶|병|chai|शीशी (बोतल)|বোতল|botol|chupa|şişe|botelo|pullo|butelka
 bot.er:|boter||||sailer||velero||||||||||||||veneilijä|żeglarz (marynarz)
@@ -430,7 +431,7 @@ brox:|brox|||eng:brush, fra:brosse, ben:ব্রাশ (braś), hin:ब्र�
 brun:i|bruni|rang||fra:brun, ara:(bunniy), hin:भूरा (bhūrā), eng:brown|brown|brun (marron)|marrón|castanho (marrom)|коричневый|بُنِّيّ|棕色 (色)|茶色|갈색|nâu|भूरा||cokelat|kahawia|kahverengi|bruna|ruskea|brązowy, koloru kawy
 brun.alg:e|brunalge|biw|Phaeophyceae||brown algae|algues brunes|algas pardas||бурые водоросли|||褐藻||||||||||brunatnica
 brun.salmon:|brunsalmon|biw|Salmo trutta||brown trout|truite brune (truite de mer)|trucha marrón|truta-marrom|кумжа||褐鳟|ブラウントラウト|||||trout coklat|||||pstrąg potokowy
-Bruney:|Bruney|desh|BN||Brunei Darussalam||Brunei||||||||||||||Brunei|Brunei Darussalam
+Brunei:|Brunei|desh|BN||Brunei Darussalam||Brunei||||||||||||||Brunei|Brunei Darussalam
 buc:a|buca||||butcher|abattre|carnear (matar)|abater||||||||||||buĉi|teurastaa (lahdata)|
 buc.er:|bucer|||eng:butcher, fra:boucher, ita:beccaio, hin:बूचड़ (būcaṛ)|butcher|boucher|carnicero|açougueiro (talhante)|мясник|جَزَّار‎|屠夫|肉屋|푸주한|người hàng thịt|क़साई (बूचड़)||tukang daging|||buĉisto|teurastaja|
 buc.o.kan:|bucokan|||fas: سلاخ خانه‎ (sallâx-xâne), hin:बूचड़खाना (būcaṛkhānā), ben:কসাইখানা (kôśaikhana)|abattoir (slaughterhouse)|abattoir|matadero|matadouro|бойня||屠宰场|屠畜場|도살장|lò mổ|बूचड़खाना (कसाईखाना)|কসাইখানা|||mezbaha|buĉejo|teurastamo|
@@ -440,7 +441,7 @@ bud:e|bude|||san:बोधि (bodhi), hin:बुद्धि (buddhi), jpn:菩�
 bud:i|budi||||aware (enlightened)||concienciado (iluminado)|||||||||||||konscia|valaistunut|świadomy; oświecony
 bud.ist:e|budiste||||Buddhist||budista|||||||||||||budhisto|buddhalainen|buddysta
 bud.ist:ia|budistia||||Buddhism||budismo||||||||बौद्ध धर्म|||||budhismo|buddhalaisuus (buddhismi)|Buddyzm
-Budapext:|Budapext|shefocite|HU||Budapest||||||||||||||||Budapest|
+Budapext:e|Budapexte|shefocite|HU||Budapest||||||||||||||||Budapest|
 bufet:e|bufete|||fra:buffet, eng:buffet, spa:bufé, por:bufete, deu:Büfett, rus:буфет (bufet), zho:部飛 (bùfēi), jpn:ビュッフェ (byuffe), kor:뷔페 (bwipe), may:bufet, swa:bufee|buffet (smorgasbord)||bufé||буфет||自助餐|ビュッフェ (バイキング)|||||||||noutopöytä (buffetti)|bufet (szwedzki stół)
 bufon:|bufon|||spa:bufón, eng:buffoon, fra:bouffon|fool (buffoon)||bufón|||||||||||||pajaco|hölmö (narri)|głupiec, bufon
 bug:e|buge|||eng:bugle, ara:(būq), fas:(buq), kat:ბუკი (buḳi)|bugle (horn instrument)||clarín (corneta)||||||||||||||torvi (torvisoitin)|róg
@@ -452,7 +453,7 @@ bulbul:|bulbul|biw|Luscinia megarhynchos|may:bulbul, tur:bülbül, hin:बुल
 bum:|bum|||eng:boom, deu:Bumm, fra:boum, spa:por:bum, hin:बूम (būm), zho:砰 (pēng), kor:펑 (peong), vie:bùm|explosion (blast, eruption)|explosion|explosión (estallado)|explosão|взрыв||爆炸|爆発|||||||||räjähdys (pamaus)|wybuch
 bum:u|bumu||||explode (blow up)||explotar (estallar)||взрываться|||爆発する|||||||||räjähtää|eksplodować (wybuchnąć, wybuchać)
 burg:e|burge|||deu:Burg, egy:(burg), ara:urd:(burj), hin:बुर्ज (burj), may:puri, + hin:दुर्ग (durg), ben:দুর্গ (durg)|castle (fortress, stronghold)||castillo (fortaleza)||||||||||||||linna (linnake, linnoitus)|zamek, forteca, twierdza
-Burkina:|Burkina|desh|BF||Burkina Faso||Burkina Faso||||||||||||||Burkina Faso|Burkina Faso
+Burkina: Faso:|Burkina Faso|desh|BF||Burkina Faso||Burkina Faso||||||||||||||Burkina Faso|Burkina Faso
 bus:|bus|||deu:fra:eng:spa:bus, rus:автобус (avtobus), hin:बस (bas), urd:(bas), jpn:バス (basu), kor:버스 (beoseu), fas:(otobus), tur:otobüs, swa:basi, zho:巴士 (bāshì)|bus||bus (autobús)|||||||||||||buso|linja-auto (bussi)|autobus, autokar
 bust:e|buste|||fra:buste, eng:bust, spa:por:busto, rus:бюст (byust), deu:Büste|bust (bosom)||pecho (busto)||||||||||||||povi|biust
 but:e|bute|||eng:boot, fra:botte, spa:por:bota, ell:μπότα (bóta), rus:ботинок (botinok), pol:may:but, fas: بوت‎ (but), jpn:ブーツ (būtsu), swa:buti|boot|botte|bota|bota|ботинок|||ブーツ|||||||||saapas (buutsi)|but
@@ -525,7 +526,6 @@ cili.fun:|cilifun||||paprika||||||辣椒粉|パプリカ|||||||||paprikajauhe|pa
 cimpanz:e|cimpanze|biw||eng:chimpanzee, spa:chimpancé, por:fra:chimpanzé, rus:шимпанзе (shimpanze), tur:şempanze, ara:شمبانزي‎ (šimbanzī), hin:चिंपांजी (cimpāñjī), jpn:チンパンジー (chinpanjī), may:cimpanzi|chimpanzee||chimpancé|||||||||||||ĉimpanzo|simpanssi|szympans
 cin:i|cini|||hin:चीनी (cīnī), tur:Çin, ara:(ṣiniy), spa:chino, eng:Chinese, tha:จีน (chin), zho:秦 (qín)|Han Chinese||chinés (de los Han)||хань||汉族|||||||||hana|han-kiinalainen|han chiński
 cincil:|cincil|biw|||chinchilla||chinchilla|||||||||||||ĉinĉilo|chinchilla|szynszyla
-Ciper:ia|Ciperia|desh|AL||Albania||Albania||||||||||||||Albania|Albania
 cir:|cir||||tear (rip, edge)|déchirer|rasgar (romper)|rasgar|рвать||撕裂|裂く|||||||||repeämä|rwać (drzeć)
 cir:a|cira|||hin:mar:चीर (chīra), ben:চেরা (chērā), pan:ਚੀਰ (chīra) + eng:tear|tear (rip, split)|déchirer|rasgar (romper)|rasgar|рвать||撕裂|裂く|||||||||repiä|drzeć (rwać, rozrywać, rozdzierać, rozszczepiać)
 cir.cir:a|circira||||tear up (tatter, shred)||||изорвать||撕毁|千切る|||||||||raastaa|strzępić (drzeć)
@@ -541,15 +541,14 @@ cod:a|coda|||ben:চোদা (coda), hin:चोदना (codnā)|fuck (copulat
 cokolat:e|cokolate|||spa:por:eng:chocolate, fra:chocolat, hin:चाकलेट (cāklet), ben:চকলেট (côkleṭ), zho:巧克力 (qiǎokèlì), jpn:チョコレート (chokorēto), kor:초콜렛 (chokollet), may:cokelat, tur:çikolata|chocolate|chocolat|chocolate|chocolate|шоколад||巧克力|チョコレート|초콜렛|sô cô la|चाकलेट|চকলেট|cokelat (coklat)|chokoleti|çikolata|ĉokolado|suklaa|czekolada
 cokolat.o.baton:|cokolatobaton||||chocolate bar|tablette de chocolat|barra de chocolate|barra de chocolate|||巧克力棒|チョコバー||||||||ĉokolado|suklaapatukka|baton czekoladowy
 cop:e|cope|||zho:锄 (chú), yue:鋤 (co4), tha:จอบ (chop), tur:çapa|hoe|houe|azada|enxada|мотыга||锄头|クワ|||||||||kuokka|motyka
+Congcing:|Congcing||||Chongqing||||||重庆||||||||||Chongqing|Chongqing
 cor:|cor|||hin:mar:चोरी (corī), urd:(corī), tha:โจร (chon), may:curi, ben:চুরি (curi)|theft||robo (hurto)|||||||||||||ŝtelo|varkaus|kradzież
 cor:a|cora||||steal||robar (hurtar)|||||||||||||ŝteli|varastaa|ukraść, kraść
 cor.er:|corer||||thief||ladrón|||||||||||||ŝtelisto|varas|złodziej
 Cosen:|Cosen|desh||kor:조선 (Joseon), jpn:朝鮮 (chōsen), zho:朝鲜 (zh) (Cháoxiǎn)|Korea||Corea||||||||||||||Korea|Korea
 Cosen:i|Coseni||||Korean||coreano||||||||||||||korealainen|koreański
 coy:|coy|||zho:菜 (cài), yue:菜 (coi3), eng:-choy, may:-coy|greens||verduras|verdura|зелень|||菜|||||||||vihannes|zielenina
-Cuana:|Cuana|desh|BW||Botswana||Botsuana||||||||||||||Botswana|Botswana
 cum:|cum|||hin:चूमना (cūmnā), urd:(cūmnā), mal:ചുംബനം (cumbanaṃ), may:cium, jpn:チュー (chū), tha:จูบ (cup)|kiss||beso|||||||||||||kiso|suukko (pusu)|całus
-Cungking:|Cungking||||Chongqing||||||重庆||||||||||Chongqing|Chongqing
 cup:a|cupa|||spa:por:chupar, khm:ជប់ (cup)|suck (absorb)||chupar (succionar)|||||||||||||suĉi|imeä|ssać
 cut:a|cuta|||zho:出 (chū), hak:(chut), kor:출 (chul), hin:छूटना (chūtnā) + tur:çıkmak|leave (go out, exit)||salir (irse)|||||||||||||eliri|poistua|wyjść, wychodzić, wyjechać, wyjeżdżać, wypłynąć, wypływać
 cut:e|cute||||exit (leaving)||escapatoria|||||||||||||eliro|poistuminen|wyjśćie, opuszczenie
@@ -557,6 +556,7 @@ cut.o.mun:|cutomun||||exit door||salida|||||||||||||elirejo|uloskäynti|drzwi wy
 cuz:a|cuza|||eng:choose, + hin:चुनना (cunnā), + vie:chọn|choose (elect, select, pick)||elegir (escoger, seleccionar)|||||||||||||elekti|valita|wybrać, wybierać, selekcjonować
 cuz:e|cuze||||choice (election, selection)||elección|||||||||||||elekto|valinta (vaali)|wybór, elekcja, selekcja
 cuz.abl:e|cuzable||||option (choice)|option|opción|opção|||选择 (买卖权)|オプション (選択)|||||||||vaihtoehto|opcja (wybór)
+Cwana:|Cwana|desh|BW||Botswana||Botsuana||||||||||||||Botswana|Botswana
 D|D||||D|D|D|D|D|D|D|D|D|D|D|D|D|D|D|D|D|D
 d:a|da|||fra:de,du, por:de,do,da, pas:د‎ (də), arm:דְּ‎ (də)|of (particle of possession)||de (posposición de posesión)|||||||||||||de (partiklo de posedo)|omistetun omistajaan liittävä partikkeli|z (partykuła posiadania)
 d:a|da||||that (function word to introduce a relative clause)|||||||||||||||kiu (komencigas relativan frazon)|joka (sivulauseen aloittava sana)|
@@ -695,7 +695,7 @@ dom.is:a|domisa||||accommodate||alojar (hospedar)|||||||||||||loĝigi|asuttaa|da
 dom.zez:e|domzeze|biw|Musca domestica||housefly|mouche|mosco||муха|||||||||||muŝo|kärpänen|mucha
 domin.o.gem:|dominogem|||eng:dominoes, spa:por:dominó, fra:dominos, rus:домино (domino), zho:多米诺 (duōmǐnuò), jpn:ドミノ牌 (dominohai)|dominoes||dominó||||||||||||||dominopeli|domino
 Dominika:|Dominika|desh|DM||Dominica||Dominica||||||||||||||Dominika|Dominika (Wspólnota Dominiki)
-Dominikana:|Dominikana|desh|DO||Dominican Republic||Republica Dominicana||||||||||||||Dominikaaninen Tasavalta|Republika Dominikańska (Dominikana)
+Dominik:i Komun.krat:ia|Dominiki Komunkratia|desh|DO||Dominican Republic||Republica Dominicana||Доминиканская Республика|||ドミニカ共和国|||दोमिनिकन गणराज्||Republik Dominika|Jamhuri ya Dominika|Dominik Cumhuriyeti||Dominikaaninen Tasavalta|Republika Dominikańska (Dominikana)
 don:|don||||gift||regalo (obsequio)|||||||||||||donaco|lahja|podarunek, dar, prezent
 don:a|dona|||fra:donner, eng:donate, spa:por:donar|give||dar|||||あげる (くれる)||||||||doni|antaa|dać, dawać
 don.iv:i|donivi||||generous (open-handed)|généreux|generoso (dadivoso)|generoso (dadivoso, mão-aberta)|щедрый|كَرِيم‎||||||||karimu||malavara|antelias (avokätinen)|
@@ -776,7 +776,7 @@ eks.o.nam:|eksonam||||exonym||exónimo||||||||||||||eksonyymi|egzonim
 eks.o.tir:a|eksotira||||stretch (extend)|tender|estirar (extender)|estirar|вытянуть||拉|伸びる (張る)||||||||||rozciągać (rozciągnąć)
 eks.o.yam:|eksoyam||||picnic|piquenique|jira (pícnic)|piquenique|пикник||野餐||||||||||eväsretki (piknik)|piknik
 eksa:|eksa*|||eng:fra:spa:por:exa, rus:экза- (ekza-), may:eska-, zho:艾可萨- (àikěsà-), jpn:エクサ (ekusa), kor:엑사- (eksa-)|exa-|||||||||||||||eksa-|eksa-|
-ekuador|Ekuador|desh|EC||Ecuador||Ecuador|||||||||||||Ekvadoro|Ecuador|Ekwador
+Ekuador|Ekuador|desh|EC||Ecuador||Ecuador|||||||||||||Ekvadoro|Ecuador|Ekwador
 eletr:e|eletre|||por:eletricidade, ita:elettricità, eng:electricity, rus:электричество (električestvo), fra:électricité, spa:electricidad, tur:elektrik|electricity|électricité|electricidad|eletricidade||||電気|||||||cereyan (elektrik)|elektro|sähkö|elektryczność
 eletr:i|eletri||||electric||eléctrico|||||||||||||elektra|sähköinen|elektryczny
 eletr.o.liny:e|eletrolinye||||cable (wire, line)||cable||провод (кабель)||电缆 (电线)|電線|||||||||sähköjohto|kabel (linia)
@@ -832,7 +832,7 @@ Espan:ia|Espania|desh|ES||Spain||España|||||||||||||Hispanio|Espanja|Hiszpania
 espan.o.fon:i|espanofoni||||hispanophone (Spanish speaking)||||||||||||||||espanjaa puhuva|
 esperant:i|esperanti||||Esperanto||Esperanto|||||||||||||Esperanto|esperanto|Esperanto
 esponj:e|esponje|biw||ell:σφουγγάρι (sphoungári), eng:sponge, spa:por:esponja, tur:süngre, ara:إسفنج (ʾisfanj), fas:اسفنج‎ (esfanj), hin:स्पंज (spanja), jpn:スポンジ (suponji), may:spon|sponge|éponge|esponja|esponja|губка||海绵|スポンジ (海綿)|||||||||sienieläin|gąbka
-Est:ia|Estia|desh|EE||Estonia||Estonia|||||||||||||Estonio|Viro (Eesti)|Estonia
+Est:e|Este|desh|EE||Estonia||Estonia|||||||||||||Estonio|Viro (Eesti)|Estonia
 estad:ia|estadia|||fra:stade, por:estádio, spa:estadio, rus:стадион (stadion), eng:stadium, tur:stadyum, ara:(ʾistād), hin:स्टेडियम (sṭeḍiyam)|stadium (arena)||estadio (arena)|||||||||||||stadiono (areno)|stadioni (areena)|stadion, arena
 estan:|estan|mate|Sn|spa:estaño, por:estanho, fra:étain, ita:stagno, eng:tin|tin|étain|estaño|estanho|||锡|珍|||||||||tina|cynk
 estas:a|estasa||||hold (detain)||mantener (detener)||||||||||||||seisottaa|zatrzymać (zatrzymywać, wstrzymać, wstrzymywać)
@@ -921,7 +921,7 @@ fet:i|feti||||fatty (greasy)||graso (adiposo)|||||||||||||grasa|rasvainen|tłust
 fey:u|feyu|||zho:飞 (fēi), yue:飛 (fei1), wuu:飛 (fi1), jpn:飛 (hi), kor:비 (bi), vie:bay|fly (go through air)|voler|volar|voar|лететь|طار‎|飞|飛ぶ|날다|bay|उड़ना|ওড়া|terbang|kuruka|uçmak|flugi|lentää|latać, lecieć
 fey.mux:|feymux|biw|||bat (flying mammal)|chauve-souris|murciélago||летучая мышь|||こうもり (飛鼠)|||||||||lepakko|nietoperz
 figur:|figur|||eng:fra:figure, spa:por:figura|figure (representation)||representación (figura)|||||||||||||figuro|hahmo (figuuri)|figura, reprezentacja
-Fij:ia|Fijia|desh|FJ||Fiji||Fiji||||||||||||||Fidži|Fidżi
+Fiji:|Fiji|desh|FJ||Fiji||Fiji||||||||||||||Fidži|Fidżi
 fikr:a|fikra||||think (ponder, reflect)||pensar|||||||||||||pensi|ajatella (miettiä)|myśleć, dumać, rozmyślać, zastanawiać się, rozważać
 fikr:e|fikre|||ara:(fikr), fas:(fekr), tur:fikir, may:pikir, hin:(fikr)|thought (idea)||idea (pensamiento, reflexión)|||||||||||||penso|ajatus|myśl, pomysł
 fiks:a|fiksa|||eng:fix, fra:fixer, spa:fijar, por:fixar|fix (attach)||fijar (pegar, asegurar)|||||||||||||fiksi|kiinnittää|przyczepić, przymocować
@@ -929,8 +929,8 @@ fiks:e|fikse||||attachment (affix)||accesorio (afijo)||||||||||||||kiinnitys|za�
 fil:a|fila||||like||gustarse (querer)||||||||||||||tykätä (pitää)|lubić
 fil:ia|filia||||attraction (-philia)||attracción (-filia)||||||||||||||tykkääminen|zamiłowanie (-filia)
 fil.er:|filer|||eng:fra:-phile, por:spa:-filo|fan (-phile)||fan (-filo)||||||||||||||fani (-fiili)|miłośnik (fan, -fil)
-Filipin:ia|Filipinia|desh|PH||Philippines||Filipinas|||||||||||||Filipinoj|Filippiinit|Filipiny
-Filistin:ia|Filistinia|desh|PS||Palestinian Territory||Palestina||||||||||||||Palestiina|Terytorium Palestyńskie
+Filipinas:|Filipinas|desh|PH||Philippines||Filipinas|||||||||||||Filipinoj|Filippiinit|Filipiny
+Filistin:|Filistin|desh|PS||Palestinian Territory||Palestina||||||||||||||Palestiina|Terytorium Palestyńskie
 film:e|filme|||eng:spa:fra:film, por:filme, deu:Film, rus:фильм (fil’m), tur:film, ara:فيلم (film), jpn:フィルム (firumu), may:pilem|film (membrane, video)||película (film, membrana)||плева (фильм)||膜|フィルム (膜)||||||||filmo|filmi|film
 filsof:i|filsofi||||philosophic||filosófico|||||||||||||filozofia|filosofinen|filozoficzny
 filsof:ia|filsofia|||spa:filosofia, rus:философия (filosofiya), may:filsafat, ara:(falsafa), swa:falsafa, tur:felsefe, hin:फ़लसफ़ा (falasfā), eng:philosophy, fra:philosophie|philosophy|philosophie|filosofía|filosofia|философия|فَلْسَفَة|哲学|哲学|철학|triết học|दर्शन (फ़लसफ़ा)||filsafat|falsafa|felsefe|filozofio|filosofia|filozofia
@@ -987,6 +987,7 @@ fot.o.minar:|fotominar||||beacon (lighthouse)|fanal (balise)|faro (baliza, almen
 fot.o.rad:e|fotorade||||ray of light||rayo luminoso||||||||||||||valonsäde|promień światła
 franc:i krep:e|franci krepe|yame|||crepe|crêpe|crepa (crep, tortilla de trigo)|crepe||||||||||||franca krepo|kreppi|francuski naleśnik (crêpe)
 Franc:i Pol.nes:ia|Franci Polnesia|desh|PF||French Polynesia||Polinesia Francesa||||||||||||||Ranskan Polynesia|Polinezja Francuska
+Franc:i Guyana:|Franci Guyana|desh|GF||French Guiana||Guyana Francesa||||||||||||||Ranskan Guiana|Gujana Francuska
 Franc:ia|Francia|desh|FR||France||Francia|||||||||||||Francio|Ranska|Francja
 franc.em:|francem|mate|Fr||francium||francio|||||||||||||franciumo|fransium|frans
 franc.o.fon:i|francofoni||||Francophone (French speaking)|francophone|||||||||||||||ranskaa puhuva (frankofoni)|
@@ -1082,7 +1083,6 @@ gaw.darj:i|gawdarji||||advanced (high-level)||||||||||||||||korkeatasoinen (edis
 gaw.darj:u|gawdarju||||level up (graduate)|||||||||||||||||
 gaw.tal:i|gawtali||||vertical||vertical||||||||||||||pystysuuntainen|pionowy
 gaw.tal:u|gawtalu||||bob up and down||inclinar|||||浮き沈みする||||||||||
-Gayan:|Gayan|desh|GY||Guyana||Guyana|||||||||||||Gujano|Guyana|Gujana
 gaz:e|gaze|||deu:fra:por:gaze, jpn:ガーゼ (gāze), rus:газ (gaz), eng:gauze|gauze||gasa|||||||||||||gazo|harso|gaza
 gazel:|gazel|biw||ara:(ḡazāl), eng:fra:gazelle, rus:газель (gazel'), jpn:ガゼル (gazeru)|gazelle|gazelle|gacela||газель|||ガゼル||||||||gazelo|gaselli|gazela
 gazet:e|gazete|||eng:fra:gazette, rus:газета (gazeta), swa:gazeri, tur:gazete|magazine (journal, gazette)||revista (periódico, gaceta)||газета|||||||||gazeti|gazete|gazeto (revuo)|lehti (sanomalehti)|magazyn, dziennik, gazeta
@@ -1091,9 +1091,9 @@ gem:|gem|||eng:game, tha:เกม (geem), jpn:ゲーム (gēmu), kor:게임 (ge
 gem:a|gema||||play a game||jugar un juego|||||||||||||ludi|pelata|grać w grę
 gem.er:|gemer||||player (gamer)||jugador||игрок (геймер)|||||||||||ludanto|pelaaja|gracz
 genc:a|genca|||zho:检查 (jiǎnchá), yue:檢查 (gimcaa), vie:kiểm tra, jpn,検査 (kensa)|examine (inspect, check)||examinar (inspeccionar)||||检查||||||||||tutkia|sprawdzić, sprawdzać, skontrolować, kontrolować, zbadać, badać
-Genz:ia|Genzia|desh|GG||Guernsey||Guernesey||||||||||||||Guernsey|Guernsey
 German:ia|Germania||||Germania|Germanie|Germania|Germânia|||||||||||||Germania|
 german.em:|germanem|mate|Ge||germanium||germanio|||||||||||||germaniumo|germanium|german
+Gernesey:|Gernesey|desh|GG||Guernsey||Guernesey||||||||||||||Guernsey|Guernsey
 get:a|geta|||eng:get|get (receive, obtain, take)||conseguir (obtener, recibir)|ter (achar, receber)|получить||获得|受ける (もらう)|||पाना|||kupata (kuget)|elde etmek|akiri (ricevi, preni)|hankkia (saada)|dostać, dostawać, otrzymać, otrzymywać, wziąć, brać
 get.er:|geter||||getter (receiver, recipient)||engendrador||||||||||||||saaja (vastaanottaja)|odbiorca
 gew:|gew|||eng:spa:por:geo-, fra:géo-, rus:гео- (geo-)|earth (ground)||tierra|||||地|||||||||maa (maaperä)|ziemia, grunt, gleba
@@ -1122,7 +1122,6 @@ gid.o.buk:e|gidobuke||||guide book|guide touristique|guía de viaje||путев�
 giga:|giga*|||eng:fra:spa:por:may:tur:giga-, rus:гига- (giga-), jpn:ギガ (giga), kor:기가- (giga-)|billion (giga-)||giga-|||||||||||||miliardo (giga-)|miljardi (giga-)|bilion, giga-
 gitar:|gitar|||eng:guitar, fra:guitare, spa:por:guitarra, rus:гитара (gitara), ara:(qīṯāra), hin:गिटार (giṭār), ben:গিটার (giṭar), zho:吉他 (jítā), jpn:ギター (gitā), kor:기타 (gita), swa:gitaa|guitar|guitare|guitarra|guitarra|гитара||吉他|ギター|기타|ghi-ta|गिटार|গিটার|gitar|gitaa|gitar|gitaro|kitara|gitara
 giuk:e|giuke|||zho:玉 (yù), yue:玉 (yuk6), nan:玉 (gio̍k), jpn:玉 (gyoku), vie:ngọc (玉), may:giok|jade|jade|jade|jade|нефрит (жад)||玉||||||giok||yeşim|jado|jade|żad
-Giyan:|Giyan|desh|GF||French Guiana||Guyana Francesa||||||||||||||Ranskan Guiana|Gujana Francuska
 glis:u|glisu|||fra:glisser, ita:glissare + eng:glacier,glissando, spa:por:glaciar,glisando, rus:глиссандо (glissando), ara:غليساندو (ghlysandw), jpn:グリッサンド (gurissando) + may:gelangsar|slide (slip, glide, skate)|glisser|deslizar|deslizar|задвигаться (скользи́ть)||滑下|滑る|||||||||liukua (luistaa)|ślizgać się (poślizgnąć się, jeździć na łyżwach)
 glut:a|gluta||||stick (adhere, paste, glue)|coller|pegar|colar (aderir)|клеиться|||張る (付く)|||||||||liimata|lepić (kleić)
 glut:e|glute|||eng:glue, swa:gluu, + fra:glutineux|glue (adhesive)||pegamento (pega, goma)|||||||||||||gluo|liima|klej
@@ -1181,6 +1180,7 @@ gust:u k:o|gustu ko||||taste like||tener gusto a|||||||||||||gusti kiel|maistua|
 gut:e|gute|||swa:goti, guj:ઘૂંટણ (ghū̃ṭaṇ), hin:घुटना (ghuṭnā), mar:गुडघा (guḍghā)|knee|genou|rodilla|joelho|колено||膝|膝|무릎|đầu gối|घुटना|হাঁটু|lutut|goti|diz|genuo|polvi|kolano
 guy:|guy|||zho:鬼 (guǐ), vie:quỷ, + tha:กุ๊ย (gui)|ogre (troll, goblin)||ogro (gnomo, trol, duende, trasgo)|||||鬼||||||||ogro (trolo)|peikko|ogr (trol, goblin)
 guy.papil:|guypapil|biw|Papaver orientale||oriental poppy|pavot d'Orient|||мак восточный||鬼罂粟 (東方罌粟)|オニゲシ||||||||||mak wschodni
+Guyana:|Guyana|desh|GY||Guyana||Guyana|||||||||||||Gujano|Guyana|Gujana
 H|H||||H|H|H|H|H|H|H|H|H|H|H|H|H|H|H|H|H|H
 h:e|he|||fra:por:hein, jpn:e|huh? (pardon?)||cómo? (eh?)|||||||||||||ĉu?|häh?|hę?, co?, pardon?
 habar:|habar|||ara:(xabar), tur:haber, may:kabar, swa:habari, hin:ख़बर (xabar), ben:খবর (khôbôr), yor:làbarè|news||noticias||новости||消息||||ख़बर||kabar|habari|haber|novaĵoj|uutinen|wiadomość, nius
@@ -1223,6 +1223,7 @@ harf:ia|harfia||||alphabet|alphabet|alfabeto||алфавит||字母表|||||||||
 harmon:i|harmoni||||harmonious||armonioso|||||||||||||harmonia|harmoninen|harmoniczny
 harmon:ia|harmonia|||eng:harmony, spa:armonía, por:harmonia, fra:harmonie, rus:гармония (garmoniya)|harmony||armonía|||||||||||||harmonio|harmonia|harmonia
 harnes:|harnes|||fra:harnais, eng:harness, spa:arnés, por:arnês|harness||arnés (arreos, jaeces)||||||||||||||valjaat|zaprzęc, zaprzęgać
+Hartum|Hartum|shefocite|SD||Khartoum|Khartoum|Jartum|Cartum|Хартум|الخرطوم|喀土穆|ハルツーム|||||Khartoum|Khartoum|Hartum|Ĥartumo|Khartoum|
 has:a|hasa||||distinguish||diferenciar (distinguir)||||||||||||||erottaa (nähdä ero)|rozróżniać (rozróżnić)
 has:i|hasi|||ara:(xāṣṣ), fas:urd:(xās), hin:ख़ास (xās), may:khas|special (distinct)||especial (diferenciado, distinto)|||||||||||||speciala|erikoinen (erityinen)|specjalny, wyraźny, wyrazisty
 has:ia|hasia||||distinction (specialty)||especialización (distinción)||||||||||||||erikoisuus|różnica (specjalność)
@@ -1232,8 +1233,8 @@ hatr:e|hatre|||ara: خطر‎ (xaṭar), fas: خطر‎ (xatar), urd: خطرہ�
 hatr:i|hatri||||dangerous (perilous)||peligroso|||||||||||||danĝera|vaarallinen|niebezpieczny
 haw:|haw|||hin:हवा (havā), ben:হাওয়া (haowa) + ara: هَوَاء‎ (hawāʾ), tur:hava, may:hawa, swa:hewa|wind||viento|||||風|||हवा (पवन)|||||vento|tuuli (puhallus)|wiatr
 haw:a|hawa||||blow||soplar (echar)|||||||||||||venti|tuulla (puhaltaa)|dmuchać
-Haway:i nes:ia|Hawayi nesia||||Hawaiian archipelago||archipiélago de Hawái||||||||||||||Havaijin saaret|Hawaje (archipelag hawajski)
-Haway:ia|Hawayia|desh|||Hawaii||Hawái||||||||||||||Havaiji|Hawaje
+Hawaii: nes:ia|Hawaii nesia||||Hawaiian archipelago||archipiélago de Hawái||||||||||||||Havaijin saaret|Hawaje (archipelag hawajski)
+Hawaii:|Hawaii|desh|||Hawaii||Hawái||||||||||||||Havaiji|Hawaje
 haxix:|haxix||||hashish||hachís||||||||||||||hasis|haszysz
 hay:|hay|||zho:海 (hǎi), yue:海 (hoi2), jpn:海 (kai), kor:해양 (haeyang), vie:hải|sea|mer|mar|mar|море||海|海|바다 (해양)|biển (hải)|समन्दर (समुद्र)|সাগর (সমুদ্র)|laut (samudera)|bahari|deniz|maro|meri|może
 hay:i|hayi||||maritime||marítimo|marítimo|морской|||||||||||mara|meri- (merellinen)|morski
@@ -1291,7 +1292,7 @@ hisab:ia|hisabia||||arithmetics||aritmética (cálculos)||||||||||||||laskuoppi 
 histor:|histor||||history (annals)||historia (pasado)|||||||||||||historio|historia (aikakirjat)|historia; annały, roczniki
 histor:ia|historia|||eng:history, spa:swa:historia, por:história, fra:histoire, rus:история (istoriya)|history (study of history)||historia (estudio de sucesos del pasado)|||||||||||||historio (studo de historio)|historia (oppiaine)|historia, badanie historii
 histor.er:|historer||||historian||historiador|||||||||||||historiisto|historioitsija|historyk
-Ho Ci Min sit:e|Ho Ci Min cite||||Ho Chi Minh City (Saigon)|||||||||Thành phố Hồ Chí Minh||||||||Ho Chi Minh (Sajgon)
+Ho Ci Min sit:e|Ho Ci Min site||||Ho Chi Minh City (Saigon)|||||||||Thành phố Hồ Chí Minh||||||||Ho Chi Minh (Sajgon)
 hob:e|hobe|||eng:spa:por:deu:fra:hobby, rus:хобби (hobbi)|hobby||pasatiempo (hobby, afición)|||||||||||||hobio|harrastus|hobby
 hog:a|hoga||||burn (cause to burn)|brûler|quemar|queimar|жечь (палить)|أَحْرَقَ|燃烧|燃やす|태우다||जलाना|||kuchoma|yakmak||polttaa|spalić, palić
 hog:e|hoge|||spa:fuego, por:fogo + rus:огонь (ogon’), hin:आग (āg), ben:অগ্নি (ôgni), pan:ਅੱਗ (ag) + zho:火 (huǒ), yue:火 (fo2), wuu:火 (hu2), kor:화 (hwa), vie:hoả|fire (burning)|feu|fuego|fogo|огонь|نَار|火|火|불|lửa|आग (अग्नि)|আগুন (অগ্নি)|api|moto|ateş|fajro|tuli|ogień
@@ -1412,7 +1413,7 @@ jag:a|jaga||||wake (make awake)||despertar||||||||||||||herättää|obudzić, bu
 jag:i|jagi|||hin:जागना (jāgnā), ben:জাগা (jaga), pan:ਜਾਗਣਾ (jāgṇā), mar:जागणे (j̈āgṇe), guj:જાગવું (jāgvũ), may:jaga|awake|éveillé|despierto|acordado|acordado|||||||||jaga||uyanık|olla hereillä|przebudzony, przytomny
 jag:u|jagu||||wake (become awake)||despertarse|despertar|проснуться||睡醒|起きる|||जागना||menjagakan||uyanmak|||
 jak:e|jake|||eng:jacket, zho:夹克 (jiākè), rus:жакет (žaket), deu:Jacke, por:jaqueta|jacket||chaqueta|||||||||||||jako|pikkutakki (jakku)|kurtka
-Jakarta:|Jakarta||||Jakarta||||||||||||Jakarta|||||Dżakarta
+Jakarta:|Jakarta|shefsite|||Jakarta||||||||||||Jakarta|||||Dżakarta
 jam:a|jama||||collect (gather, bring together, assemble)||recoger (juntar, reunir, acumular, recolectar, montar)|||||||||||||kolekti (kunigi)|koota (kerätä)|kolekcjonować, zebrać, zbierać
 jam:i|jami||||collective||colectivo|||||||||||||kolekta|kollektiivinen|zbiorowy, zbiorczy
 jam:ia|jamia|||ara:(jamʿiyya), hau:jam'iyya, swa:jamii, tur:camia|collection (congregation, assembly)||colección (grupo, conjunto, montón)||||||||||||||yhteisö (kokoontuminen, kollektiivi)|kolekcja, zbiór; zgromadzenie, zebranie
@@ -1429,7 +1430,7 @@ jangl:e|jangle|||eng:fra:jungle, spa:jungla, por:jângal, rus:джунгли (d�
 jar:|jar|||eng:jar, ara:(jara), por:spa:jarra|jug (jar, pitcher)||jarra||||||||||||||kannu (karahvi)|dzban, dzbanek; słój, słoik
 jawab:a|jawaba||||respond (give an answer)||responder (contestar)|||||||||||||respondi|vastata|odpowiedzieć, odpowiadać
 jawab:e|jawabe|||ara: جَوَاب‎ (jawāb), hin:जवाब (javāb), may:jawab, swa:jibu,jawabu, tur:cevap|answer (reply, response)|réponse|repuesta (contestación)|resposta|ответ|جَوَاب‎|回答|答え (回答)|대답 (회답)|trả lời|जवाब (उत्तर)|উত্তর|jawab|jibu|cevap|respondo|vastaus|odpowiedź, odzew
-Jayer:|Jayer|desh|DZ||Algeria||Argelia||||||||||||||Algeria|Algieria
+Jayer:ia|Jayeria|desh|DZ||Algeria|Algérie|Argelia|||الجزائر‎ (الدزاير‎)|||||||||||Algeria|Algieria
 jaz:e|jaze||||jazz||jazz||||||||||||||jazz (jatsi)|jazz, dżez
 jeb:e|jebe|||hin:जेब (jeb), pnb:ਜੇਬ (jeb), urd:(jeb), tel:(jēbu), ara:(jayb), tur:cep, wol:jiba|pocket||bolsillo|||||||||||||poŝo|tasku|kieszeń
 jebr:ia|jebria|||ara:fas:(jabr), tur:cebir, urd:(aljabrā), eng:algebra, fra:algèbre|algebra||álgebra||||||||||||||algebra|algebra
@@ -1456,7 +1457,7 @@ jeng:i|jengi||||military (martial, warlike)||macrial (militar)|||||||||||||milit
 jeng.er:|jenger||||warrior (fighter)||luchador (guerrero)||||||||||||||soturi (taistelija)|wojownik, bojownik
 jeng.o.xut:e|jengoxute|||zho:武术 (wǔshù), jpn:武術 (bujutsu), vie:võ thuật, kor:무술 (musul), eng:martial art|martial art||arte marcial||||||||||||||kamppailulaji|sztuka walki
 jenxen:|jenxen|bine|Panax|zho:人蔘 (rénshēn), min:人蔘 (jîn-sam), eng:spa:por:tur:may:ginseng, rus:женьшень (zhen’shen’), hind:जिनसेंग (jinseṅg), jpn:人参 (ninjin)|ginseng||ginseng||||||||||||||ginseng|żeń-szeń
-Jers:ia|Jersia|desh|JE||Jersey||Jersey||||||||||||||Jersey|Jersey
+Jersey:|Jersey|desh|JE||Jersey||Jersey||||||||||||||Jersey|Jersey
 jest:e|jeste|||eng:gesture, spa:por:gesto, fra:geste, rus:жест (zhest), tur:jest, fas:ژست‎ (žest)|gesture||gesto||||||||||||||ele|gest
 Jibraltar:|Jibraltar|desh|GI||Gibraltar||Gibraltar||||||||||||||Gibraltar|Gibraltar
 Jibut:i|Jibuti|desh|DJ||Djibouti||Yibuti||||||||||||||Djiboutia|Dżibuti
@@ -1493,7 +1494,7 @@ jung:i|jungi||||central (middle)||central|||||||||||||||centralny (środkowy)
 Jung:i Afrik:e|Jungi Afrike|desh|CF||Central African Republic||República Centroafricana||||||||||||||Keski-Afrikan Tasavalta|Republika Środkowoafrykańska
 jung:u|jungu||||to be centered (amid, in the middle)||centrarse (en el centro de)||||||||||||||keskittyä (olla keskellä)|być wycentrowanym, być w środku
 jung.o.fon:|jungofon||||vowel|voyelle|vocal|vogal|гласный||||보컬 부분||||vokal|||vokalo|vokaali|samogłoska
-Jungog:ia|Jungogia|desh|CN||China|Chine|China|China|Китай|اَلصِّين‎|中国|中国|중국|Trung Quốc|चीन|চীন|Cina (Tiongkok)|Uchina|Çin|Ĉinio|Kiina|Chiny
+Junguo:|Junguo|desh|CN||China|Chine|China|China|Китай|اَلصِّين‎|中国|中国|중국|Trung Quốc|चीन|চীন|Cina (Tiongkok)|Uchina|Çin|Ĉinio|Kiina|Chiny
 jup:e|jupe|||fra:jupe, ara:(jūb), rus:юбка (yubka)|skirt||falda|||||||||||||jupo|hame|spódnica
 Jupiter:|Jupiter|planete 5|||Jupiter|Jupiter|Jupiter|Júpiter|Юпитер|المشتري|木星|木星|||||||Jüpiter||Jupiter|Jowisz
 jus:|jus|||eng:juice, swa:jusi, tam:ஜூஸ் (jūs), jpn:ジュース (jūsu), kor:주스 (juseu)|juice|jus|jugo (zumo)|suco (sumo)|сок|عَصِير‎|汁|ジュース|즙 (스)|dịch|रस|রস|jus|jusi|šire|suko|mehu|sok
@@ -1516,8 +1517,8 @@ kababa|kababa|||ara:fas:urd: كباب (kabāb), tur:may:eng:spa:kebab, rus:ке�
 kababi manse|kababi manse||||grilled meat (kebab)||||кебаб|كباب|||||कबाब|কাবাব|||kebap||kebab (grilliliha)|kebab
 kabaw|kabaw|biw|Bubalus bubalis|spa:carabao, may:kerbau, jav:kebo, khm:ក្របី (krɑbəy)|water buffalo||búbalo (arni)||||||||||||||vesipuhveli|bawół domowy
 kabin|kabin|||eng:cabin, spa:cabaña, por:cabana, fra:cabane, ben:কেবিন (kebin)|cabin (booth)||cabaña||||||||||||||koppi (maja)|kabina, budka
-kaboge|kaboge|biw||Cucurbitatur:kabak, swa:boga, jpn:カボチャ (kabocha)|squash (pumpkin, gourd)|citrouille|calabaza|abóbora (jerimun)|тыква||南瓜|カボチャ||||||||||kabaczek (dynia, tykwa)
-Kabu Verde|Kabu Verde|desh|CV||Cabo Verde (Cape Verde)||Cabo Verde||||||||||||||Cabo Verde|Wyspy Zielonego Przylądka (Republika Zielonego Przylądka)
+kaboge|kaboge|biw|Cucurbita|tur:kabak, swa:boga, jpn:カボチャ (kabocha)|squash (pumpkin, gourd)|citrouille|calabaza|abóbora (jerimun)|тыква||南瓜|カボチャ||||||||||kabaczek (dynia, tykwa)
+Kabo Verde|Kabo Verde|desh|CV||Cabo Verde (Cape Verde)||Cabo Verde||||||||||||||Cabo Verde|Wyspy Zielonego Przylądka (Republika Zielonego Przylądka)
 kade|kade|biw|Gadus|eng:cod, ara:قد (qad)|cod|morue|bacalao||||鱈|鱈||||||||||dorsz
 kadem|kadem|mate|Cd||cadmium||cadmio|||||||||||||kadmio|kadmium|kadm
 kafe:|kafe*|||deu:Kaffee, fra:spa:por:café, rus:кофе, zho: 咖啡 (kāfēi), yue:咖啡 (gaa3 fe1), eng:coffee, hin:काफ़ी (kāfī), ben:কফি (kôphi), tur:kahve, tgl:kape, tha:กาแฟ (kafæ)|coffee|café|café|café|кофе|قَهْوَة|咖啡|コーヒー|||काफ़ी (क़हवा)||kopi|kahawa|kahve|kafo|kahvi|kawa
@@ -1529,6 +1530,7 @@ kagujolimon|kagujolimon|biw|Citrus × aurantiifolia||key lime|lime (citron vert)
 kaka|kaka||||defecate (shit)||defecar||||||||||||||ulostaa (kakata)|defekować, srać
 kakaw|kakaw|biw||por:cacau, ara:(kākāw), spa:cacao, eng:cocoa, vie:cacao, jpn:カカオ (kakao), zho:可可 (kěkě), rus:какао (kakao)|cocoa||cacao|||||||||||||kakao|kaakao|kakao
 kake|kake|||spa:por:fra:caca, deu:Kacke, ara:(kākā), tur:kaka, rus:кака (kaka), fas:(kake)|excrement (shit)||caca|||||||||||||feko|uloste (kakka)|ekskrement, gówno
+Kaiman nesia|Kaiman nesia|desh|KY||Cayman Islands||islas Caimán||||||||||||||Cayman-saaret|Kajmany
 kal|kal||||void (empty space)||espacio (separación)||||||||||||||tyhjö|pustka
 Kalalia|Kalalia|desh|GL||Greenland||Groenlandia||||||||||||||Grönlanti|Grenlandia
 kalam|kalam|||ara:fas:urd:(qalam), hau:alƙalami, yor:swa:kalamu, tur:kalem, hin:क़लम (qalam), ben:কলম (kôlôm), spa:por:cálamo|pen (writing tool)|plume|bolígrafo|lápis|ручка||笔|ペン|||क़लम|কলম |pen (pena, kalam)|kalamu|kalem|plumo|kynä|pióro, długopis
@@ -1548,7 +1550,7 @@ kalsopetre|kalsopetre||||limestone|calcaire|caliza|calcário|известняк|
 kamar|kamar|||may:kamar, por:câmara, hin:कमरा, (kamrā), deu:Kammer, rus:камера (kamera)|room (chamber)|pièce (chambre)|habitación (cuarto, sala, pieza)|sala (câmara)|комната (камера)|قَمَرَة|房间|部屋|방||कमरा|কক্ষ|kamar|chumba||ĉambro|huone|pokój, sala
 kamargaw|kamargaw||||ceiling|||||||||||||||||sufit
 kamartal|kamartal||||floor||piso (suelo)||||||||||||||lattia|podłoga
-Kambujia|Kambujia|desh|KH||Cambodia||Camboya|||||||||||||Kamboĝo|Kambodja|Kambodża
+Kambojia|Kambojia|desh|KH||Cambodia||Camboya|||||||||||||Kamboĝo|Kambodja|Kambodża
 Kamerun|Kamerun|desh|CM||Cameroon||Camerún||||||||||||||Kamerun|Kamerun
 kamia|kamia||27 emotions|hin:काम (kām), tha:กาม (gaam), eng:kama|sexual desire (lust)||lujuria (deseo)|||||||||||||deziro|himo (halu)|pożądanie, żadza
 kamil|kamil|biw|Matricaria recutita|deu:Kamille, eng:camomile, por:camomila, fra:camomille, jpn:カモミール (kamomīru), may:kamomil|German camomile|Camomille sauvage|manzanilla de Castilla|camomila-vulgar|ромашка аптечная||母菊|カモミール (カミツレ)|||||||||kamomilla|rumianek pospolity
@@ -1557,8 +1559,8 @@ kamisi xake|kamisi xake||||sleeve|manche|manga|manga|||袖子|袖||||||||||ręka
 kamote|kamote|biw|Ipomoea batatas|spa:camote, tgl:kamote|sweet potato||camote (batata)|||||||||||||batato|bataatti|słodki ziemniak
 kampe|kampe|||eng:camp, spa:campamento, por:acampamento, tur:kamp, swa:kambi, hin:कैंप (kaimp), may:kem, jpn:キャンプ (kyanpu)|camp||campamento||||||||||||||leiri|obozowicz
 kamper|kamper||||camper||campista||||||||||||||retkeilijä|obóz
-kamri|kamri||||Welsh||galés||||||||||||||walesilainen|walijski
-Kamria|Kamria|desh|||Wales (Cambria)||Gales||||||||||||||Wales|Walia
+kamri:i|kamrii||||Welsh||galés||||||||||||||walesilainen|walijski
+Kamri:|Kamri|desh|||Wales (Cambria)||Gales||||||||||||||Wales|Walia
 kan:|kan|||fas:خانه‎ (xâne), rus:-хана (-hana), hin:ख़ाना (xānā), ben:খানা (khana), tur:hane + zho:馆 (guǎn), kor:관 (gwan), jpn:館 (-kan), vie:quán|shop (store or workshop)||||||店 (馆)|店 (館)|관|quán|ख़ाना|খানা|||hane|farejo|paja (tekimö)|
 Kanada|Kanada|desh|CA||Canada||Canadá||||||||||||||Kanada|Kanada
 kanal|kanal|||eng:spa:por:fra:canal, rus:канал (kanal), ben:খাল (khal), may:kanal|channel||canal (cauce, acequia)|||||||||||||kanalo|kanava (kanaali)|kanał
@@ -1636,13 +1638,12 @@ kax.er:|kaxer||||cashier||cajero||||||||||||||kassanhoitaja|kasjer
 kay:a|kaya||||open||abrir|||||||||||||malfermi|aukaista (avata)|otworzyć, otwierać
 kay:i|kayi|||zho:开 (kāi), wuu:開 (khe1), jpn:開 (kai), kor:개 (gae), vie:khai, tha:ไข (kǎi), lao:ໄຂ (khai)|open (not closed)||abierto|||||||||||||malferma|auki (avoin)|otwarty, niezamknięty
 kay:u|kayu||||become open||abirse|||||||||||||malfermiĝi|aueta (avautua)|otworzyć się, otwierać się
-Kazahia|Kazahia|desh|KZ||Kazakhstan||Kazajistán (Kazakistan)||||||||||||||Kazakstan|Kazachstan
+Kazak.istan|Kazakistan|desh|KZ||Kazakhstan||Kazajistán (Kazakistan)||||||||||||||Kazakstan|Kazachstan
 kecape|kecape|||yue:茄汁 (kezap), eng:ketchup, hin:केचप (kecap), rus:кетчуп (ketčup), jpn:ケチャップ (kechappu), tgl:ketsap|ketchup||kétchup|||||||||||||keĉupo|ketsuppi|keczup
 keci|keci|||zho:客气 (kèqì), yue:客氣 (haak3 hei3), wuu:客氣 (khaq qi4)|polite||educado||||客气|||||||||ĝentila|kohtelias (kiltti)|uprzejmy
 keg:a|kega||||visit||visitar|||||||||||||vizito|käydä (vierailla)|odwiedzić, odwiedzać
 keg:e|kege|||zho:客 (kè), wuu:客 (ka’), jpn:客 (kyaku), kor:객 (gaeg), vie:khách, tha:แขก (khæk)|visitation (visit)||visitar|||||||||||||viziti|käynti (vierailu, visiitti)|wizyta
 keg:e|keger||||visitor (guest)||invitado (visita)||||客人|客人|손님|khách||||||vizitanto|vierailija (vieras)|wizytant (gość)
-Keiman nesia|Keiman nesia|desh|KY||Cayman Islands||islas Caimán||||||||||||||Cayman-saaret|Kajmany
 kek:e|keke|||swa:keki, jpn:ケーキ (kēki), eng:cake, ara:(kaʿka), tur:kek, hin:केक (kek), deu:Keks, rus:кекс (keks)|cake (cookie)||pastel (galleta)|||||||||||||kuko|kakku (keksi)|ciasto, ciastko
 kel|kel|||hin:खेल (khel), ben:খেলা (khela), tha:กีฬา (kīlā), khm:កីឡា (keila)|sport (athletics)||deporte|||||||||||||sporto|urheilu|sport, lekkoatletyka
 kelel|kelel|||swa:kon:makelele|noise||ruido||||||||||||||meteli|atleta, sportowiec
@@ -1665,7 +1666,6 @@ ketl:e|ketle|||eng:kettle, rus:котёл (kot’ol), hin:केतली (ketl�
 kex:|kex|||jpn:毛 (ke), hin:केश (keś), urd:(keś), pnb:ਕੇਸ਼ (keś), tel:(kēśamu), kan:(kēśa)|hair||pelo|||||毛||||||||haro|hius (karva, tukka, hiukset)|włos
 kex.o.bend:e|kexobende||||hairband (headband)||cinta (cinta para el pelo)||||||||||||||hiuspanta|opaska do włosów
 kex.o.sabun:|kexosabun||||shampoo||champú|||||||||||||ŝampuo|šampoo|szampon
-Khartum|Khartum|shefocite|SD||Khartoum|Khartoum|Jartum|Cartum|Хартум|الخرطوم|喀土穆|ハルツーム|||||Khartoum|Khartoum|Hartum|Ĥartumo|Khartoum|
 kilo:|kilo*|||eng:fra:spa:por:may:tur:kilo-, rus:кило- (kilo-), jpn:キロ- (kiro-), kor:킬로- (killo-)|thousand (kilo-)||mil (kilo-)|||||千 (１０００)||||||||mil (kilo-)|tuhat (kilo-)|tysiąc (kilo-)
 kilo.gram:|kilogram|unomete|kg||kilogram (kg)||kilograma||||||||||||||kilogramma|kilogram (kg)
 kilo.mitr:e|kilomitre|unomete|km||kilometer (km)||kilometre|||||||||||||kilometro|kilometri|kilometr
@@ -1759,8 +1759,8 @@ kon.ten.er:|kontener||||container|conteneur|contenedor|contêiner|контейн
 kon.trat:e|kontrate||||pact (contract, covenant, alliance)|convention (alliance, pacte)|convenion (pacto)|pacto|контракт||公約||||||||||liittosopimus|pakt (kontrakt, ugoda, umowa, konwencja)
 Konakri Ginia|Konakri Ginia|desh|GN||Guinea||Guinea||||||||||||||Guinea|Gwinea
 koncung|koncung|biw|Insecta|zho:昆蟲 (kūnchóng), yue:昆蟲 (kwan1 cung4), nan:昆蟲 (khun-thiông), jpn:昆蟲 (konchū)|insect|insecte|insecto|inseto|насекомое||昆虫|昆虫|곤충|sâu bọ (côn trùng)|कीड़ा||serangga|mdudu|böcek||hyönteinen (ötökkä)|owad
-konfuze|konfuze|||zho:孔夫子 (Kǒng Fūzǐ)|Confucious||confucio|||||||||||||Konfuceo|Kungfutse|Konfucjusz
-konfuzistia|konfuzistia||||Confucianism||confucianismo||||||||||||||Kungfutselaisuus|konfucjanizm
+Kongfuz:e|konfuze|||zho:孔夫子 (Kǒng Fūzǐ)|Confucious||confucio|||||||||||||Konfuceo|Kungfutse|Konfucjusz
+Kongfuz.ist:ia|konfuzistia||||Confucianism||confucianismo||||||||||||||Kungfutselaisuus|konfucjanizm
 kong:|kong|||zho:孔 (kǒng), yue:孔 (hung2), wuu:孔 (khon2), jpn:孔 (kō), kor:공 (gong), vie:hỏng|hole||agujero (hueco)||||||||||||||reikä|dziura
 Konkani|Konkani|nas|||Konkani||konkani||||||||||||||konkani (eräs intialainen kieli)|konkani
 konserte|konserte|||eng:fra:concert, spa:concierto, por:concerto, deu:Konzert, rus:концерт (koncert), may:tur:konser, jpn:コンサート (konsāto), kor:콘서트 (konseoteu), hin:कॉन्सर्ट (kŏnsarṭ)|concert|concert|concierto|concerto|концерт||音乐会|コンサート (音楽会)|콘서트 (음악회)||कॉन्सर्ट|সঙ্গীতানুষ্ঠান|konser||konser|koncerto|konsertti|koncert
@@ -1793,7 +1793,7 @@ Kosta Rika|Kosta Rika|desh|CR||Costa Rica||Costa Rica||||||||||||||Costa Rica|Ko
 koste|koste||||cost (price)||precio (coste)||||||||||||||hinta (maksu)|koszt, cena
 kosti|kosti||||expensive (costly)|||||||||||||||||kosztowny (drogi)
 kote|kote|||eng:coat, swa:koti, orm:koota, jpn:コート (kōto), fas:(kot), hin:कोट (kot)|coat||abrigo (chaqueta)||||||||कोट|||||palto|takki|płaszcz
-Kotedivuar|Kotedivuar|desh|CI||Côte d’Ivoire (Ivory Coast)||Costa de Marfil||||||||||||||Norsunluurannikko|Wybrzeże Kości Słowniowej
+Kot:e D:a Ivuar:|Kote Da Ivuar|desh|CI||Côte d’Ivoire (Ivory Coast)||Costa de Marfil||||||||||||||Norsunluurannikko|Wybrzeże Kości Słowniowej
 koy (koyi)|koy (koyi)|||hin:कोई (koī), urd:(koī), rus:кое- (koye-)|some||algún|||||何分の||||||||iu|jokin (joku)|jakiś
 koy jan|koy jan||||someone (somebody)||algién|||||||||||||iu persono|joku|ktoś
 koy sate|koy sate||||sometime||algún día (algún vez)|||||||||||||iam|joskus|sometime
@@ -1859,7 +1859,7 @@ kurem|kurem|mate|Cm||curium||curio|||||||||||||kuriumo|curium|kiur
 kurse|kurse|||ara:(kursiy), hin:कुरसी (kursī), urd:(kursī), pnb:ਕੁਰਸੀ (kursī), tel:(kurcī), may:som:kursi, fas:(korsi)|chair||silla|||||||||||||seĝo|tuoli|kszesło, fotel
 kurv:e|kurve|||eng:curve, fra:courbe, spa:por:curva|curve (bend)||curva|||||||||||||kurbo|mutka (kurvi)|wygiąć, wyginać, zgiąć, zginać, zakrzywić, zakrzywiać
 kurv:i|kurvi||||curvy (curved)||curvo||||||||||||||mutkikas|zakrzywiony
-Kuwaitia|Kuwaitia|desh|KW||Kuwait||Kuwait||||||||||||||Kuwait|Kuwejt
+Kuwait:e|Kuwaite|desh|KW||Kuwait||Kuwait||||||||||||||Kuwait|Kuwejt
 kuxa|kuxa||||lay (lay down)|coucher|acostar (poner)|deitar|положить  (уложить)|||横たえる|||||||||panna jkn maate|położyć
 kuxen|kuxen||||cushion (pillow)||almohada||||||||||||||tyyny|poduszka
 kuxloke|kuxloke|||fra:eng:couchette, ita:cuccetta, pol:kuszetka|berth (couchette)|couch (couchette)||||||||||||||||kuszetka (koja)
@@ -1889,10 +1889,9 @@ lancografa|lancografa||||project (cast)|projeter (donner)|proyectar||||投射|�
 lancografer|lancografer||||image projector||proyector||||||||||||||projektori (videotykki, piirtoheitin)|projektor (rzutnik)
 lancovute|lancovute||||projectile (missile)|projectile|proyectil (misil)|projétil|снаряд||投掷物|飛翔体 (矢玉)||||||||||pocisk
 langan|langan|||zho:栏杆 (lángān), jpn:欄干 (rankan), kor:난간 (nan-gan)|banister (handrail)||barandilla (pasamanos)||||||||||||||kaide (reelinki)|poręcz (balustrada)
-Lanka|Lanka|desh|LK||Sri Lanka (Ceylon)||Sri Lanka||||||||||||||Sri Lanka|Sri Lanka
 lantan.em:|lantanem|mate|La||lanthanum||lantano||||鑭|ランタン|||||||||lantaani|lantan
 Lao:|Lao|desh|LA||Laos||Laos||||||||||||||Laos|Laos
-Lao:i|Laoi||||Lao (Laotian)||laosiano||||||||||||||laoslainen|laotański
+lao:i|laoi||||Lao (Laotian)||laosiano||||||||||||||laoslainen|laotański
 larve|larve|||deu:fra:larve, eng:tur:larva, hin:लार्वा (lārvā), urd:(lārvā), pol:larwa|larva (maggot, caterpillar)||larva||||||||||||||toukka|larwa, czerw, gąsienica
 lasti|lasti|||eng:elastic, spa:por:elástico, gla:lastaig, rus:эласти́чный (elastíčnyj), tur:may:elastik, jpn:エラスティック (erasutikku)|elastic||elástico (flexible)||||||||||||||joustava (elastinen)|elastyczny
 lasun|lasun|biw|Allium sativum|hin:लहसुन (lahsun), ben:রসুন (rôśun), zho:大蒜 (dàsuàn)|garlic|ail|ajo|alho|чеснок||大蒜 (蒜头)|大蒜|마늘|tỏi|लहसुन|রসুন|bawang putih|kitunguu saumu|sarımsak|ajlo|valkosipuli|larwa, czerw, gąsienica
@@ -1921,7 +1920,6 @@ left:e|lefte|||eng:left|left||lado izquerdo|esquerdo|левый||左|左|||ब�
 left:i|lefti||||left hand||izquierdo|||||||||||||||lewy (lewostronny, z lewej strony)
 left.ist:e|leftiste||||leftist (left-winger)||izquerdista||||||||||||||vasemmistolainen|lewicowiec (lewak)
 leg:i|legi|||eng:light, spa:ligero, fra:léger, rus:лёгкий (l’ogkiy), pol:lekki, ben:লঘু (laghu)|light (weightless)|léger|ligero|||||||||||||||lekki
-Legos:|Legos||||Lagos|||||||||||||||||Lagos
 leng:i|lengi|||zho:冷 (lěng), vie:lạnh, yue:冷 (laang5)|cold||frío||||冷たい (寒い)|||||||||malvarma|kylmä|zimny, chłodny
 leng.o.mosim:|lengomosim||||winter|hiver|invierno|inverno|зима||冬天||||सर्दी (जाड़ा,  शिशिर)||musim dingin||kış|vintro|talvi|zima
 leng.o.mosim:i|lengomosimi||||wintry|hivernal (hibernal)|invernal|invernal (hibernal)|зимний|||||||||||vintra|talvinen|zimowy
@@ -1939,20 +1937,20 @@ Lib:ia|Libia|desh|LY||Libya||Libia||||||||||||||Libya|Libia
 lib:u|libu|||zho:立 (lì), yue:(lip), vie:lập, kor:립 (rib)|stand||estar de pie|||||立つ|||||||||seistä (seisoa)|stać
 lib.o.ban:|liboban||||shelf (bookshelf)|étagère|estante (repisa)|prateleira (estante)|полка||架子 (搁板)|棚||||||||||półka (regał na książki)
 lib.o.baz:e|libobaze||||stand (rack)||soporte (perchero, atril)||||架子|台||||||||||stojak (wieszak)
-Libanon:|Libanon|desh|LB||Lebanon||Líbano||||||||||||||Libanon|Liban
+Libanen:|Libanen|desh|LB||Lebanon||Líbano||||||||||||||Libanon|Liban
 libel:|libel|||spa:por:libélula, fra:libellule, deu:Libelle|dragonfly|libellule|libélula|libélula|стрекоза||蜻蜓|蜻蛉|잠자리||व्याध पतंग|ফড়িং|capung||yusufçuk|libelo|sudenkorento|ważka
 Liber:ia|Liberia|desh|LR||Liberia||Liberia||||||||||||||Liberia|Liberia
 lic:e|lice|||zho:荔枝 (lìzhī), hin:लीची (līcī), eng:lychee, rus:личи (liči), may:leci, vie:lệ chi|lychee (litchi)||lichi||||||||||||||litši|liczi
 lid:a|lida||||lead (direct)||dirigir (mandar, conducir, capitanear)||||||||||||||johtaa|prowadzić, dowodzić, kierować
 lid.er:|lider|||eng:fra:leader, spa:por:líder, rus:лидер (lider), tur:lider, hin:लीडर (līdar), jpn:リーダー (rīdā), kor:리더 (rideo)|leader (director)|dirigeant (leader)|dirigente (líder)|líder (chefe)|руководитель (лидер)||领导||||||||||johtaja (pomo)|dowódca, kierownik
 lid.o.kord:e|lidokorde||||leash (rein)||correa (rein)|||||リード (手綱)||||||||||smycz (cugiel, lejc, wodza)
-lietuv:i|lietuvi||||Lithuanian||lituano||||||||||||||liettualainen|litewski
-Lietuv:ia|Lietuvia|desh|LT||Lithuania||Lituania||||||||||||||Liettua|Litwa
+lietuva:i|lietuvai||||Lithuanian||lituano||||||||||||||liettualainen|litewski
+Lietuva:|Lietuva|desh|LT||Lithuania||Lituania||||||||||||||Liettua|Litwa
 lifaf:|lifaf|||ara:(lifāfa), fas:(lefâf), hin:लिफ़ाफ़ा (lifāfā)|wrapping (envelope, covering)||envoltura||||||||||||||kääre (kuori)|owinięcie (koperta, okładka)
 lifaf:a|lifafa||||wrap|envelopper (emballer)|envolver|embalar|||||||||||||kääriä (panna kääröön)|zawijać (zawinąć)
 lig:a|liga||||associate||asociar|||||||||||||aligi|liittää|stowarzyszać się (zrzeszać się)
 lig:e|lige|||fra:ligue, deu:spa:pol:por:liga, eng: league, rus: лига (liga), tur:lig, swa:ligi, jpn:リーグ (rīgu)|league (association)||liga (asociación, federación)||||||||||||||liitto (liittouma, liiga)|liga (stowarzyszenie)
-Lihtenxtain|Lihtenxtain|desh|LI||Liechtenstein||Liechtenstein||||||||||||||Liechtenstein|Liechtenstein
+Lihtenstain|Lihtenstain|desh|LI||Liechtenstein||Liechtenstein||||||||||||||Liechtenstein|Liechtenstein
 lil:i|lili|||eng:little|little (small; a little, somewhat)|petit|pequeño|pequeno|маленький (малый)||小|小さい|작은|nhỏ|छोटा||||küçük|malgranda|pieni (pienesti, vähän)|mały; mało, trochę, nieco
 lil:xek:e|lilxeke||||pebble (gravel)|caillou||pedrinha|галька||砾石|小石|자갈||||||çakıl|ŝtoneto|sorakivi|kamyk
 lil.bol:|lilbol||||bubble||burbuja (pompa)|||||||||||||bobelo|kupla|bańka
@@ -2007,6 +2005,7 @@ lok:u|loku||||be located (lie, be situated)||encontrarse (estar, situarse)||||||
 lon:|lon|||zho:论 (lùn), yue:論 (lœn6), kor:론 (ron), jpn:論 (ron), vie:luận|discussion (debate, discourse)||discusión (debate, discurso)||||论||||||||||väittely (debatti)|dyskusja, debata, dyskurs
 lon:a|lona||||debate (discuss)||debatir (discutir)||||||||||||||keskustelu (debatti)|debatować, prowadzić dyskurs
 lon:a biznes:|lona biznes||||negotiate (arrange)||negociar|||||話し合う (話を付ける)||||||||||negocjować
+London:|London||||London|||||||||||||||||Londyn
 long:a|longa||||lengthen (prolong)||alargar|||||||||||||longigi|pidentää|przedłużyć, przedłużać
 long:i|longi|||eng:fra:long, deu:lang, por:longo|long (lengthy)|long|largo|longo|||长|長い|길다|dài|लम्बा|দীর্ঘ (লম্বা)||panjang|uzun|longa|pitkä|długi
 long:ia|longia||||length||largo (longitud)||||||||||||||pituus|długość
@@ -2015,7 +2014,6 @@ long.o.dur:i|longoduri||||long (long-lasting, prolonged)|prolongé|perdurable (l
 long.o.dur:o|longoduro||||for a long time|longtemps||por muito tempo|долго||久||||||||||kauan (pitkän aikaa)|
 long.o.krokodil:|longokrokodil|biw|Crocodylidae||crocodile|crocodile|cocodrilo|crocodilo||||クロコダイル||||||||||krokodyl
 long.o.pipr:e|longopipre|biw|Piper longum||long pepper (pipli)|poivre long|||перец длинный||荜拔|畢撥|필발||पिप्पली|পিঁপুল|||||pitkäpippuri|pieprz długi
-Longon:|London||||London|||||||||||||||||Londyn
 lontr:e|lontre|biw|Lutrinae|spa:tgl:lutrino, fra:loutre, por:lontra, ita:lontra|otter|loutre|nutria|lontra|выдра||獭|獺||||||||||wydra
 lot:e|lote|||por:spa:lote, eng:fra:lot|batch (lot)||lote (grupo)||||||||||||||erä (satsi)|wsad, partia, porcja, seria
 low:a|lowa|||zho:漏 (lòu), yue:漏 (lau6), jpn:漏 (rō), 루 (ru)|leak||chorrear|vazar|протекать (просочиться)||漏|漏る||||||||liki|vuotaa|przeciekać, ciec
@@ -2030,8 +2028,8 @@ lusun|lusun||||asparagus||espárrago||||||||||||||parsa|szparag; szparagia
 luta|luta|||hin:लूटना (lūṭnā), urd:(lūṭnā), ben:লুটা (luṭā), pnb:ਲੁੱਟ (luṭ), eng:loot, + zho:掠夺 (lüèduó), yue:掠 (loek6)|rob (loot, plunder, pillage, ransack)||saquear (desvalijar, robar)||||掠夺|||||||||rabi|ryöstää (ryövätä)|obrabować, splądrować
 luter|luter||||robber (plunderer)|brigand (bandit)|ladrón|ladrão|грабитель||强盗||||डाकू|||||rabisto|ryöväri (rosvo)|rabuś (grabieżca)
 lutetem|lutetem|mate|Lu||lutetium||lutecio|||||||||||||lutecio|lutetium|lutet
-lutheristi|lutheristi||||Lutheran|luthérien|luterano|luterano|лютеранский||||||||||||luterilainen|luterański
-lutheristia|lutheristia||||Lutheranism|luthéranisme|luteranismo|luteranismo|лютера́нство||||||||||||luterilaisuus|luteranizm
+luteristi|lutheristi||||Lutheran|luthérien|luterano|luterano|лютеранский||||||||||||luterilainen|luterański
+luteristia|lutheristia||||Lutheranism|luthéranisme|luteranismo|luteranismo|лютера́нство||||||||||||luterilaisuus|luteranizm
 luv:a|luva||||love (hold dear)|aimer|amar||любить||爱|||||||||ami (ŝati)|rakastaa (pitää, tykätä)|kochać
 luv:e|luve||eng:love, rus:любовь (l’ubov’), hin:लोभ (lobh), ltn:libido||love (liking, affection)|amour (affection)|amor|amor|любовь||愛|愛|||मुहब्बत (अनुराग, पसंद)||cinta (kasih, asmara)|penzi (ashiki, upendo)|sevda (aşk)|amo|rakkaus (tykkääminen)|miłość (afekt)
 luv:i|luvi||||dear (beloved)|cher|querido|querido (caro)|||亲爱的|愛しい|||प्यारा|||||kara|rakas (armas)|kochany (drogi)
@@ -2040,9 +2038,9 @@ M|M||||M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M
 m:e|me|pron.||eng:me, fra:por:spa:me, hindi:मैं (mẽ), swa:mimi|I (me)|je (me)|yo|eu (me)|я|أَنَا‎|我|私|||मैं||saya (aku)|mimi||mi|minä|ja, mnie
 m:i|mi||||my||mi|||||私の||||||||mia|minun|mój
 m.o.m:e|mome|pron.|||we|nous|nosotros|nós|мы|نَحْنُ|我们|私たち|||हम|আমরা|kami (kita)|||ni|me|my
-Madagasi|Madagasi|desh|MG||Madagascar||Madagascar||||||||||||||Madagaskar|Madagaskar
-madagasi|madagasi||||Malagasy||malgache||||||||||||||malagassi|madagaskarski; malagaski
-Madyar|Madyar|desh|HU||Hungary||Hungría||||||||||||||Unkari|Węgry
+Madagaskar:|Madagaskar|desh|MG||Madagascar||Madagascar||||||||||||||Madagaskar|Madagaskar
+madagaskar:i|Madagaskari||||Malagasy||malgache||||||||||||||malagassi|madagaskarski; malagaski
+Madyar:ia|Madyaria|desh|HU||Hungary||Hungría||||||||||||||Unkari|Węgry
 mafan|mafan||||trouble (disturbance, bother)||problema (disturio)||||||||||||||vaiva (haitta)|problem, kłopot, zakłócenie
 mafana|mafana|||zho:麻煩 (máfan), yue:麻煩 (maa4 faan4), wuu:麻煩 (mo ve3)|bother||molestar (preocupar)||утруждать||||||||||||vaivata|przeszkodzić, przeszkadzać, robić kłopot
 mafanu|mafanu||||be bothered by (bother to, take the trouble to)||molestar en||утруждай|||悩む (わざわざする)||||||||||przejmować się (zawracać sobie głowę)
@@ -2070,11 +2068,11 @@ Makaw|Makaw|desh|MO||Macao||Macao||||||||||||||Macao|Makau
 mal (mali)|mal (mali)|||eng:mal-, spa:fra:mal, por:mau, rus:моль (mol’)|bad||malo|||||悪い||||||||malbona|huono|zły
 mal zar|mal zar||||misfortune (bad luck)||infortunio (mala suerte)||||||||||||||epäonni|zły los
 mal.darj.a|maldarja||||downgrade||degradar||||||||||||||laskea tasoa|dezaktualizować (pogorszyć)
-Malaisia|Malaisia|desh|MY||Malaysia||Malasia||||||||||||||Malesia|Malezja
 malaria|malaria||||malaria||malaria (paludismo)||||||||||||||malaria|malaria
 Malawi|Malawi|desh|MW||Malawi||Malaui||||||||||||||Malawi|Malawi
 malayali|malayali|nas|||Malayali (Malayalam)||malayali (malabar, malayalam)||||||||||||||malajalam (eräs intialainen kieli)|malajski
 malayi|malayi||||Malay||malayo||||||||||||||malaiji|malajski
+Malays:ia|Malaysia|desh|MY||Malaysia||Malasia||||||||||||||Malesia|Malezja
 malfunce|malfunce||||malfunction||falla (mal funcionamiento)||||||||||||||toimintahäiriö|awaria (wadliwe działanie)
 Mali|Mali|desh|ML||Mali||Mali|||||||||||||Malio|Mali|Mali
 malike|malike|||kan:(mallige), tam:(mallikai), tel:(malla), may:melati,  kor:말리 (malli), tha:มะลิ (mali), zho:茉莉 (mòlì)|jasmine||jazmín|||||||||||||jasmeno|jasmiini|jaśmin
@@ -2136,6 +2134,7 @@ matur|matur||||adult|adulte|adulto||взрослый||成年人|大人||||||||pl
 maturi|maturi|||eng:fra:mature, spa:por:maduro|mature (ripe, adult)||maduro (adulto, curado)|||||||||||||matura (plenkreska)|kypsä (aikuinen)|dorosły, dojrzały
 maturi fem|maturi fem||||woman (adult female)||mujer (señora)||||女人|女の人||||||||virino|nainen|kobieta, dorosła samica
 maturi man|maturi man||||man (adult male)||hombre (señor)||||男人|男の人||||||||viro|mies|mężczyzna, dorosły samiec
+Mauris|Mauris|desh|MU||Mauritius||Mauricio||||||||||||||Mauritius|Mauritius
 maw:|maw|biw||zho:猫 (māo), yue:貓 (maau), vie:mèo, swa:nyau|cat|chat|gato|gato|кошка||猫|猫|고양이|mèo|बिल्ली|বেড়াল|kucing|paka (nyau)|kedi|kato|kissa|kot
 max:|max|||spa:mas, por:mais + eng:fra:maximum, rus:максимум (maksimum), may:maksimum, fas: ماکسیمم‎ (mâksimom)|more|plus|más|mais||||||||||||pli|enemmän (myös, lisäksi, plus)|bardzie
 max: k:a bas:|max ka bas||||too much||demasiado|||||||||||||tro|liikaa|zbyt
@@ -2173,8 +2172,6 @@ megawate|megawate|unomete|MW||megawat (MW)||megavatio||||||||||||||megawatti (MW
 mege|mege|||hin:मेघ (megh), ben:মেঘ (megh), tam:மேகம் (mēgam), tel:మేఘము (mēghamu), may:mega, tha:เมฆ (mek)|cloud|nuage|nube|nuvem|облако|سَحَابَة|云|雲|구름|mây|मेघ (बादल)|মেঘ|awan (mega)|wingu|bulut||pilvi|chmura
 mehe|mehe|biw||hin:मेष (meṣ), fas:(miš), tha:เมษ (met), + lin:kon:meme, jpn:メーメー (mē mē), por:meh, ara:(maa'), tur:mee|sheep||oveja|||||||||||||ŝafo|lammas|owca
 mehi kex|mehi kex||||wool (fleece)|laine||||||||||||||||wełna (runo owcze)
-Mehiko|Mehiko|desh|MX||Mexico||México|||||||||||||Meksikio|Meksiko|Meksyk
-Mehiko site|Mehiko site||||Mexico City||Ciudad de México|||||||||||||||Meksyk
 mel|mel|||por:mel, fra:spa:miel, ell:μέλι (méli)|honey|miel|miel|mel||||||||||||mielo|hunaja|miód
 melodi|melodi||||melodious (melodic)||melodioso||||||||||||||melodinen (sointuisa)|melodyczny
 melodia|melodia|||eng:melody, spa:melodía, por:melodia, rus:мело́дия (melódija), tur:may:melodi, fas:ملودی‎ (melodi), jpn:メロディー (merodī)|melody||melodía|||||||||||||melodio|melodia (sävelmä)|melodia
@@ -2205,10 +2202,11 @@ metaljanger|metaljanger||||blacksmith (iron forger)||herrero||||铁匠||||||||||
 metode|metode|||eng:method, spa:por:método, fra:méthode, rus:ме́тод (métod), tur:metod, may:metode|method (means)||método|||||||||||||metodo|keino (menetelmä, metodi)|metoda, sposób
 metr.un:|metrun||||unit (measurement)||unidad (medida)|||||||||||||||jednostka miary
 metre|metre|||eng:meter, hin:मात्रा (mātrā), ben:মাত্রা (matra), may:matra|measurement||medida|||||||||||||mezuro|mitta (koko, määrä)|miara
+Mexiko|Mexiko|desh|MX||Mexico||México|||||||||||||Meksikio|Meksiko|Meksyk
+Mexiko site|Mexiko site||||Mexico City||Ciudad de México|||||||||||||||Meksyk
 mey (meyi)|mey (meyi)|||zho:每 (měi), wuu:每 (me), vie:mọi, kor:매 (mae)|every (each)||cada||||每|毎||||||||ĉiu(j)|joka (jokainen)|każdy, wszyscy
 meze|meze|||por:spa:mesa, hin:मेज़ (mez), swa:meza, may:meja, tam:மேசை (mesei), fas: میز‏‎ (miz), tur:masa|table|table|mesa|mesa|стол|طَاوِلَة|桌子|机 (テーブル)|||मेज़||meja|meza|masa|tablo|pöytä|stół
 mezistan|mezistan||||plateau (tableland)||meseta|||||台地 (高地)||||||||||płaskowyż (plateau)
-Mianma|Mianma|desh|MM||Myanmar (Burma)||Myanmar (Birmania)|||||||||||||Birmo|Myanmar (Burma)|Mjanma, Birma
 mien|mien|||zho:面 (miàn), may:mie, jpn:麺 (men), tha:หมี่ (mii), khm:មី (mi)|noodle||fideo (tallarín)|||||ヌードル||||||||nudelo|nuudeli|makaron
 migra|migra||||move (migrate, relocate)||migrar (emigrar, tralsadar)||||搬家||||||||||muuttaa (siirtää)|ruszać się (migrować, poruszać się, przenieść się, przesiedlać się, przesiedlić się)
 migre|migre|||fra:eng:migration, spa:migración, por:migração, rus:миграция (migratsiya)|migration (moving)|migration|migración|migração|миграция|||||||||||migrado|muutto (migraatio)|migracja
@@ -2251,8 +2249,8 @@ misalo|misalo||||for example|par exemple|por ejemplo|por exemplo|наприме�
 miser|miser||||sender (transmitter)||remitente||||||||||||||lähettäjä (lähetin)|nadawca
 misia|misia||||mission (transmission, emission)||emisión||||||||||||||lähetys|misja
 miskini|miskini||||poor (miserable)||pobre (miserable)|||||||||||||mizera|kurja (raukka)|biedny, mizerny
+Misr:e|Misre|desh|EG|ara:(miṣr), tur:Mısır, swa:Misri, hin:मिस्र (misra), ben:মিশর (miśôr)|Egypt|Égypte|Egipto|Egipto (Egito)|Египет||埃及|エジプト|이집트|Ai Cập|मिस्र|মিশর|Mesir|Misri|Mısır|Egipto|Egypti|Egipt
 misr:i|misri||||Egyptian||egipcio|||||||||||||egipta|egyptiläinen|egipski
-Misr:ia|Misria|desh|EG|ara:(miṣr), tur:Mısır, swa:Misri, hin:मिस्र (misra), ben:মিশর (miśôr)|Egypt|Égypte|Egipto|Egipto (Egito)|Египет||埃及|エジプト|이집트|Ai Cập|मिस्र|মিশর|Mesir|Misri|Mısır|Egipto|Egypti|Egipt
 mita|mita||||meet||encontrar|encontrar|||聚会|会う|||मिलना||||||tavata|spotkać
 mite|mite|||eng:meet, fra:meeting, spa:mitin, jpn:ミーティング (mītingu), hin:मीटिंग (mīṭiṅg)|meeting (gathering)||reunión (junta, mitin)||||会议|会合 (会議, ミーティング)|회합 (회의)||बैठक (सभा, मीटिंग)||||||tapaaminen (kokous)|spotkanie, zebranie
 mitr:e|mitre|||eng:tur:metre, deu:may:meter, fra:mètre, spa:por:metro, rus:метр (metr), ara: متر‎ (mitr), zho:米 (mǐ), jpn:メートル (mētoru), kor:미터 (miteo), vie:mét, hin:मीटर (mīṭar), ben:মিটার (miṭar), swa:mita|meter (100 cm)|mètre|metro|metro|метр|متر‎|米 (公尺)|メートル|미터|mét|मीटर|মিটার|meter|mita|metre|metro|metri|metr
@@ -2285,7 +2283,6 @@ Mongolia|Mongolia|desh|MN||Mongolia||Mongolia|||||||||||||Mongolio|Mongolia|Mong
 monost.er:|monoster|||eng:monster, spa:por:monstro, fra:monstre, rus:монстр (monstr), jpn:モンスター (monsutā)|monster||monstro|||||||||||||monstro|hirviö|potwór, monstrum
 morf:e|morfe|||eng:morph, spa:morfo, rus:морф (morf)|morph||morfo||||||||||||||morfi|morf
 morf.em:|morfem||||morpheme||morfema||||||||||||||morfeemi|morfem
-Morisia|Morisia|desh|MU||Mauritius||Mauricio||||||||||||||Mauritius|Mauritius
 mort:a|morta||||kill||matar (morir, asesinar)|||||||||||||mortigi|tappaa|zabić, zabijać
 mort:e|morte||||death||muerte (fallecimiento)|||||||||||||morto|kuolema (kuolo)|śmierć
 mort:i|morti|||por:morto, fra:mort, spa:muerto, fas:(morde), urd:(murda), hin:मृत (mrta), rus:мёртвый (myortvïy), + may:mati, + ara:(mawt), amh:ሞት (mot)|dead (deceased)||muerto|||||||||||||morta|kuollut (vainaa)|martwy, nieżywy, zabity
@@ -2333,6 +2330,7 @@ muskul|muskul|||eng:fra:muscle, spa:por:músculo, deu:Muskel, rus:му́скул
 muskulbin|muskulbin||||bodybuilding|culturisme (musculation)|fisicoculturismo (culturismo, musculación)|fisiculturismo|культуризм||健美运动|||||||||korpokulturado|kehonrakennus (bodaus)|kulturystyka
 muta|muta|||spa:mudar, eng:mutate, fra:muter|change (alter, convert)||cambiar|||||||||||||aliigi|muuttaa (muuntaa)|zmienić, zmieniać
 mux|mux|||pol:mysz, rus:мышь (myś), fas:(muš)|mouse||ratón|||||||||||||muso|hiiri|mysz
+Myanma|Myanma|desh|MM||Myanmar (Burma)||Myanmar (Birmania)|||||||||||||Birmo|Myanmar (Burma)|Mjanma, Birma
 N|N||||N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N|N
 n:a|na||||without||sin|sem||||||||||||sen|ilman|bez
 n:a liny:e|na linye||||offline|||||||||||||||||offline (nie na linii, poza siecią)
@@ -2343,7 +2341,6 @@ nafas|nafas|||ara:fas:(nafas), may:napas, tur:nefes, hau:numfashi|breath||respir
 nagre|nagre|||hin:नगर (nagar), ben:নগর (nôgôr), tel:నగరము (nagaramu), kan:ನಗರ (nagara), tam:நகரம் (nakaram), khm:អង្គរ (ʾɑngkɔɔ), tha:นคร (na-khon)|town||pueblo|||||||||||||urbo|kaupunki|miasto
 nagri|nagri||||urban||urbano|||||||||||||urba|urbaani (kaupunkilais-)|miejski
 nahun|nahun|||fas:ناخن‎ (nâxon), hin:नाख़ुन m (nāxun), ben:নখ (nôkh), pan:नख (nakh), rus:нога́ (nogá)|nail (fingernail)||uña||||||||||||||kynsi|paznokieć
-Naijiria|Naijiria|desh|NG||Nigeria||Nigeria|||||||||||||Niĝerio|Nigeria|Nigeria
 najis|najis|||ara:نجس (najis), fas:نجس (najes), may:najis + eng:najis, rus:наджа́са (nadžása), tur:necis|corruption (filth, pollution, contamination, najis)|pollution|contaminación (corrupción, porquería, suciedad)|poluição|грязь (скверна)||污染物|汚れ (汚染)|||गंदगी (संदूषक, विकृति, दोष)||najis (pencemaran, polusi)|uchafu||||
 najisa|najisa||||corrupt (pollute, soil, defile, stain, taint)||corromper (contaminar)||||污染|汚す||||||-chafua||||
 najisbinde|najisbinde||||stain (spot)||mancha|||||染み (汚点)||||||||||
@@ -2375,8 +2372,8 @@ navmes|navmes|mese|||September||septiembre|||||９月|||||||||syyskuu|grudzień
 nawati|nawati||||Nahuatl (Nahua)||náhuatl (nahua)|||||||||||||naūatla|nahuatli|nahuatl
 naz.ist:e|nasiste|||rus:нацист (natsist), jpn:ナチ (nachi), kor:나치 (nachi), por:ita:nazista|Nazi||Nazi||||||||||||||natsi|nazista
 naz.ist:ia|nasistia||||Nazism||nazismo||||||||||||||natsismi|nazizm
-Nederlandi Antile|Nederlandi Antile|desh|AN||Netherlands Antilles||Antillas Neerlandesas||||||||||||||Alankomaiden Antillit|Antyle Holenderskie
-Nederlandia|Nederlandia|desh|NL||Netherlands||Países Bajos||||||||||||||Alankomaat (Hollanti)|Holandia (Królestwo Niderlandów)
+Nederland:e|Nederlande|desh|NL||Netherlands||Países Bajos||||||||||||||Alankomaat (Hollanti)|Holandia (Królestwo Niderlandów)
+Nederland:i Antil:|Nederlandi Antil|desh|AN||Netherlands Antilles||Antillas Neerlandesas||||||||||||||Alankomaiden Antillit|Antyle Holenderskie
 nefre|nefre|||eng:fra:nephro-, spa:por:nefro-, deu:Niere|kidney|rein|riñon|rim|почка||肾脏|腎臓|콩팥 (신장)|thận|गुर्दा|বৃক্ক|ginjal||böbrek|reno|munuainen|nerka
 nefritis|nefritis||||nephritis||nefritis||||||||||||||munuaistulehdus (nefriitti)|zapalenie nerek
 nefte|nefte|||ara:نفط (nifṭ), heb:נֵּפְטְ‎ (neft), tur:aze:neft, rus:нефть (neft’), kar:ნავთი (navti) + fas:نفت (naft), eng:naphtha, spa:por:nafta, jpn:ナフサ (nafusa), kor:나프타 (napeuta), may:nafta|oil|huile (pétrole)|aceite (óleo)|aeite (óleo)|масло||油|油 (オイル)||||||||||olej
@@ -2406,7 +2403,8 @@ nic:a|nica||||go under||||||||||||||||alittaa|iść w dół (iść pod spód, i�
 nic:e|nice|||ben:নিচে (nice), hin:नीचे (nīce), urd:(nīce), rus:ниже (niže)|underside (underneath)|dessous|parte inferior|||||下|||||||||alapuoli|spód
 nic:i|nici||||lower (inferior)||inferior||||||||||||||ala-|poniższy
 nic:o|nico||||under||debajo||||||||||||||alla|pod (poniżej)
-Nijer|Nijer|desh|NE||Niger||Níger|||||||||||||Niĝero|Niger|Niger
+Niger:ia|Nigeria|desh|NG||Nigeria||Nigeria|||||||||||||Niĝerio|Nigeria|Nigeria
+Niger:|Niger:|desh|NE||Niger||Níger|||||||||||||Niĝero|Niger|Niger
 Nikaragua|Nikaragua|desh|NI||Nicaragua||Nicaragua|||||||||||||Nikaragvo|Nikaragua|Nikaragua
 nikel|nikel|mate|Ni||nickel||níquel|||||||||||||nikelo|nikkeli|nikiel
 nilcentaur|nilcentaur|biw|Centaurea cyanus||cornflower|Centaurée bleuet|aciano (azulejo)|escovinha (centáurea)|василёк синий||矢車菊|ヤグルマギク||||||||||bławatek
@@ -2419,7 +2417,7 @@ niobem|niobem|mate|Nb||niobium||niobio|||||||||||||niobo|niobium|niob
 Nipon|Nipon|desh|JP||Japan|Japon|Japón|Japão|Япония||日本|日本|일본|Nhật Bản|जापान|জাপান|Jepang|Japani|Japonya|Japanio|Japani|Japonia
 niponem|niponem|mate|Nh||nihonium||nihonio|||||||||||||nihonio|nihonium|nihonium
 niponi|niponi||||Japanese||japonés|||||日本の (日本語, 日本人)||||||||japana|japanilainen|japoński
-Nistria|Nistria|desh|||Transnistria||Transnistria (Cisdniéster)||||||||||||||Transdnistria|Naddniestrze
+Nistrov:ia|Nistrovia|desh|||Transnistria||Transnistria (Cisdniéster)||||||||||||||Transdnistria|Naddniestrze
 nitre|nitre|mate|N||nitrogen||nitrógeno|||||||||||||nitrogeno|typpi|azot
 Niue|Niue|desh|NU||Niue||Niue||||||||||||||Niue|Niue
 nix|nix|||fra:eng:niche, por:nicho, rus:ниша (niša)|niche (recess, alcove)|niche|hornacina|nicho|ниша||壁龛|壁龕|반침||||||||alkovi|nisza, alkowa
@@ -2430,7 +2428,7 @@ noce|noce|||spa:noche, por:noite, rus:ночь (nočʹ), pol:noc|night|noit|noc
 nocomode|nocomode||||night mode||modo nocturno||||||||||||||yömoodi|tryb nocny
 noda|noda||||tie a knot||hacer un nudo||||||||||||||solmia (tehdä solmu)|zawiązywać (zawiązać węzeł)
 node|node|||eng:node, spa:nudo, por:nó, fra:nœud|knot (node)||nudo|||||||||||||nodo|solmu|węzeł, zupeł
-Nofrolke|Nofrolke|desh|NF||Norfolk Island||Isla Norfolk||||||||||||||Norfolkin saaret|Norfolk
+Norfolke nes|Nofrolke|desh|NF||Norfolk Island||Isla Norfolk||||||||||||||Norfolkin saaret|Norfolk
 nol (noli)|nol (noli)|||rus:ноль (nol'), may:nol, deu:null, eng:null|zero (none)||cero (ninguno)|||||零 (０)|||||||||nolla (ei yhtään)|zero, nic, żaden
 nol jan|nol jan||||nobody (no-one)||ningunos||||||||||||||ei kukaan|nikt, żadna osoba
 nol sate|nol sate||||never||nunca||||||||||||||ei koskaan (ei kertaakaan)|nigdy
@@ -2446,7 +2444,7 @@ nonger|nonger||||farmer||granjero (agricultor)||||||||||||||maanviljelijä|rolni
 norde|norde|||eng:north, spa:por:norte, deu:Nord, fra:nord, rus:норд (nord)|north|nord|norte|norte|север (норд)||北|北|북|||||||nordo|pohjoinen|północ
 nordi|nordi||||northern||norteño||||||||||||||pohjoinen|północny
 Nordi Aire|Nordi Aire|desh|||Northern Ireland||Irlanda del Norte||||||||||||||Pohjois-Irlanti|Irlandia Północna
-nordi amerike|nordi amerike||||North America||Norteamérica||||||||||||||Pohjois-Amerikka|Ameryka Północna
+Nordi Amerike|Nordi Amerike||||North America||Norteamérica||||||||||||||Pohjois-Amerikka|Ameryka Północna
 Nordi Cosen|Nordi Cosen|desh|KP||North Korea (Democratic People’s Republic of Korea)||Corea del Norte||||||||||||||Pohjois-Korea|Korea Północna (Koreańska Republika Ludowo-Demokratyczna)
 Nordi Kipris|Nordi Kipris|desh|||Northen Cyprus||Chipre del Norte||||||||||||||Pohjois-Kypros|Cypr Północny
 Nordi Makedonia|Nordi Makedonia|desh|MK||Republic of North Macedonia||Macedonia del Norte||||||||||||||Makedonia|Republika Macedonii, Macedonia
@@ -2467,8 +2465,9 @@ nova|nova||||renew (make new, renovate)||renovar||||||||||||||uudistaa|odnowić,
 nove|nove||||novelty||novedad|||||||||||||||nowość
 novi|novi|||rus:новый (novyy), por:novo, spa:nuevo, hin:नव (nav), eng:novel, fra:nouveau|new (recent)|nouveau|nuevo|novo|новый|جَدِيد|新|新しい|||नया||baru|-pya||nova|uusi|nowy
 Novi Kaledonia|Novi Kaledonia|desh|NC||New Caledonia||Nueva Caledonia||||||||||||||Uusi-Kaledonia|Nowa Kaledonia
-Novi Yorke|Novi Yorke|cite|US||New York City|||||||||||||||||Nowy Jork
-Novi Zilande|Novi Zilande|desh|NZ||New Zealand||Nueva Zelanda||||||||||||||Uusi-Seelanti|Nowa Zelandia
+Novi Yorke|Novi Yorke||||New York|||||||||||||||||Nowy Jork
+Novi Yorke site|Novi Yorke site|cite|US||New York City|||||||||||||||||Stan Nowy Jork
+Novi Zelande|Novi Zelande|desh|NZ||New Zealand||Nueva Zelanda||||||||||||||Uusi-Seelanti|Nowa Zelandia
 novike|novike||||novice (newbie)|néophyte|novato|novato (neófito)|новичок||新手|初心者|승진자|||||||novulo|noviisi (uusikko, vasta-alkaja)|nowicjusz (nowa osoba)
 novo|novo||||just (recently)||ahora mismo (justo)|||||||||||||ĵus|äsken (vasta, juuri)|właśnie, dopiero co, ostatnio, niedawno
 novyangi|novyangi||||modern||moderno|||||近代的||||||||||nowoczesne
@@ -2498,7 +2497,7 @@ okey:a|okeya||||accept (say okay)||aceptar||||||||||||||hyväksyä|zaakceptować
 okey:i|okeyi|||eng:okay, spa:tur:may:okey, por:OK, rus:окей (okej), ara:أُوكِي‎‎‎ (ʾokey), hin:ओके (oke), zho:OK (ōukèi), jpn:オーケー (ōkē)|okay (acceptable)||bien|||||大丈夫 (ＯＫ)||||||||akceptebla (okej)|kelpo (okei)|okej, spoko, akceptowalny
 okse|okse|mate|O||oxygen||oxígeno|||||||||||||oksigeno|happi|tlen
 okside|okside||||oxide|oxyde|óxide|óxide|окись (оксид)||氧化物|||||||||oksido|oksidi|tlenek
-Olande|Olande|desh|AX||Aland Islands||islas Aland||||||||||||||Ahvenanmaa (Oolanti)|Wyspy Alandzkie
+Olande nesia|Olande nesia|desh|AX||Aland Islands||islas Aland||||||||||||||Ahvenanmaa (Oolanti)|Wyspy Alandzkie
 Oman|Oman|desh|OM||Oman||Omán||||||||||||||Oman|Oman
 onde|onde|||spa:por:ita:onda, fra:onde, may:ombak|wave|onde|onda|onda|||波浪|波||||||||ondo|aalto (laine)|fala
 onor:|onor|||eng:pol:spa:honor, fra:honneur, por:honra, tur:onur|respect (honor, esteem)|honneur|respeto (honor)|honra|честь|شَرَف‎|||||सम्मान|সম্মান|hormat|heshima|saygı (hürmet, şeref, onur)|honoro (respekto)|kunnioitus (arvostus)|respekt, honor, szacunek, poważanie
@@ -2542,7 +2541,7 @@ pad.o.mun:|padomun||||trapdoor||trampilla||лаз|||落とし戸||||||||||klapa
 pagre|pagre|||hin:mar:पगड़ी (pagṛī), urd:(pagṛī), ben:পাগড়ি (pagri)|turban|turban|turbante|turbante|чалма||包头||||पगड़ी|পাগড়ি|||||turbaani|turban
 paka|paka||||pack||embalar (llevar)||||||||||||||pakata|zapakować, pakować
 pake|pake|||eng:pack, rus:пакет (paket), hin:पैकेट (pækeṭ), deu:tur:paket, fra:paquet, spa:paquete, por:pacote|pack (package)|paquet|paquete|pacote|пакет||||||पैकेट||||paket|pako|pakkaus (paketti)|paczka, paka
-pakistan|pakistan||||Pakistan||Pakistán||||||||||||||Pakistan|Pakistan
+Pakistan|Pakistan|desh|||Pakistan||Pakistán||||||||||||||Pakistan|Pakistan
 pakse|pakse|biw|Aves|hin:mar:पक्षी (pakṣī), mal:പക്ഷി (pakṣi), tel:(pakṣi), kh:បក្សី (baksəy), tha:ปักษา (pak-sa), ben:পাখী (pakhī), pnb:ਪੰਖੀ (paṅkhī)|bird|oiseau|pájaro (ave)||||||||पक्षी|পাখী||||birdo|lintu|ptak
 pal|pal|||hin:फल (phal), pnb:ਫਲ (phal), ben:ফল (phal), tam: பழம் (palam), tel:(phalamu), tha:ผน-ละ- (phon-la)|fruit||fruta||||||||फल|ফল||||frukto|hedelmä|owoc
 paladem|paladem|mate|Pd||palladium||paladio|||||||||||||paladio|palladium|pallad
@@ -2688,7 +2687,7 @@ piratiste|piratiste||||pirate (one who disobeys intellectual property laws)||par
 piratisti partia|piratisti partia||||Pirate Party||Partido Pirata||||||||||||||piraattipuolue|Partia Piratów
 pis|pis|biw|Picea|spa:por:pícea, fra:Épicéa|spruce tree|Épicéa|pícea|pícea (espruce)|ель||云杉|トウヒ||||||||||świerk
 pistol|pistol|||eng:pistol, spa:por:pistola, fra:pistolet, rus:пистолет (pitolet), hin:पिस्तौल (pistaul), ben:পিস্তল (piśtôl)|pistol||pistola||||||||||||||pistooli|pistolet
-Pitkerne|Pitkerne|desh|PN||Pitcairn||Islas Pitcairn||||||||||||||Pitcairn|Pitcairn
+Pitkerne nesia|Pitkerne nesia|desh|PN||Pitcairn Islands||Islas Pitcairn||||||||||||||Pitcairn|Pitcairn
 pix|pix|||eng:piss, fra:pisse, ita:piscia, hin:पेशाब (pešāb), may:pipis|piss (urine)||pis (meados)|||||||||||||piso (urino)|virtsa (pissa, kusi)|siki
 pixa|pixa||||piss (urinate)||mear|||||||||||||pisi (urini)|virtsata (kusta)|sikać, szczać, oddawać mocz
 pize|pize|||ita:eng:fra:pizza, zho:比萨 (bǐsà), rus:пицца (pitsa), jpn:ピザ (piza), kor:피자 (pija)|pizza|pizza|pizza||пицца|||||||||||pico|pitsa (pizza)|pizza
@@ -2749,7 +2748,6 @@ porey|porey|biw|Allium ampeloprasum, Porrum|spa:puerro, por:porro, fra:poireau, 
 porne|porne|||eng:porn, spa:tur:may:porno, por:pornô, deu:Pornografie, rus:порно (porno), jpn:ポルノ (poruno)|porn||porno||||||||||||||porno|porno, film erotyczny
 pornografia|pornografia||||pornography||pornografía||||||||||||||pornografia|pornografia
 porte|porte|||eng:port, fra:porte, spa:por:porto, rus:порт (port), hin:पोर्ट (porṭ), urd:(porṭ), ben:পোর্ট (porṭ), tha:พอร์ต (phot)|port (station)|porte|porto|porto|порт||港||||||bandar||liman|haveno|asema (satama, lentokenttä)|port
-Porto Riko|Porto Riko|desh|PR||Puerto Rico||Puerto Rico||||||||||||||Puerto Rico|Puerto Rico
 Portugal|Portugal|desh|PT||Portugal||Portugal||||||||||||||Portugali|Portugalia
 portugalofoni|portugalofoni||||lusophone (Portuguese speaking)||||||||||||||||portugalia puhuva|
 pospor|pospor|mate|P||phosphorus||fósforo|||||||||||||fosforo|fosfor|fosfor
@@ -2782,6 +2780,7 @@ protacinem|protacinem|mate|Pa||protactinium||proactinio|||||||||||||protaktinio|
 pud:i|pudi|||eng:putrid, spa:por:podre, fra:putride + zho:腐 (fǔ), jpn:腐 (fu) + tha:ผุ (phu)|rotten|pourri|podrido (cariado)||||||||||||||mätä|zgniły
 pud:u|pudu||||decay (rot, deteriorate)|pourrir (se décomposer)|pudrirse (cariarse, descomponerse)|apodrecer-se|гнить (портиться)||腐烂|腐敗|||सड़ना||||||mädäntyä (mädätä)|rozłożyć się (rozkładać się, gnić, psuć się)
 puding:|puding|||eng:pudding, spa:pudín, rus:пудинг (puding), tur:may:puding, ara:بودنغ (budingh), zho:布丁 (bùdīng), jpn:プディング (pudingu)|pudding||pudín||||布丁||||||||||vanukas|puding
+Puerto Riko|Puerto Riko|desh|PR||Puerto Rico||Puerto Rico||||||||||||||Puerto Rico|Puerto Rico
 puj:a|puja||||worship (revere)||adorar (venerar)||||||||||||||palvoa|czcić, szanować
 puj:e|puje|||hin:पूजा (pūjā), urd:(pūjā), tha:บูชา (bucha), may:puja|worship (reveration)||adoración (veneración, culto)||||||||पूजा||||||palvonta|cześć, szacunek
 puj.o.kan:|pujokan||||temple (place of worship)|temple|templo|templo|храм (место богослужения)|مَعْبَد‎|寺庙|神殿|절 (사원)|đền|मन्दिर|মন্দির|kuil|hekalu|tapınak (ibadethane)|templo|temppeli|świątynia
@@ -2841,7 +2840,7 @@ rangomate|rangomate||||dye|colorant|tinte||||染料|染め粉||||||||||barwnik
 rapidi|rapidi|||spa:por:rápido, eng:rapid, fra:rapide|fast (quick, rapid, speedy)|vite (rapide)|rápido|rápido|быстрый||快|速い|빠르다|Mau (nhanh)|तेज़ (तीव्र)||cepat|haraka|hızlı|rapida|nopea (pikainen, vauhdikas)|szybki, prędki
 rapidia|rapidia||||speed (velocity)||rapidez (velocidad)|||||||||||||rapideco|nopeus (vauhti)|prędkość (szybkość)
 rapidometer|rapidometer||||speedometer||velocímetro||||||||||||||nopeusmittari|prędkościomierz
-rari|rari|||eng:fra:rare, spa:por:raro, jpn:レア (rea)|rare (uncommon, sparse)|rare|raro|raro|редкий (разбро́санный)|nadir, mutanathir|稀有 (稀少的)|稀 (疎ら)|||durlabha|birala (durlabha)||nadra|nadir|||rzadki (nieczęsty)
+rari|rari|||eng:fra:rare, spa:por:raro, jpn:レア (rea)|rare (uncommon, sparse)|rare|raro|raro|редкий (разбро́санный)||稀有 (稀少的)|稀 (疎ら)||||||nadra|nadir|||rzadki (nieczęsty)
 raria|raria||||rarity|||||||||||||||||rzadkość
 ras|ras|||eng:fra:race, spa:raza, por:raça, rus:раса (rasa), may:ras|race (breed)|race|raza|raça|раса||种族|人種|인종|chủng tộc|वंश (जाति)||bangsa (ras)||ırk|raco|rotu|rasa
 rasiste|rasiste||||racist||racista|||||||||||||racisto|rasisti|rasista
@@ -2927,7 +2926,6 @@ rot.o.top:e|rototope|||eng:top, fra:toupie|top (spinning top)|toupie|trompo||в�
 roze|roze|biw|Rosa|fra:eng:rose, spa:por:rosa, rus:роза (roza), fas:(roz, gol-e sorx), tgl:rosas|rose|rose|rosa|rosa|роза||玫瑰|バラ|장미|hoa hồng|गुलाब|গোলাপ|mawar (ros)|waridi|gül|rozo|ruusu|róża
 rozorangi|rozorangi|rang|||pink (rosy)||rosa||||||||||||||vaaleanpunainen|różowy, różany
 rozosalmon|rozosalmon|biw|Oncorhynchus gorbuscha||pink salmon|saumon rose|salmón rosado|salmão-rosa|горбуша||粉紅鮭|カラフトマス||||||||||gorbusza
-Ruanda|Ruanda|desh|RW||Rwanda||Ruanda||||||||||||||Ruanda|Rwanda
 rubidem|rubidem|mate|Rb||rubidium||rubidio|||||||||||||rubidio||rubid
 ruh.mix:a|ruhmixa||||confuse (perplex, bewilder, baffle)||confundir (desconcertar, perplejo)||озадачить|||惑わす||||||||||mylić (gmatwać, zmieszać, konsternować)
 ruh.mix:i|ruhmixi||||confused (perplexed, disoriented, bewildered)|perplexe (désorienté)|confundido|perplexo (confuso)|растерянный (озадаченный)|حَيْران‎|困惑 (混乱)|まごまご|||भ्रमित (हैरान, संभ्रांत)||bingung (hilang akal, keliru)|kuzubaa (vuruguvurugu)|şaşkın|||smieszany (skonfudowany)
@@ -2955,6 +2953,7 @@ ruterfordem|ruterfordem|mate|Rf||rutherfordium||rutherfordio|||||||||||||ruterfo
 rutin|rutin|||eng:fra:routine, spa:rutina, por:rotina, deu:Routine, fas:روتین‎ (rutin), rus:рутина (rutina)|routine (habit)||rutina (hábito)|||||||||||||rutino (kutimo)|tapa (rutiini)|rutyna, nawyk, zwyczaj
 rutogalta|rutogalta||||stray (deviate)||apartarse (desviarse)||отходить (скитаться)|||逸れる||||||||||zbłąkać się (wykoleić się)
 rutogalti|rutogalti||||stray (deviant)|||||||||||||||||zbłąkany (dewiacyjny, wykolejony)
+Rwanda|Rwanda|desh|RW||Rwanda||Ruanda||||||||||||||Ruanda|Rwanda
 S|S||||S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S
 s:a|sa||||be|être|ser (estar)|ser (estar)|быть||对||||होना||ialah||olmak|esti|olla|być
 s:e|se||||self (reflexive pronoun)|se|se|se|себя (-ся)|||||||||||si|itse|sam, siebie
@@ -2999,7 +2998,6 @@ salam yam|salam yam||||bon appetit!||buen provecho|||||||||||||bonan apetiton!|h
 salama|salama||||greet||saludar|||||||||||||saluti|tervehtiä|pozdrowić, pozdrawiać
 salame|salame|||ara:(salām), swa:salamu, may:selamat, hin:सलाम (salām), ben: সালাম (salam), zho:萨拉姆 (sàlāmǔ), jpn:サラーム (sarāmu), kor:살람 (sallam), vie:xa lam, rus:салям (salyam)|greeting (hello)|salut (salam)|saludo|saudação|приветствие|سَلَام|迎接|挨拶|인사|lời chào|सलाम|সালাম|selamat|salaam (salamu)|selam|saluto|tervehdys (terve!)|pozdrowienie
 salmon|salmon|biw||eng:may:salmon, spa:salmón, por:salmão, fra:saumon, swa:samoni, jpn:サーモン (sāmon)|salmon (trout)|truite|salmón (trucha)|||||鮭鱒|||||ikan salmon (ikan trout)|samoni||||łosoś (pstrąg)
-Salone|Salone|desh|SL||Sierra Leone||Sierra Leona||||||||||||||Sierra Leone|Sierra Leone
 Salvador|Salvador|desh|SV||El Salvador||El Salvador||||||||||||||El Salvador|Salwador
 saman:|saman|||ara:(samāʾ), amh:ሰማይ (sämay), orm:samii, hau:sama, yor:sánmà, hin:आसमान (āsmān), fas:pnb:urd:(āsmān)|sky (heaven)|ciel|cielo|céu|небо|سَمَاء|天空|空|하늘|trời|आसमान (आकाश)|আকাশ|langit|mbingu|gök|ĉielo|taivas|niebo
 saman:i|samani||||celestial (heavenly)||celeste (celestial)|||||||||||||||niebieski, niebiański, podniebny
@@ -3064,7 +3062,7 @@ seksi|seksi||||sexy (sexually arousing)||sexy (sexual)||||||||||||||seksikäs|se
 sekunde|sekunde|||eng:second, spa:por:segundo, rus:секунда (sekunda), swa:sekunde, hin:सैकण्ड (saikaṇḍ), ben:সেকেন্ড (śekenḍ)|second(s)||segundo||||||||||||||sekunti|sekunda
 sekura|sekura||||protect (secure, save)||proteger (asegurar, guardar)||||||||||||||suojella (suojata, turvata)|chronić (ratować)
 sekuri|sekuri|||eng:secure, deu:sicher, spa:por:seguro|safe (secure, protected)|sûr|seguro|seguro|||||||||||||turvallinen (varma)|bezpieczny
-sekuri kopiye|sekuri kopiye||||backup||copia de seguridad|||||バックアップ (控え)||||||||||
+sekuri kope|sekuri kope||||backup||copia de seguridad|||||バックアップ (控え)||||||||||
 sekurkode|sekurkode||||password (security code)||contraseña|||||||||||||||hasło
 sekurnombre|sekurnombre||||personal identification number (PIN)||número de identificación personal|||||暗証番号||||||||||osobisty numer identyfikacyjny (pin)
 sel:|sel|||ara: صَلَاح‎ (ṣalāḥ), hin:सलाह (salāh), tel:సలహా (salahā), tur:salık + eng:counsel, fra:conseil, spa:consejo, por:conselho + rus:консультант (konsultant)|advice (counsel)|conseil|consejo|conselho|совет||||||||||||neuvo|rada, porada
@@ -3095,7 +3093,7 @@ sesam|sesam|biw|Sesamum indicum|tur:susam, eng:sesame, rus:сезам (sezam), s
 set.yom:|setyom||||Sunday|dimanche|domingo|domingo|воскресенье|يوم الأحد|星期日 (禮拜日)|日曜日|일요일|chủ nhật|रविवार|রবিবার|minggu|jumapili|pazar|dimanĉosunnuntai|niedziela|niedziela
 seti|seti|||spa:siete, por:sete, fra:sept, hin:सात (sāt), ben:সাত (sat), tha:เจ็ด (chet), yue:七 (chat1), jpn:七 (shichi), tur:yedi|seven (7)|sept (7)|siete (7)|sete (7)|семь (7)|七 (7)|七 (7)|||||||||sep (7)|seitsemän (7)|siedem (7)
 setomes|setomes|mese|||July||julio|||||７月|||||||||heinäkuu|październik
-Sexel nesia|Sexel nesia|desh|SC||Seychelles||Seychelles||||||||||||||Seychellit|Seszele
+Seyxel nesia|Seyxel nesia|desh|SC||Seychelles||Seychelles||||||||||||||Seychellit|Seszele
 siah:i|siahi|rang||fas:سیاه‎ (siyâh), hin:सियाह (siyāh), urd:سیاہ (siyāh), pan:ਸਿਆਹ (siāh), tur:siyah|black|noir|negro|preto|чёрный|أَسْوَد|黑色|黒い|검다|đen|काला|কালো|hitam|eusi|kara (siyah)|nigra|musta|czarny
 sian:i|siani|||eng:cyan, spa:cian, rus:циан (tsian), ara:سيان (sayan), hin:क्यान (kyāna), jpn:シアン (shian), may:sian|cyan||cian||циан|||シアン|||||||||syaani|niebieskozielony (cyjan)
 Sibir:ia|Sibiria||||Siberia||Siberia||||||||||||||Siperia|Syberia
@@ -3103,6 +3101,7 @@ siborg.em:|seaborgem|mate|Sg||seaborgium||seaborgio|seabórgio|сиборгий|
 sida|sida|||rus:сидеть (sidet'), eng:sit, deu:sitzen, ita:sedere|sit (put down)||sentar||сидеть|||||||||||sidi|istua|siedzieć
 side|side||||seat (saddle)||silla (montura)||сиденье (седло)||座部 (马鞍)|座席 (鞍)||||||||||siedzenie (siodło)
 sidu|sidu||||sit down||sentarse|||||座る||||||||||usiąść
+Siera: Leon:|Siera Leon|desh|SL||Sierra Leone||Sierra Leona||||||||||||||Sierra Leone|Sierra Leone
 sif|sif|||hin:गुण (guṇ), ben:গুণ (guṇ), tel:గుణము (guṇamu), mya:ဂုဏ် (gun), may:guna, tha:คุณ (kun), khm:គុណ (kun)|attribute (charasteristic, quality, feature, description, property)||cualidad (atributo, descripción)||||||||||||||laatu (ominaisuus, ominaispiirre, määrite)|cecha, właściwość, parametr
 sifa|sifa||||qualify (describe)||definir||||||||||||||määritellä (luonnehtia)|opisać (zakwalifikować)
 sifi|sifi||||descriptive||descriptivo||||||||||||||kuvaileva (määrittelevä)|opisowy
@@ -3151,6 +3150,7 @@ sistemi|sistemi||||systemic||sistémico|||||||||||||||systemowy
 sit:e|site|||eng:city, fra:cité, por:cidade, spa:ciudad, ita:città + zho:市 (shì), kor:시 (si), jpn:都市 (toshi)|city (town)|ville|ciudad|cidade||||||||||||urbo|kaupunki|miast, miasteczko
 sivil:i|sivili|||eng:civil, por:civil, hin:सिविल (sivil), may:sipil|civilized (civil)||civilizado||||||||||||||sivistynyt|cywilizowany (ucywilizowany)
 sivil:ia|sivilia||||civilization||civilización||||||||||||||sivilisaatio|cywilizacja
+Skot:ia|Skotia|desh|||Scotland||Escocia||||||||||||||Skotlanti|Szkocja
 slavi|slavi||||Slavic||eslavo|eslavo|славянский||||||||||||slaavilainen|słowiański
 Slovakia|Slovakia|desh|SK||Slovakia||Eslovaquia||||||||||||||Slovakia|Słowacja
 Slovenia|Slovenia|desh|SI||Slovenia||Eslovenia||||||||||||||Slovenia|Słowenia
@@ -3174,7 +3174,7 @@ Solomon nesia|Solomon nesia|desh|SB||Solomon Islands||Islas Salomón||||||||||||
 solsentaur|solsentaur|biw|Centaurea solstitialis||yellow starthistle|Centaurée du solstice|abrepuño|||||||||||||||chaber wełnisty
 solsistem|solsistem||||solar system||sistema solar||||太阳系|||||||||sunsistemo|aurinkokunta|układ słoneczny
 Somalia|Somalia|desh|SO||Somalia||Somalia||||||||||||||Somalia|Somalia
-Somalilandia|Somalilandia|desh|||Somaliland||Solamilandia||||||||||||||Somalimaa|Somaliland
+Somalilande|Somalilande|desh|||Somaliland||Solamilandia||||||||||||||Somalimaa|Somaliland
 son|son|||rus:сон (son), por:sono, hin:सोना (sonā), ben:শোয়া (śoya)|sleep||sueño|||||||||||||dormo|nukkuminen (uni)|sen
 sonda|sonda||||sound (make a sound)||sonar||||||||||||||ääntää|brzmieć, wydać dźwięk, wydawać dźwięk
 sonde|sonde|||eng:sound,sonic, fra:son, spa:son,sonido, ita:suono, + kor:소리 (sori)|sound (audio)||sonido (audio)|||||||||||||sono|ääni|dźwięk, brzmienie
@@ -3185,23 +3185,22 @@ sonu|sonu||||sleep (be asleep)|dormir|dormir|dormir|спать||睡觉 (困觉)|
 sor|sor|||zho:锁 (suǒ), yue:鎖 (so2), wuu:鎖 (su2), jpn:錠 (jō), khm:សោ (sao), spa:cierre, fra:serrure, hun:zár|lock (fastener)|serrure|cerradura (candado)|fechadura|замок||锁|錠||||||||||zamek (zapięcie)
 sora|sora||||lock (fasten)|||||||||||||||||zamknąć (zamykać, zakluczyć, zakluczać, zapinać, zapiąć)
 sori|sori||||locked (secure)||||запереть|||||||||||||zamknięty (zakluczony, zapięty, bezpieczny)
-sos|sos|||eng:fra:sauce, rus:соус (sous), hin:सॉस (sos), deu:Soße, vie:xốt, jpn:ソース (sōsu), that:ซอส (soot), kor:소스 (soseu), may:saus|sauce|sauce|salsa||соус||||||सॉस||saus|||saŭco|kastike (soosi)|sos
+sos|sos|||eng:fra:sauce, rus:соус (sous), hin:सॉस (sos), deu:Soße, vie:xốt, jpn:ソース (sōsu), tha:ซอส (soot), kor:소스 (soseu), may:saus|sauce|sauce|salsa||соус||||||सॉस||saus|||saŭco|kastike (soosi)|sos
 sosis|sosis|||fra:saucisse, tur:may:sosis, fas:(sosis), rus:сосиска  (sosiska), jpn:ソーセージ (sosēji), hin:सॉसेज (sosej), ben:সসেজ (sôsej), eng:sausage|sausage|saucisse|salchicha|salsicha|колбаса (сосиска)|سُجُق|香肠|ソーセージ|||सॉसेज||sosis (sosej)|soseji||kolbaso|makkara|kiełbasa
 Soto|Soto|desh|LS||Lesotho||Lesoto||||||||||||||Lesoto|Lesotho
 sow:a|sowa|||zho:搜 (sōu), yue:搜 (sau1), wuu:搜 (seu1), jpn:捜 (sō)|search (seek, look for)|chercher|buscar|buscar (procurar)|искать||寻找|探す (捜索する)|||कुछ खोजना||menggeledah|kutafuta|aramak|||szukać
-suahili|suahili||||Swahili||suajili|||||||||||||sŭahili|suahili|suahili
 suan:i|suani|||zho:酸 (suān), yue:酸 (syun1), wuu:酸 (soe1), jpn:酸 (san), kor:산 (san), vie:toan|sour||agrio (ácido)|||||||||||||acida|hapan (kirpeä)|kwaśny
 sub:e|sube|||ara:(ṣabāḥ), tur:sabah, fas:(sobh), urd:(subah), hin:सुबह (subah), swa:asubuhi, hau:asuba|morning (dawn)||mañana|||||朝||||||||mateno|aamu|ranek, rano, poranek
 sub.o.den:|suboden||||forenoon||mañana (antes mediodía)|||||||||||||||przedpołudnie
 sub.yam:|subyam||||breakfast||desayuno|||||朝食|||||||||aamiainen|śniadanie
 sud:e|sude|||spa:sur, por:sul, fra:sud|south||sur|||||||||||||sudo|etelä|południe
 sud:i|sudi||||southern||sureño|||||||||||||||południowy
+Sud:i Afrik:e|Sudi Afrike|desh|ZA||South Africa||Sudáfrica||||||||||||||Etelä-Afrikka|Południowa Afryka
 Sud:i Amerik:e|sudi amerike||||South America||Sudamérica||||||||||||||Etelä-Amerikka|Ameryka Południowa
 Sud:i Cosen:|Sudi Cosen|desh|KR||South Korea (Republic of Korea)||Corea del Sur|||||||||||||Sudkoreio|Etelä-Korea|Korea Południowa
 Sud:i Iria (Alonia)|Sudi Iria (Alonia)|desh|||South Ossetia (Alania)||Osetia del Sur||||||||||||||Etelä-Ossetia|Osetia Południowa
-Sud:i Jorj:ia e: Sud:i Sanduic:e nes:ia|Sudi Jorjia e Sudi Sanduice nesia|desh|GS||South Georgia and the South Sandwich Islands||Georgias del Sur y Sándwich del Sur|||||||||||||||Wyspy Georgia Południowa i Sandwich Południowy
+Sud:i Georg:ia w:a Sud:i Sandwic:e nes:ia|Sudi Georgia e Sudi Sandwice nesia|desh|GS||South Georgia and the South Sandwich Islands||Georgias del Sur y Sándwich del Sur|||||||||||||||Wyspy Georgia Południowa i Sandwich Południowy
 Sud:i Sudan:|Sudi Sudan|desh|SS||South Sudan||Sudán del Sur||||||||||||||Etelä-Sudan|Sudan Południowy
-Sud.afrik:e|Sudafrike|desh|ZA||South Africa||Sudáfrica||||||||||||||Etelä-Afrikka|Południowa Afryka
 sud.o.nord:ia|sudonordia||||latitude||latitud|||||||||||||||południk
 Sudan:|Sudan|desh|SD||Sudan||Sudán||||||||||||||Sudan|Sudan
 suede|suede|||eng:sweat, spa:sudor, por:suor, fra:sueur, san:स्वेद (sveda)|sweat (perspiration)|sueur|sudor|suor|||||||||||||hiki|pot
@@ -3222,8 +3221,8 @@ sundardake|sundardake||||decoration (ornament)||decoración (adorno)||украш
 sundari|sundari|||hin:सुन्दर (sundar), ben:সুন্দর (sundôr), guj:સુંદર (sundar),|beautiful (handsome, pretty)|beau|hermoso (bello, lindo)|belo (lindo)|красивый|جَمِيل|漂亮 (美)|美しい|아름답다|đẹp|सुन्दर (ख़ूबसूरत)|সুন্দর|indah (cantik)|zuri|güzel|bela|kaunis (komea, sievä)|piękny, przystojny
 sundaria|sundaria||||beauty|beauté|belleza (hermosura)|beleza|красота|جَمَال|美丽|美しさ|아름다움||सौन्दर्य|||uzuri (jamala, urembo)|güzellik|beleco|kauneus|piękno
 suno|suno|||eng:soon|soon||pronto||||||||||||||pian|wkrótce
-Suomi|Suomi|desh|FI||Finland||Finlandia|||||||||||||Finnlando|Suomi|Finlandia
-suomi|suomi||||Finnish||finés|||||||||||||finna|suomalainen|fiński
+Suomi:|Suomi|desh|FI||Finland||Finlandia|||||||||||||Finnlando|Suomi|Finlandia
+suomi:i|suomii||||Finnish||finés|||||||||||||finna|suomalainen|fiński
 supe|supe|||spa:sopa, eng: soup, fra: soupe, deu: Suppe, swa: supu, rus:суп (sup), may:sup, jpn:スープ (sūpu)|soup (stew)||sopa|||||||||||||supo|keitto (soppa)|zupa
 superi|superi||||superb (wonderful, super)||maravilloso (magnífico)|||||||||||||bonega|upea (mahtava)|wspaniały, znakomity, cudowny, zdumiewający, zadziwiający, super
 supr:a|supra|||eng:super, spa:por:sobre, ita:sopra|surpass (go over)||sobrepasar|||||||||||||superiri|ylittää|przekroczyć, przekraczać, przejść nad, iść nad
@@ -3232,7 +3231,7 @@ supr:i|supri||||upper||superior (más alto)||||||||||||||ylä- (yli-)|górny
 supr:o|supro||||above (over)||sobre|||||||||||||super|yllä (pääll)|nad
 suprize|suprize|||eng:surprise, tur:sürpriz, fas:(surpris), rus::сюрприз (siurpriz), por:surpresa, spa:sorpresa|surprise||sorpresa||||惊奇|||||||||surprizo|yllätys|zaskoczenie
 Suria|Suria|desh|SY||Syria||Siria||||||||||||||Syyria|Syria
-Suriname|Suriname|desh|SR||Suriname||Surinam||||||||||||||Surinam|Surinam
+Surinam|Surinam|desh|SR||Suriname||Surinam||||||||||||||Surinam|Surinam
 surinami bax|surinami bax||||Sranan Tongo||sranan tongo||||||||||||||sranan tongo|język surinamski
 susan|susan|biw|Lilium candidum|fas:sousan, ara:(sawsan), heb:(šōšān), + eng:Susan, por:spa:Susana, fra:Suzanne, pol:Zuzana, rus:Сусанна (Susanna)|lily|lys|lirio|lírio|лилия||百合花||||कुमुदिनी||lili||zambak||lilja|lilia
 suta|suta|||hin:सीना (sīnā), rus:шить (šit'), eng:sew|sew||coser||||||||||||||ommella|szyć
@@ -3248,6 +3247,7 @@ suyrang|suyrang||||watercolor||acuarela||||||||||||||vesiväri (akvarelliväri)|
 suysekuri|suysekuri||||waterproof||impermeable (sumergible)||||||||||||||vesitiivis|wodoodporny
 Svalbarde|Svalbarde|desh|||Svalbard||Svalbard||||||||||||||Svalbard|Swalbard
 Svenia|Svenia|desh|SE||Sweden||Suecia||||||||||||||Ruotsi|Szwecja
+swahili|swahili||||Swahili||suajili|||||||||||||sŭahili|suahili|suahili
 Swati|Swati|desh|SZ||Eswatini (Swaziland)||Esuatini (Suazilandia)||||||||||||||Swazimaa|Suazi
 Swisia|Swisia|desh|CH||Switzerland||Suiza||||||||||||||Sveitsi|Szwajcaria
 T|T||||T|T|T|T|T|T|T|T|T|T|T|T|T|T|T|T|T|T
@@ -3260,7 +3260,7 @@ tabl:a dat:e|tabla date||||tabulate||tabular||||||||||||||taulukoida|ułożyć w
 tabl:e|table|||eng:table, fra:tableau, spa:tabla, rus:табличка (tablichka), may:tabel, tur:tablo|slab (slate, tablet, board)||tabla (lámina, plancha)||плита||||||बोर्ड||||tahta||laatta (levy)|
 tabl.o.komput.er:|tablokomputer||||tablette computer|ordinateur tablette|tablet|tablet|планшетный компьютер||平板电脑|タブレットコンピュータ|태블릿 컴퓨터||||||elaltı bilgisayar||taulutietokone (tabletti)|
 tafun:|tafun|||zho:大风 (dàfēng), yue:大風 (daai6fung1), kor:태풍 (taepung), jpn:台風 (taifuu), tha:ไต้ฝุ่น (taifun), ara:(ṭūfān), fas:urd:(tufān), hin:तूफ़ान (tūfān), pnb:ਤੂਫ਼ਾਨ (tūfān), por:tufão, spa:tifón, fra:typhon, eng:typhoon, rus:тайфун (tayfun)|storm (tempest, typhoon, hurricane, cyclone)||tormenta (tempestad)|||||||||||||ŝtormo|myrsky|burza, sztorm, tajfun
-taibey|taibey||||Taipei||Taipei||||||||||||||Taipei|Tajpej
+Taibey|taibey||||Taipei||Taipei||||||||||||||Taipei|Tajpej
 taige|taige|||rus:тайга (tayga), eng:spa:por:may:taiga, tur:tayga, ara:تايغا‎ (tāyḡā), zho:泰加林 (tàijiālín), jpn:タイガ (taiga)|taiga||taiga|||||||||||||tajgo|taiga|tajga
 tail|tail|||eng:tile, por:telha, fra:tuile, nld:tegel, fin:tiili, hin:टाइल (ṭāila), ben:টালি (ṭali), jpn:タイル (tairu), kor:타일 (tail)|tile|carreau (tuile)|baldosa (teja, azulejo)|ladrilho (telha, azulejo)|черепи́ца||砖 (瓦)|タイル (瓦)||||||||||płyta
 Taiwan|Taiwan|desh|TW||Taiwan (Republic of China)||Taiwán||||||||||||||Taiwan|Tajwan, Republika Chińska
@@ -3413,10 +3413,11 @@ tunike|tunike|||spa:túnica, eng:tunic, rus:туника (tunika)|tunic (gown)||
 Tunisia|Tunisia|desh|TN||Tunisia|Tunisie|Túnez||||||||||||||Tunisia|Tunezja
 turki|turki||||Turkish||turco||||||||||||||turkkilainen|turecki
 Turkia|Turkia|desh|TR||Turkey||Turquía|||||||||||||Turkio|Turkki|Turcja
-Turkomenia|Turkomenia|desh|TM||Turkmenistan||Turkmenistán||||||||||||||Turkmenistan|Turkmenistan
+Turkmenia|Turkmenia|desh|TM||Turkmenistan||Turkmenistán||||||||||||||Turkmenistan|Turkmenistan
 Tuvalu|Tuvalu|desh|TV||Tuvalu||Tuvalu||||||||||||||Tuvalu|Tuwalu
 tuze|tuze|bio|Lagomorpha|zho:兔子 (tùzi), yue:兔仔 (tou3zai2), kor:토끼 (tokki), vie:thỏ, tha:เถาะ (tho)|rabbit (hare)|lapin (lièvre)|conejo (liebre)|coelho (lebre)|кролик (заяц)||兔子|うさぎ|||खरगोश (शशक, सुस्सा)||arnab (kelinci)|sungura|tavşan||jänis|królik, zając
 U|U||||U|U|U|U|U|U|U|U|U|U|U|U|U|U|U|U|U|U
+UDA: d:u|UDA du||||American (US)||estadounidense||||||||||||||yhdysvaltalainen (ns. Amerikkalainen)|amerkański (dotyczący USA, Stanów Zjednoczonych Ameryki)
 Ukraina|Ukraina|desh|UA||Ukraine||Ucrania||||||||||||||Ukraina|Ukraina
 ulul|ulul||||howling||aullido||||||||||||||ulvonta|wycie, skowyt
 ulula|ulula|||deu:Heulen, ita:ululato, tur:uluma, tgl:aulong,|howl||aullar||||||||||||||ulvoa|wyć
@@ -3433,7 +3434,8 @@ un.em.ist:ia|unistia||||monism||monismo|||||||||||||monismo|monismi|monizm
 un.ik:i|uniki||||only (single, sole, lone)|seul (unique)|único|único (só)|единственный (уникальный)||唯一 (独)|唯一の|유일한|duy nhất|एकमात्र||unik|||sola (ununura)|ainoa (ainut)|jedyny (wyłączny)
 un.ik:o|uniko||||only (solely, just)|uniquement|únicamente (solo)|unicamente|только (единственно)||只有 (惟独)|だけ|||सिर्फ़|||||sole (nur)|ainoastaan (vain)|jedynie (tylko)
 un.it:i|uniti||||united||unido||||||||||||||yhtenäinen|zjednoczony
-Un.it:i Arab:i Amir:ia|Uniti Arabi Amiria|desh|AE||United Arab Emirates||Emiratos Árabes Unidos||||||||||||||Yhdistyneet Arabiemiirikunnat|Zjednoczone Emiraty Arabskie
+Un.it:i Arab:i Amir:ia (UAA)|Uniti Arabi Amiria (UAA)|desh|AE||United Arab Emirates||Emiratos Árabes Unidos||||||||||||||Yhdistyneet Arabiemiirikunnat|Zjednoczone Emiraty Arabskie
+Un.it:i Desh: D:a Amerike (UDA)|Uniti Desh Da Amerike (UDA)|desh|US||United States of America (USA)||Estados Unidos de América||||||||||||||Yhdysvallat (ns. Amerikka)|Stany Zjednoczone Ameryki
 un.jan:i|unjani||||alone (lonely, isolated, solitary, single)||solo (aislado, solitary, soltero)|só (solitário)|одинокий (единичный)||独自的 (孤单)|一人の (寂しい, ポツリ)|||एकाकी||seorangan (sendiri)|||||
 un.mar:o|unmaro||||once|une fois|una vez|uma vez|один раз||一次 (一遍)||一度 (一回, 一遍)|한번|एक बार|||||unufoje|kerran|raz (jeden raz)
 un.men:i|unmeni||||unambiguous||inequívoco||||||||||||||yksimerkityksinen|jednoznaczny
@@ -3450,11 +3452,7 @@ urd:i|urdi|nas|||Urdu||urdu||||||||||||||urdu|urdu
 Urdun:|Urdun|desh|JO||Jordan||Jordania||||||||||||||Jordania|Jordan
 urs:e|urse|biw|Ursidae|fra:ours, por:urso, spa:oso, fas:(xers)|bear|ours|oso|urso||||||||||||urso|karhu|niedźwiedź
 Uruguay|Uruguay|desh|UY||Uruguay||Uruguay||||||||||||||Uruguai|Urugwaj
-Uruxalem|Uruxalem||||Jerusalem|||||القُدس‎||||||||||||Jerozolima
-Usameriki|Usameriki||||American (US)||estadounidense||||||||||||||yhdysvaltalainen (ns. Amerikkalainen)|amerkański (dotyczący USA, Stanów Zjednoczonych Ameryki)
-Usameriki Samoa|Usameriki Samoa|desh|AS||American Samoa||Samoa Americana|||||||||||||||Amerykańska Samoa
-Usameriki Virjin nesia|Usameriki Virjin nesia|desh|VI||Virgin Islands, US||Islas Vírgenes|||||||||||||||Wyspy Dziewicze USA
-Usamerikia|Usamerikia|desh|US||United States of America (USA)||Estados Unidos de América||||||||||||||Yhdysvallat (ns. Amerikka)|Stany Zjednoczone Ameryki
+Uruxalem|Uruxalem|shefsite|||Jerusalem|||||القُدس‎||||||||||||Jerozolima
 uza|uza|||eng:use, spa:usar, pol:używać|use (employ, apply)||usar (aplicar)|||||||||||||uzi|käyttää|użyć, używać, zatrudnić, stosować
 uzabli|uzabli||||usable (available)||utilizable (disponible)|||||使用可能||||||||||
 Uzbekia|Uzbekia|desh|UZ||Uzbekistan||Uzbekistán||||||||||||||Uzbekistan|Uzbekistan
@@ -3515,6 +3513,7 @@ vinil:|vinil|||eng:vinyl, spa:vinilo, por:vinil, fra:vinyle, rus:винил (vin
 violet:i|violeti|||eng:por:fra:violet, spa:violeta, deu:violett, rus:фиолетовый (fioletovyy), jpn:バイオレット (baioretto), kor:보라 (bola)|purple (violet)|violet (pourpre)|morado (púrpura)|purpúreo (roxo)|фиолетовый (пурпурный)|||紫色 (パープル)||||||||||fioletowy
 vir:|vir|||hin:वीर (vīr), urd:(vīr), ben:বীর (bīr), tam:வீரன் (vīraṉ), tel:వీరుడు (vīruḍu), may:wira, tha:วีร (wi-ra), + fra:por:spa:viril, eng:virile|hero||héroe|||||||||||||heroo|sankari (urho)|bohater, heros
 vir:i|viri||||heroic||valiente (heroico)|||||||||||||heroa|urhea (sankarillinen)|bohaterski, heroiczny, odważny, brawurowy
+Virgin nesia|Virgin nesia|desh|VI||Virgin Islands, US||Islas Vírgenes|||||||||||||||Wyspy Dziewicze USA
 virus:|virus|||eng:spa:fra:may:virus, por:vírus, rus:вирус (virus), tur:virüs, hin:वाइरस (vāirasa), jpn:ウイルス (uirusu)|virus|virus|virus||вирус||||||||||||virus|wirus
 virus.loj:ia|viruslojia|||pol:wirusologia, rus:вирусология (virusologiya)|virology||virología||вирусология||||||||||||virologia|wirusologia
 vis:|vis||||alternative (substitute, replacement)||alternativa (sustituto)|||||代替||||||||||alternatywa (substytut, zastępstwo)
@@ -3553,8 +3552,7 @@ waw:|waw|||zho:哇 (wā), eng:wow|wow! (gee!)||guau (vaya)||вау!|||||||||||ŭ
 wax:a|waxa|||eng:wash, deu:waschen, zho:洗 (xǐ)|wash||lavar||мыть|||||||||||lavi|pestä|prać, umyć, myć
 wax.maxin:|waxmaxin||||washing machine||lavadora||стиральная машина|||||||||||lavmaŝino|pesukone|pralka
 wax.urs:e|waxurse|||zho:浣熊, jpn:洗熊, ita:orsetto lavatore, deu:Waschbär, heb:דביבון רוחץ|raccoon|raton laveur|mapache|guaxinim (rato-lavadeiro)|енот||浣熊|狸 (ラクーン, 洗い熊)||||||||||szop pracz
-Waxington:|Waxington|shefocite|US||Washington DC||||||||||||||||Washington DC|
-Waxington: DC|Waxington DC||||Washington D.C.|||||||||||||||||Waszyngton D.C
+Waxington: DC|Waxington DC|shefsite|US||Washington DC||||||||||||||||Washington DC|Waszyngton D.C
 waz:e|waze|||ara:(wāḥa), tur:vaha, fas:(vāhe) + eng:fra:spa:por:oasis, rus:оазис (oazis), deu:Oase, pol:oaza, jpn:オアシス (oashisu), kor:오아시스 (oasiseu)|oasis||oasis|oasis|oasis|oásis|оазис|||オアシス|오아시스 (천지)|||||oazo|keidas|oaza
 Wenjow:|Wenjow||||Wenzhou||||||温州||||||||||Wenzhou|Wenzhou
 wenjow.oranj:e|wenjoworanje|biw|Citrus unshiu||satsuma mandarin|mandarine satsuma|unshu mikan||мандарин уншиу||温州蜜柑|ウンシュウミカン|||||||||satsuma|mandarynka Satsuma (pomarańcza Satsuma)
@@ -3636,6 +3634,7 @@ xite|xite|||eng:shit, zho:屎 (shǐ), yue:屎 (si2)|shit (feces)|merde|mierda|m
 xix|xix|||tur:şiş + eng:shish-, rus:шиш- (šiš-)|skewer|brochette|brocheta||||扦子|||xiên|||||şiş||varras|rożen (szpikulec)
 xixkababe|xixkababe||||shish kebab||||шиш-кебаб||||||||||şiş kebap||varraskebab|szisz kebab
 xixmanse|xixmanse||||shashlik|chachlik|||шашлык||串烧||||||sate||şişlik|ŝaŝliko|saslik|szaszłyk
+Xkip:ia|Xkipia|desh|AL||Albania||Albania||||||||||||||Albania|Albania
 xofa|xofa||||drive (steer)||conducir|conduzir|||开车|||||||||konduki|ajaa (kuskata)|prowadzić pojazd
 xofer|xofer|||fra:eng:deu:chauffeur, spa:por:chofer, rus:шофёр (šofjor), pol:szofer, tha: โชเฟอร์ (chofoe), tur:şoför, fas:(šofer)|chauffeur (driver)||conductor (chofer)|condutor (chofer, motorista)|шофёр||司机||||||||sürücü (şoför)|ŝoforo (kondukisto)|kuski (ajuri, ajaja)|szofer (kierowca)
 xogun|xogun|||jpn:将軍 (shōgun), eng:shogun|shogun||sogún|||||||||||||||szogun
@@ -3646,6 +3645,7 @@ xope|xope|||eng:fra:spa:shopping, jpn:ショッピング (shoppingu), kor:쇼핑
 xoper|xoper||||buyer||comprador|||||||||||||aĉetanto (aĉetisto)|ostaja|nabywca (kupiec)
 xow|xow|||eng:deu:fra:spa:por:show, rus:шоу (šou), tur:şov, swa:shoo, tha:โชว์ (choo), kor:쇼 (syo), jpn:ショー (shō), zho:秀 (xiù)|show (display, exhibition)||exposición (espectáculo)|||||||||||||montri (ekspozicii)|näytös (esitys, show)|pokaz, ekspozycja, wystawa
 xowa|xowa||||show (display, demonstrate)||mostrar||доказать (демонстрировать)|||見せる (示す, デモる)|||||||||näyttää|pokazać, pokazywać, wystawić, wystawiać
+Xri Lanka|Xri Lanka|desh|LK||Sri Lanka (Ceylon)||Sri Lanka||||||||||||||Sri Lanka|Sri Lanka
 xudu|xudu|||eng:should|should (ought)||deber (se recomienda)|||||||||||||devus|pitäisi|powinien
 xukar:|xukar|||ara:(sukkar), swa:sukari, por:açúcar, spa:azúcar, hin:शक्कर (śakkar), ben:শর্করা (śôrkôra), tur:şeker, tam:சக்கரை (cakkarai)|sugar|sucre|azúcar|açúcar|сахар|سُكَّر|糖|砂糖|||शक्कर|চিনি (শর্করা)|sakar|sukari|şeker|sukero|sokeri|cukier
 xukar:i|xukari||||sugary (sweet)||azucarado||||||||||||||sokerinen (makea)|słodki
@@ -3690,7 +3690,7 @@ yaw.xin.abl:i|yawxinabli||||loyal (faithful, trustworthy)||leal (fiel)||верн
 yaw.xin.abl:ia|yawxinablia||||loyalty (faithfulness)||lealtad (fidelidad)||верность|||||||||||||lojalność (wierność)
 yehud:i|yehudi||||Jewish||judío||||||||||||||juutalainen|żydowski
 yehud.ist:ia|yehudistia||||Judaism||judaísmo||||||||||||||juutalaisuus|judaizm
-Yemen:ia|Yemenia||||Yemen||Yemen||Йемен|||||||||||Jemeno|Jemen|Jemen
+Yemen:|Yemen||||Yemen||Yemen||Йемен|||||||||||Jemeno|Jemen|Jemen
 Yesus:|Yesus||||Jesus|Jésus|Jesús||Иисус|||||||||||Jesuo|Jeesus|Jezus
 yex:o|yexo|||rus:ещё (yeščo), pol:jeszcze|still (yet)|encore|todavía (aún)|ainda|ещё||还 (依然)|まだ||||||||ankoraŭ|vielä (yhä)|wciąż, nadal
 yey:|yey|||eng:yay, pol:jej, jpn:イエイ (iei)|yay! (yeah!)||yupi||||||||||||||jee! (hurraa!)|jej

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -407,7 +407,7 @@ bor:i|bori|||eng:bored, spa:aburrido, hin:(bhorī)|bored||aburrido|||||||||||||e
 bor:ia|boria||27 emotions||boredom||aburrimiento||||||||बोरियत|||||enuo|tylsyys (pitkästys)|nuda (znudzenie)
 bor.em:|borem|mate|Bh||bohrium||bohrio|||||||||||||borio|bohrium|bohr
 boron:|boron|mate|B||boron||boro|||||||||||||boro|boori|bor
-Bosn:ia w:a Herzegovina:|Bosnia wa Herzegovina|desh|BA||Bosnia and Herzegovina||Bosnia y Herzegovina||||||||||||||Bosnia ja Hertsegovina|Bośnia i Harcegowina
+Bosn:ia e Herzegovina:|Bosnia e Herzegovina|desh|BA||Bosnia and Herzegovina||Bosnia y Herzegovina||||||||||||||Bosnia ja Hertsegovina|Bośnia i Harcegowina
 bot:a|bota||||sail||navegar (ir en bote)|||||||||||||boatumi|veneillä|żeglować (płynąć)
 bot.el:|botel|||eng:bottle, fra:bouteille, spa:botella, por:botelha, rus:бутылка (butylka), hin:बोतल (botal), ben:বোতল (botôl), may:botol|bottle|bouteille|botella|garrafa (botelha)|бутылка||瓶|瓶|병|chai|शीशी (बोतल)|বোতল|botol|chupa|şişe|botelo|pullo|butelka
 bot.er:|boter||||sailer||velero||||||||||||||veneilijä|żeglarz (marynarz)
@@ -985,13 +985,13 @@ fot.o.graf.er:|fotografer||||photographer||fotógrafo|||||||||||||fotisto|valoku
 fot.o.graf.maxin:|fotografmaxin||||camera||cámara|||||||||||||fotilo|kamera|kamera, aparat fotograficzny
 fot.o.minar:|fotominar||||beacon (lighthouse)|fanal (balise)|faro (baliza, almenara)|farol (baliza)|маяк||信号|狼煙 (ビーコン)|||||||||majakka|latarnia morska
 fot.o.rad:e|fotorade||||ray of light||rayo luminoso||||||||||||||valonsäde|promień światła
-franc:i krep:e|franci krepe|yame|||crepe|crêpe|crepa (crep, tortilla de trigo)|crepe||||||||||||franca krepo|kreppi|francuski naleśnik (crêpe)
-Franc:i Pol.nes:ia|Franci Polnesia|desh|PF||French Polynesia||Polinesia Francesa||||||||||||||Ranskan Polynesia|Polinezja Francuska
-Franc:i Guyana:|Franci Guyana|desh|GF||French Guiana||Guyana Francesa||||||||||||||Ranskan Guiana|Gujana Francuska
-Franc:ia|Francia|desh|FR||France||Francia|||||||||||||Francio|Ranska|Francja
-franc.em:|francem|mate|Fr||francium||francio|||||||||||||franciumo|fransium|frans
-franc.o.fon:i|francofoni||||Francophone (French speaking)|francophone|||||||||||||||ranskaa puhuva (frankofoni)|
-Franc.o.fon:ia|Francofonia||||Francophonie|francophonie|||||||||||||||ranskankielinen maailma|
+frans:i krep:e|fransi krepe|yame|||crepe|crêpe|crepa (crep, tortilla de trigo)|crepe||||||||||||franca krepo|kreppi|francuski naleśnik (crêpe)
+Frans:i Pol.nes:ia|Fransi Polnesia|desh|PF||French Polynesia||Polinesia Francesa||||||||||||||Ranskan Polynesia|Polinezja Francuska
+Frans:i Guyana:|Fransi Guyana|desh|GF||French Guiana||Guyana Francesa||||||||||||||Ranskan Guiana|Gujana Francuska
+Frans:ia|Fransia|desh|FR||France||Francia|||||||||||||Francio|Ranska|Francja
+frans.em:|fransem|mate|Fr||francium||francio|||||||||||||franciumo|fransium|frans
+frans.o.fon:i|fransofoni||||Francophone (French speaking)|francophone|||||||||||||||ranskaa puhuva (frankofoni)|
+Frans.o.fon:ia|Fransofonia||||Francophonie|francophonie|||||||||||||||ranskankielinen maailma|
 frem:|frem|||eng:frame, ben:ফ্রেম (phrēma), pan:ਫਰੇਮ (pharēma), mar:फ्रेम (phrēma), swa:fremu|frame|cadre|marco|moldura|рама||框|額||||||fremu|frame|kadro|kehys (raamit)|rama
 frik:a|frika|||eng:friction, spa:por:friccionar, fra:frictionner + ara:فرك (farak)|rub (scrape, scrub)||raspar (arañar)||царапать||擦伤|擦る (擦り傷する)|||||||||hangata|trzeć (pocierać, obetrzeć, pucować)
 fuga|fuga|||zho:复 (fù), yue:(fuk), vie:phục|return (restore, recover, resume)||regresar (restablecer, restaurar, recuperar, reanudar)||||||||||||||palauttaa|wznowić, wznawiać, ponowić, ponawiać, przywrócić, przywracać, odnowić, odnawiać
@@ -1579,8 +1579,8 @@ kanjar|kanjar|||fas:(xanjar), tur:haner, rus:кинжал (kinžal)|dagger||puñ
 kankuat:e|kankuate|biw|Citrus japonica|yue:柑橘 (gam1gwat1), zho:金橘 (jīnjú), jpn:キンカン (kinkan), kor:금귤 (geumgyul), vie:kim quất, eng:spa:fra:kumquat, por:cunquate, rus:кумкват (kumkvat), tur:kumkat, ara:كمكوات (kamakawat), may:kumkuat|kumquat|kumquat|kumquat (quinoto)|quincã (cunquate)|кумкват (кинкан)||金柑|キンカン (キンキツ)|||||kumkuat||kumkat||kumkvatti|kumkwat
 kano:|kano|||eng:canoe, fra:canoë, spa:por:canoa, rus:каноэ (kanoe), jpn:カヌー (kanū), kor:카누 (kanu), tur:kano|canoe|canoë|canoa|canoa|каноэ|||カヌー|카누||||||kano|kanuo (kanoto)|kanootti|kanoe
 kant:e|kante|||hin:कंधा (kandhā), urd:(kandhā), ben:কাঁধ (kandhô), + jpn:肩 (kata), + ara:(kataf), + min:肩頭 (keng-thâu)|shoulder||hombro|||||||||||||ŝultro|olkapää (hartia)|bark (ramię)
-kantalup.o.melon:|kantalupomelon|biw|Cucumis melo var. cantalupo|eng:cantaloupe, spa:por:cantalupo, fra:cantaloup, deu:Cantaloup, rus:канталупа (kantalupa), jpn:カンタロープ (kantarōpu)|cantaloupe||melón cantalupo|meloa (cantalupo)|канталупа||鈔皮瓜|カンタロープ||||||||||kantalupa
-Kantalupo: da Sabina|Kantalupo da Sabina||||Cantalupo in Sabina|Cantalupo in Sabina|Cantalupo in Sabina|Cantalupo in Sabina|Канталупо-ин-Сабина|||||||||||||Cantalupo in Sabina
+kantalupo.melon:|kantalupomelon|biw|Cucumis melo var. cantalupo|eng:cantaloupe, spa:por:cantalupo, fra:cantaloup, deu:Cantaloup, rus:канталупа (kantalupa), jpn:カンタロープ (kantarōpu)|cantaloupe||melón cantalupo|meloa (cantalupo)|канталупа||鈔皮瓜|カンタロープ||||||||||kantalupa
+Kantalupo: v:a Sabina:|Kantalupo va Sabina||||Cantalupo in Sabina|Cantalupo in Sabina|Cantalupo in Sabina|Cantalupo in Sabina|Канталупо-ин-Сабина|||||||||||||Cantalupo in Sabina
 kanun:|kanun|||ara:(qānūn), tur:kanun, swa:kanuni, hin:क़ानून (qānūn), + eng:fra:canon, por:cânone, rus:канон (kanon)|law||regla (ley)|||||||||||||lego|laki|prawo
 kap:a|kapa|||tur:kapmak, hun:kap, sve:kapa, fin:kaapata, ned:kapen, spa:por:capturar, eng:capture, spa:por:caber, khm:ចាប់ (cap)|catch (capture, seize, snatch, intercept)||capturar (apresar)|||||||||||||kapti|ottaa kiinni (napata, kaapata)|złapać, łapać, schwytać, chwytać
 kap:a pex:|kapa pex||||catch fish||pescar|||||||||||||||łapać rybę
@@ -1890,8 +1890,6 @@ lancografer|lancografer||||image projector||proyector||||||||||||||projektori (v
 lancovute|lancovute||||projectile (missile)|projectile|proyectil (misil)|projétil|снаряд||投掷物|飛翔体 (矢玉)||||||||||pocisk
 langan|langan|||zho:栏杆 (lángān), jpn:欄干 (rankan), kor:난간 (nan-gan)|banister (handrail)||barandilla (pasamanos)||||||||||||||kaide (reelinki)|poręcz (balustrada)
 lantan.em:|lantanem|mate|La||lanthanum||lantano||||鑭|ランタン|||||||||lantaani|lantan
-Lao:|Lao|desh|LA||Laos||Laos||||||||||||||Laos|Laos
-lao:i|laoi||||Lao (Laotian)||laosiano||||||||||||||laoslainen|laotański
 larve|larve|||deu:fra:larve, eng:tur:larva, hin:लार्वा (lārvā), urd:(lārvā), pol:larwa|larva (maggot, caterpillar)||larva||||||||||||||toukka|larwa, czerw, gąsienica
 lasti|lasti|||eng:elastic, spa:por:elástico, gla:lastaig, rus:эласти́чный (elastíčnyj), tur:may:elastik, jpn:エラスティック (erasutikku)|elastic||elástico (flexible)||||||||||||||joustava (elastinen)|elastyczny
 lasun|lasun|biw|Allium sativum|hin:लहसुन (lahsun), ben:রসুন (rôśun), zho:大蒜 (dàsuàn)|garlic|ail|ajo|alho|чеснок||大蒜 (蒜头)|大蒜|마늘|tỏi|लहसुन|রসুন|bawang putih|kitunguu saumu|sarımsak|ajlo|valkosipuli|larwa, czerw, gąsienica
@@ -1905,7 +1903,9 @@ latojan|latojan||||companion (partner, sidekick)||compañero (compinche)||||||||
 Latvia|Latvia|desh|LV||Latvia|Lettonie|Letonia|Letónia|Латвия||拉脱维亚|ラトビア|라트비아|Lát-vi-a|लातविया|লাতভিয়া|Latvia||Letonya|Latvio|Latvia|Łotwa
 laurensem|laurensem|mate|Lr||lawrencium||laurencio|||||||||||||laŭrencio|lawrensium|lorens
 law:|law||||elder||viejo (anciano)|||||||||||||||starzec
+Law:|Law|desh|LA||Laos||Laos||||||||||||||Laos|Laos
 law:i|lawi|||zho:老 (lǎo), yue:老 (lau2), wuu:老 (lau3), jpn:老 (rō), vie:lão|old (aged, elderly)|vieux (âgé, ancien)|viejo (anciano)|idoso|пожилой||老 (老年, 年歲大)|年配||già (lão)||||||||stary (sędziwy, wiekowy)
+law:i|lawi||||Lao (Laotian)||laosiano||||||||||||||laoslainen|laotański
 law.mam:|lawmam||||grandmother||abuela|||||||||||||||babcia (babka)
 law.pap:e|lawpape||||grandfather||abluelo|||||||||||||||dziadek (dziad)
 lax|lax||||leftover (residue, vestige)||vestigio (sobrante, residuo)||||||||||||||jäte (hylkytavara)|pozostałość (szczątek)
@@ -3031,12 +3031,12 @@ sant:i|santi|||por:spa:santo, eng:fra:saint, kon:santu, zho:圣 (shèng)|holy (
 Sant:i Helena:|Santi Helena|desh|SH||Saint Helena||Isla Santa Elena||||||||||||||Saint Helena|Święta Helena
 Sant:i Kits:e|Santi Kitse|desh|||Saint Kitts||San Cristóbal||||||||||||||Saint Kitts|Saint Kitts
 Sant:i Kits:e e: Nevis:|Santi Kitse e Nevis|desh|KN||Saint Kitts and Nevis||San Cristóbal y Nieves||||||||||||||Saint Kitts ja Nevis|Saint Kitts i Nevis
-Sant:i Luc:ia|Santi Lucia|desh|LC||Saint Lucia||Santa Lucía||||||||||||||Saint Lucia|Saint Lucia
+Sant:i Lus:ia|Santi Lusia|desh|LC||Saint Lucia||Santa Lucía||||||||||||||Saint Lucia|Saint Lucia
 Sant:i Marino:|Santi Marino|desh|SM||San Marino||San Marino||||||||||||||San Marino|San Marino
 Sant:i Paulo:|Santi Paulo||||Sao Paulo|||São Paulo||||||||||||||São Paulo
 Sant:i Tom:e e: Prinsip:e|Santi Tome e Prinsipe|desh|ST||Sao Tome and Principe||Santo Tomé y Príncipe||||||||||||||Sao Tome ja Principe|Wyspy Świętego Tomasza i Książęca
-Sant:i Vincent:e|Santi Vincente||||Saint Vincent||Isla de San Vicente|||||||||||||||Saint Vincent
-Sant:i Vincent:e e: Grenadin:e|Santi Vincente e Grenadine|desh|VC||Saint Vincent and Grenadines||San Vicente y las Granadinas|||||||||||||||Saint Vincent and Grenadines
+Sant:i Vinsent:e|Santi Vinsente||||Saint Vincent||Isla de San Vicente|||||||||||||||Saint Vincent
+Sant:i Vinsent:e e: Grenadin:e|Santi Vinsente e Grenadine|desh|VC||Saint Vincent and Grenadines||San Vicente y las Granadinas|||||||||||||||Saint Vincent and Grenadines
 sapat:e|sapate|||spa:zapato, por:sapato, may:sepatu, swa:sapatu|chaussure||zapato||туфля|حِذَاء|鞋|鞋|||जूता||sepatu|kiatu (sapatu)||ŝuo|kenkä|but
 sapat.er:|sapater||||shoemaker||zapatero|||||||||||||ŝuisto|suutari|szewc
 sapat.er:ia|sapateria||||shoemaker's shop||zapatería|||||||||||||ŝuistejo|suutarin paja|warsztat szewski
@@ -3198,8 +3198,8 @@ sud:i|sudi||||southern||sureño|||||||||||||||południowy
 Sud:i Afrik:e|Sudi Afrike|desh|ZA||South Africa||Sudáfrica||||||||||||||Etelä-Afrikka|Południowa Afryka
 Sud:i Amerik:e|sudi amerike||||South America||Sudamérica||||||||||||||Etelä-Amerikka|Ameryka Południowa
 Sud:i Cosen:|Sudi Cosen|desh|KR||South Korea (Republic of Korea)||Corea del Sur|||||||||||||Sudkoreio|Etelä-Korea|Korea Południowa
+Sud:i Georg:ia e Sud:i Sandwic:e nes:ia|Sudi Georgia e Sudi Sandwice nesia|desh|GS||South Georgia and the South Sandwich Islands||Georgias del Sur y Sándwich del Sur|||||||||||||||Wyspy Georgia Południowa i Sandwich Południowy
 Sud:i Iria (Alonia)|Sudi Iria (Alonia)|desh|||South Ossetia (Alania)||Osetia del Sur||||||||||||||Etelä-Ossetia|Osetia Południowa
-Sud:i Georg:ia w:a Sud:i Sandwic:e nes:ia|Sudi Georgia e Sudi Sandwice nesia|desh|GS||South Georgia and the South Sandwich Islands||Georgias del Sur y Sándwich del Sur|||||||||||||||Wyspy Georgia Południowa i Sandwich Południowy
 Sud:i Sudan:|Sudi Sudan|desh|SS||South Sudan||Sudán del Sur||||||||||||||Etelä-Sudan|Sudan Południowy
 sud.o.nord:ia|sudonordia||||latitude||latitud|||||||||||||||południk
 Sudan:|Sudan|desh|SD||Sudan||Sudán||||||||||||||Sudan|Sudan
@@ -3260,7 +3260,7 @@ tabl:a dat:e|tabla date||||tabulate||tabular||||||||||||||taulukoida|ułożyć w
 tabl:e|table|||eng:table, fra:tableau, spa:tabla, rus:табличка (tablichka), may:tabel, tur:tablo|slab (slate, tablet, board)||tabla (lámina, plancha)||плита||||||बोर्ड||||tahta||laatta (levy)|
 tabl.o.komput.er:|tablokomputer||||tablette computer|ordinateur tablette|tablet|tablet|планшетный компьютер||平板电脑|タブレットコンピュータ|태블릿 컴퓨터||||||elaltı bilgisayar||taulutietokone (tabletti)|
 tafun:|tafun|||zho:大风 (dàfēng), yue:大風 (daai6fung1), kor:태풍 (taepung), jpn:台風 (taifuu), tha:ไต้ฝุ่น (taifun), ara:(ṭūfān), fas:urd:(tufān), hin:तूफ़ान (tūfān), pnb:ਤੂਫ਼ਾਨ (tūfān), por:tufão, spa:tifón, fra:typhon, eng:typhoon, rus:тайфун (tayfun)|storm (tempest, typhoon, hurricane, cyclone)||tormenta (tempestad)|||||||||||||ŝtormo|myrsky|burza, sztorm, tajfun
-Taibey|taibey||||Taipei||Taipei||||||||||||||Taipei|Tajpej
+Taibey|Taibey||||Taipei||Taipei||||||||||||||Taipei|Tajpej
 taige|taige|||rus:тайга (tayga), eng:spa:por:may:taiga, tur:tayga, ara:تايغا‎ (tāyḡā), zho:泰加林 (tàijiālín), jpn:タイガ (taiga)|taiga||taiga|||||||||||||tajgo|taiga|tajga
 tail|tail|||eng:tile, por:telha, fra:tuile, nld:tegel, fin:tiili, hin:टाइल (ṭāila), ben:টালি (ṭali), jpn:タイル (tairu), kor:타일 (tail)|tile|carreau (tuile)|baldosa (teja, azulejo)|ladrilho (telha, azulejo)|черепи́ца||砖 (瓦)|タイル (瓦)||||||||||płyta
 Taiwan|Taiwan|desh|TW||Taiwan (Republic of China)||Taiwán||||||||||||||Taiwan|Tajwan, Republika Chińska
@@ -3298,7 +3298,7 @@ tatike|tatike|||por:tática, ita:tattica, eng:tactic, rus:тактика (taktik
 tatu*|tatu*|||sam:tah:tatau, haw:kākau, may:tato, eng:tattoo, fra:tatouage, spa:tatuaje, rus:тату (tatu)|tattoo||tatuaje||татуировка (тату)|||||||||||tatuo|tatuointi|tatuaż
 tave|tave|||hin:तवा (tavā), tur:tava, fas:(tābe)|frying pan||sartén|||||||||||||pato|pannu (paistinpannu)|patelnia
 tayi|tayi||||Thai||tailandés|||||||||||||tajlanda|thai|tajski
-tayia|tayia||||Thailand||Tailandia|||||||||||||Tajlando|Thaimaa|Tajlandia
+Tayia|Tayia|dex|TH||Thailand||Tailandia|||||||||||||Tajlando|Thaimaa|Tajlandia
 tazi|tazi|||tur:taze, hin:ताज़ा (tāzā), ben:তাজা (taja), fas:(tâze)|fresh|frais|fresco||свежий||新鲜的|||||||||freŝa|tuore (raikas)|świeży
 tehne|tehne|||ell:τεχνική (tehniki), rus:техника (tehnika), fra:eng:technique, spa:por:técnica, hin:तकनीक (taknīk), may:teknik|technique (technology)|technique|técnica|técnica|техника||技术|技術|기술|kỹ thuật|||teknik||teknik|tekniko|tekniikka (keino, menetelmä)|technika, technologia
 tehnem|tehnem|mate|Tc||technetium||tecnetio|||||||||||||teknecio||technet

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -43,6 +43,7 @@ ais:i|aisi||||icy||cubierto de hielo|||||||||||||glacia|jäinen|lodowy
 ais:u|aisu||||freeze (get frozen)|geler (glacer)|congelarse (helarse)|gelar|||结冰|凍る (凍結する)||||||||glaciiĝi (frostiĝi)|jäätyä|marznąć (zamarznąć)
 ais.krem:|aiskrem|||eng:ice cream, jpn:アイスクリーム (aisukurīmu), kor:아이스크림 (aiseukeurim), hin:आइसक्रीम (āisakrīm), ben:আইসক্রীম (aisôkrīm), may:es krim, swa:aiskrimu|ice cream|crème glacée|helado|sorvete (gelado)|мороженое||冰淇淋|アイスクリーム|아이스크림||आइसक्रीम|আইসক্রীম|es krim|||glaciaĵo|jäätelö|lody
 ais.o.hok:e|aisohoke||||ice hockey|hockey sur glace|hockey sobre hielo|hóquei no gelo|хокке́й с ша́йбой||冰球|アイスホッケー|아이스하키||||||buz hokeyi||jääkiekko|hokej na lodzie
+Aiti:|Aiti|desh|HT||Haiti||Haití|||||||||||||Haitio|Haiti|Haiti
 ajab:a|ajaba||||amaze||asombrar||||||||||||||ällistyttää|zachwycać (zachwycić, zdumiewać, zdumieć, zadziwiać, zadziwić)
 ajab:e|ajabe||||marvel (wonder)||maravilla|maravilha|||||||||||||ihme|dziw (cudo)
 ajab:i|ajabi|||ara:(ʿajīb), swa:ajabu, + fas:('ajib), urd:(ajīb), hin:अजीब (ajīb), tur:acayip|amazing (astonishing)||maravilloso (asombroso)||||||||||||||ihmeellinen (ällistyttävä, merkillinen)|zachwycający (zdumiewający, zadziwiający)
@@ -289,9 +290,9 @@ bard:e|barde|||fra:barbe, spa:por:barba, deu:Bart, eng:beard, rus:борода (
 bark:a|barka|||hau:barka, may:berkah, tur:tebrik, fas:(tabrik), ara:urd:(mubārak), yor:alubarika|congratulate (bless)|féliciter|felicitar|||||||||||||gratuli|onnitella (siunata)|gratulować; błogosławić
 bark:e!|barke!||||congratulations! (blessing)||¡Felicitaciones!||||||||||||||onneksi olkoon!|gratulacje!
 barkok:e|barkoke|frute||ara:(barqūq), pa:albaricoque, fra:abricot, rus:абрикос (abrikos), tgl:albarikoke|apricot|abricot|albaricoque|damasco (abricó)|абрикос||杏子||||ख़ूबानी|খুবানি|||kayısı (zerdali)|abrikoto|aprikoosi|morela
-Bart:e|Barte|desh|IN||India||India|||||||||||||Baratio|Intia|Indie
 bart:i|barti|||hin:भारतीय (bhārtīy), urd:(bhārtīy), mar:(bhārtīya), tel:(bhāratīya)|Indian||indio (hindú)|||||||||||||Barata|intialainen|Indyjski
 Bart:i Hay:|Barti Hay||||Indian Ocean||océano Índico||||||||||||||Intian valtameri|Ocean Indyjski
+Bart:ia|Barte|desh|IN||India||India|||||||||||||Baratio|Intia|Indie
 barud:e|barude|||ara:fas:urd:(bārūd), hin:बारूद (bārūd), pnb:ਬਾਰੂਦ (bārūd), swa:baruti, tur:barut, bul:барут (barut)|gunpowder||pólvora|||||||||||||pulvo|ruuti|proch strzelniczy
 barx:e|barxe|||hin:बारिश (bāriś), ben:বৃষ্টি (briśṭi), tur:baran|rain (precipitation)|pluie|lluvia|chuva|дождь|مطر‎|雨|雨|비|mưa|बारिश (वर्षा)|বৃষ্টি|hujan|mvua|yağmur (baran)|pluvo|sade|deszcz
 barx:i|barxi||||rainy|pluvieux|lluvioso (pluvioso)|chuvoso (pluvioso)|дождливый||多雨||||बरसाती||||yağmurlu|pluva|sateinen|deszczowy
@@ -407,7 +408,7 @@ bor:i|bori|||eng:bored, spa:aburrido, hin:(bhorī)|bored||aburrido|||||||||||||e
 bor:ia|boria||27 emotions||boredom||aburrimiento||||||||बोरियत|||||enuo|tylsyys (pitkästys)|nuda (znudzenie)
 bor.em:|borem|mate|Bh||bohrium||bohrio|||||||||||||borio|bohrium|bohr
 boron:|boron|mate|B||boron||boro|||||||||||||boro|boori|bor
-Bosn:ia e Herzegovina:|Bosnia e Herzegovina|desh|BA||Bosnia and Herzegovina||Bosnia y Herzegovina||||||||||||||Bosnia ja Hertsegovina|Bośnia i Harcegowina
+Bosn:ia e Hercegovina:|Bosnia e Hercegovina|desh|BA||Bosnia and Herzegovina||Bosnia y Herzegovina||||||||||||||Bosnia ja Hertsegovina|Bośnia i Harcegowina
 bot:a|bota||||sail||navegar (ir en bote)|||||||||||||boatumi|veneillä|żeglować (płynąć)
 bot.el:|botel|||eng:bottle, fra:bouteille, spa:botella, por:botelha, rus:бутылка (butylka), hin:बोतल (botal), ben:বোতল (botôl), may:botol|bottle|bouteille|botella|garrafa (botelha)|бутылка||瓶|瓶|병|chai|शीशी (बोतल)|বোতল|botol|chupa|şişe|botelo|pullo|butelka
 bot.er:|boter||||sailer||velero||||||||||||||veneilijä|żeglarz (marynarz)
@@ -467,7 +468,7 @@ c:e|ce||||this one||esto|||||これ||||||||ĉi tio|tämä|ten konkretny
 c:i|ci||||that (those)||eso|||||||||||||tiu|tuo (nuo)|tamten (tamten)
 c:i|ci|||zho:此 (cǐ), yue:此 (chi2), fra:ce|this (these)||esto|||||||||||||ĉi tiu|tämä (nämä)|ten, te
 cab:e|cabe|||por:chave, hin:(cābi), kon:nsapi|key||llave|||||||||||||ŝlosilo|avain|klucz
-Cad:e|Cade|desh|TD||Chad||Chad||||||||||||||Tšad|Czad
+Cad:ia|Cadia|desh|TD||Chad||Chad||||||||||||||Tšad|Czad
 cak:e|cake|||hin:चाक़ू (cāqū), fas:(čâqu), nep:चक्कु (cakku), kan:ಚಾಕು (cāku)|knife||cuchillo|||||||||||||tranĉilo|veitsi (puukko)|nóż
 cakr:e|cakre|||hin:चक्र (cakra), ben:চাকা (caka), pan:ਚੱਕਰ (cakkar), guj:ચક્ર (cakra), tel:చక్రము (cakramu), mar:चाक (cāk), tha:จักร (jàk), may:cakera, eng:chakram|wheel|roue|rueda (volante)|roda|колесо|عجلة‎|轮子|車輪|바퀴 (차륜)|bánh xe|चक्र|চাকা|roda (setir, cakera)|gurudumu|tekerlek (çark)|rado|ratas|koło
 camac:e|camace|||fas:(čamče), pnb:ਚਮਚਾ (camcā), ben:চামচ (camôc), hin:चम्मच (cammac), kan:ಚಮಚ (camaca), tha:ช้อน (chon)|spoon|cuiller|cuchara|colher|ложка||匙子|スプーン|숟가락 (스푼)||चम्मच|চামচ||||kulero|lusikka|łyżka
@@ -526,6 +527,7 @@ cili.fun:|cilifun||||paprika||||||辣椒粉|パプリカ|||||||||paprikajauhe|pa
 cimpanz:e|cimpanze|biw||eng:chimpanzee, spa:chimpancé, por:fra:chimpanzé, rus:шимпанзе (shimpanze), tur:şempanze, ara:شمبانزي‎ (šimbanzī), hin:चिंपांजी (cimpāñjī), jpn:チンパンジー (chinpanjī), may:cimpanzi|chimpanzee||chimpancé|||||||||||||ĉimpanzo|simpanssi|szympans
 cin:i|cini|||hin:चीनी (cīnī), tur:Çin, ara:(ṣiniy), spa:chino, eng:Chinese, tha:จีน (chin), zho:秦 (qín)|Han Chinese||chinés (de los Han)||хань||汉族|||||||||hana|han-kiinalainen|han chiński
 cincil:|cincil|biw|||chinchilla||chinchilla|||||||||||||ĉinĉilo|chinchilla|szynszyla
+Cip:ia|Cipia|desh|AL||Albania||Albania||||||||||||||Albania|Albania
 cir:|cir||||tear (rip, edge)|déchirer|rasgar (romper)|rasgar|рвать||撕裂|裂く|||||||||repeämä|rwać (drzeć)
 cir:a|cira|||hin:mar:चीर (chīra), ben:চেরা (chērā), pan:ਚੀਰ (chīra) + eng:tear|tear (rip, split)|déchirer|rasgar (romper)|rasgar|рвать||撕裂|裂く|||||||||repiä|drzeć (rwać, rozrywać, rozdzierać, rozszczepiać)
 cir.cir:a|circira||||tear up (tatter, shred)||||изорвать||撕毁|千切る|||||||||raastaa|strzępić (drzeć)
@@ -574,7 +576,7 @@ dang.er:|danger||||bell|cloche|campana (cencerro)|sino (campainha)|звонок|
 dank:a|danka||||thank||agradecer|||||||||||||danki|kiittää|dziękować
 dank:e|danke|||eng:thank, deu:Danke, + hin:धन्यवाद (dhanyavād)|thanks (thank you)||gracias|||||||||||||danko|kiitos|dzięki, dzięki ci
 dank:o d:a|danko da||||thanks to|grâce à|gracias a (merced a)|graças a||||||||||||dank’al|ansiosta|
-Danmark:e|Danmarke|desh|DK||Denmark||Dinamarca|||||||||||||Danio|Tanska|Dania
+Danmark:ia|Danmarkia|desh|DK||Denmark||Dinamarca|||||||||||||Danio|Tanska|Dania
 dans:e|danse|||eng:fra:dance, spa:danza, por:dança, deu:Tanz, rus:танец (taněc), tur:dans, jpn:ダンス (dansu), kor:댄스 (daenseu), swa:dansi|dance|dance|baile (danza)|baile (danza)|танец||||||||tari||dans|danco|tanssi|taniec
 dant:a|danta||||bite|mordre|morder|morder|откусить|مَضَغَ‎|咬|咬む|물어떼다 (깨물다)|cắn|||gigit|kuuma|ısırmak|mordi|purra|
 dant:e|dante|||spa:diente, por:dente, fra:dent, eng:dental, hin:दाँत (dā̃t), ben:দাঁত (dãtô), pan:ਦੰਦ (dand), may:danta|tooth||diente|||||||||||||dento|hammas|ząb
@@ -1093,7 +1095,7 @@ gem.er:|gemer||||player (gamer)||jugador||игрок (геймер)|||||||||||lu
 genc:a|genca|||zho:检查 (jiǎnchá), yue:檢查 (gimcaa), vie:kiểm tra, jpn,検査 (kensa)|examine (inspect, check)||examinar (inspeccionar)||||检查||||||||||tutkia|sprawdzić, sprawdzać, skontrolować, kontrolować, zbadać, badać
 German:ia|Germania||||Germania|Germanie|Germania|Germânia|||||||||||||Germania|
 german.em:|germanem|mate|Ge||germanium||germanio|||||||||||||germaniumo|germanium|german
-Gernesey:|Gernesey|desh|GG||Guernsey||Guernesey||||||||||||||Guernsey|Guernsey
+Gernezi:|Gernezi|desh|GG||Guernsey||Guernesey||||||||||||||Guernsey|Guernsey
 get:a|geta|||eng:get|get (receive, obtain, take)||conseguir (obtener, recibir)|ter (achar, receber)|получить||获得|受ける (もらう)|||पाना|||kupata (kuget)|elde etmek|akiri (ricevi, preni)|hankkia (saada)|dostać, dostawać, otrzymać, otrzymywać, wziąć, brać
 get.er:|geter||||getter (receiver, recipient)||engendrador||||||||||||||saaja (vastaanottaja)|odbiorca
 gew:|gew|||eng:spa:por:geo-, fra:géo-, rus:гео- (geo-)|earth (ground)||tierra|||||地|||||||||maa (maaperä)|ziemia, grunt, gleba
@@ -1192,7 +1194,6 @@ hafiz.er:|hafizer||||keeper (preserver)||guarda (preservador, conservador)||||||
 hafn.em:|hafnem|mate|Hf||hafnium||hafnio|||||||||||||hafnio|hafnium|hafn
 hah:a|haha|||eng:fra:por:tur:haha, spa:jaja, rus:ха-ха (ha-ha), zho:哈哈 (hāhā), jpn:わはは (wa-ha-ha), ara:(hahah)|laugh|rire|reír|rir|смеяться||笑|笑う|웃다|cười|हँसना|হাসা|tawa|kuseka|gülmek|ridi|nauraa|śmiać się
 haid:a|haida|||rum:háide, ell:άιντε (áinte), bul:ха́йде (hájde), rus:айда (ayda), tur:hadi, ara:هَيَّا‎ (hayyā), vie:hãy|let's||vamos a|||||||||||||ni faru...|tehkäämme|niech my, hajda
-Hait:ia|Haitia|desh|HT||Haiti||Haití|||||||||||||Haitio|Haiti|Haiti
 hak:e|hake|||ara:(ḥaq), hin:हक़ (haq), tur:may:hak, swa:haki, hau:hakki|right (entitlement)|droit|derecho|direito|||权利|権利|권리||अधिकार (हक़)|অধিকার||||rajto|oikeus (oikeutus)|prawo, przywilej
 hal:|hal|||ara:(ḥāla), hin:हालत (hālat), swa:hali, tur:hâl|state (condition, status, situation)|état|estado (condición)|estado|состояние (статус)||状态|状態|상태||हालत (दशा)||keadaan (kondisi)|hali|durum (hâl)|stato|tila (tilanne, seikka)|stan
 halal:a|halala||||allow (permit)||permitir (dejar)||||||||||||||sallia (antaa lupa)|pozwolić, pozwalać, zezwolić, zezwalać
@@ -1310,7 +1311,6 @@ hol:ia|holia||||wholeness (integrity)||totalidad (integridad)|||||||||||||||cał
 hol.graf:|holgraf||||hologram||holograma||||||||||||||hologrammi|hologram
 holir:|holir|||eng:cholera, spa:por:cólera, fra:choléra, rus:холера (holera), tur:kolera, ara:كُولِيرَا‎ (kōlīrā), hin:कॉलरा (kŏlrā), zho:虎列拉 (hǔlièlā), jpn:コレラ (korera)|cholera||cólera||||||||||||||kolera|cholera
 holm.em:|holmem|mate|Ho||holmium||holmio|||||||||||||holmio|holmium|holm
-Honduras:|Honduras|desh|HN||Honduras||Honduras|||||||||||||Honduro|Honduras|Honduras
 Hong: Gong:|Hong Gong|desh|HK||Hong Kong, SAR China||Hong Kong||||||||||||||Hong Kong|Hong Kong
 hor:|hor|||fra:heure, eng:hour, spa:por:hora|hour|heure|hora|hora|час|سَاعَة|小时|時 (１時間)|시|giờ|घंटा|ঘন্টা|jam|saa|saat|horo|tunti|godzina
 hor.log.er:|horloger|||lat:horologium, fra:horloge, ita:orologio, spa:reloj, por:relógio, may:arloji|clock (watch)|horloge|reloj|relógio|часы|ساعة‎|钟|時計|시계|đồng hồ|घड़ी|ঘড়ি|jam (jam dinding)|saa|saat|horloĝo|kello (ajannäyttäjä)|zegar (zegarek)
@@ -1385,7 +1385,7 @@ ion:|ion|||eng:fra:spa:ion, rus:ион (ion), tur:iyon|ion||ion|||||||||||||iono
 ion:i rad:i|ioni radi||||radioactive||radiactivo||||||||||||||radioaktiivinen|radioaktywny
 ion:i rad:ia|ioni radia||||radioactivity (ionizing radiation)||radiación ionizante||||||||||||||radioaktiivisuus|radioaktywność
 Irak:ia|Irakia|desh|IQ||Iraq||Iraq|||||||||||||Irakio|Irak|Irak
-Iran:ia|Irania|desh|IR||Iran||Irán|||||||||||||Iranio|Iran|Iran
+Iran:|Iran|desh|IR||Iran||Irán|||||||||||||Iranio|Iran|Iran
 irid.em:|iridem|mate|Ir||iridium||iridio|||||||||||||iridio|iridium|iryd
 irit:a|irita|||eng:irritate, fra:irriter, spa:por:irritar, deu:irritieren, jpn:いらいらさせる (iraira saseru)|irritate (annoy, disturb)||molestar (irritar, fastidiar)|||||||||||||agaci (tedi, malamuzi)|ärsyttää (häiritä)|irytować (zirytować, drażnić)
 iron:i|ironi||||ironic||irónico|||||反語的||||||||||ironiczny
@@ -1457,7 +1457,7 @@ jeng:i|jengi||||military (martial, warlike)||macrial (militar)|||||||||||||milit
 jeng.er:|jenger||||warrior (fighter)||luchador (guerrero)||||||||||||||soturi (taistelija)|wojownik, bojownik
 jeng.o.xut:e|jengoxute|||zho:武术 (wǔshù), jpn:武術 (bujutsu), vie:võ thuật, kor:무술 (musul), eng:martial art|martial art||arte marcial||||||||||||||kamppailulaji|sztuka walki
 jenxen:|jenxen|bine|Panax|zho:人蔘 (rénshēn), min:人蔘 (jîn-sam), eng:spa:por:tur:may:ginseng, rus:женьшень (zhen’shen’), hind:जिनसेंग (jinseṅg), jpn:人参 (ninjin)|ginseng||ginseng||||||||||||||ginseng|żeń-szeń
-Jersey:|Jersey|desh|JE||Jersey||Jersey||||||||||||||Jersey|Jersey
+Jerz:e|Jerz:e|desh|JE||Jersey||Jersey||||||||||||||Jersey|Jersey
 jest:e|jeste|||eng:gesture, spa:por:gesto, fra:geste, rus:жест (zhest), tur:jest, fas:ژست‎ (žest)|gesture||gesto||||||||||||||ele|gest
 Jibraltar:|Jibraltar|desh|GI||Gibraltar||Gibraltar||||||||||||||Gibraltar|Gibraltar
 Jibut:i|Jibuti|desh|DJ||Djibouti||Yibuti||||||||||||||Djiboutia|Dżibuti
@@ -1491,8 +1491,8 @@ juml:e|jumle|||ara:(jumla), tur:cümle, hin:जुमला (jumlā), zho:句 (j
 jung:|jung|||zho:中 (zhōng), yue:中 (zung), kor:중 (jung), jpn:中 (chuu-)|middle (center)|centre|centro|centro|центр|مَرْكَز|中心|中心|중심|trung tâm|केंद्र|কেন্দ্র|pusat|kati (senta)|merkez|centro|keskus (keskikohta)|środkowy, centralny
 jung:a|junga||||center (concentrate)||centrar (concentrar)||||||||||||||keskittää|centrować, skupić, skupiać
 jung:i|jungi||||central (middle)||central|||||||||||||||centralny (środkowy)
-Jung:i Afrik:e|Jungi Afrike|desh|CF||Central African Republic||República Centroafricana||||||||||||||Keski-Afrikan Tasavalta|Republika Środkowoafrykańska
 jung:u|jungu||||to be centered (amid, in the middle)||centrarse (en el centro de)||||||||||||||keskittyä (olla keskellä)|być wycentrowanym, być w środku
+Jung.afrik:e|Jungafrike|desh|CF||Central African Republic||República Centroafricana||||||||||||||Keski-Afrikan Tasavalta|Republika Środkowoafrykańska
 jung.o.fon:|jungofon||||vowel|voyelle|vocal|vogal|гласный||||보컬 부분||||vokal|||vokalo|vokaali|samogłoska
 Junguo:|Junguo|desh|CN||China|Chine|China|China|Китай|اَلصِّين‎|中国|中国|중국|Trung Quốc|चीन|চীন|Cina (Tiongkok)|Uchina|Çin|Ĉinio|Kiina|Chiny
 jup:e|jupe|||fra:jupe, ara:(jūb), rus:юбка (yubka)|skirt||falda|||||||||||||jupo|hame|spódnica
@@ -1518,7 +1518,7 @@ kababi manse|kababi manse||||grilled meat (kebab)||||кебаб|كباب|||||क
 kabaw|kabaw|biw|Bubalus bubalis|spa:carabao, may:kerbau, jav:kebo, khm:ក្របី (krɑbəy)|water buffalo||búbalo (arni)||||||||||||||vesipuhveli|bawół domowy
 kabin|kabin|||eng:cabin, spa:cabaña, por:cabana, fra:cabane, ben:কেবিন (kebin)|cabin (booth)||cabaña||||||||||||||koppi (maja)|kabina, budka
 kaboge|kaboge|biw|Cucurbita|tur:kabak, swa:boga, jpn:カボチャ (kabocha)|squash (pumpkin, gourd)|citrouille|calabaza|abóbora (jerimun)|тыква||南瓜|カボチャ||||||||||kabaczek (dynia, tykwa)
-Kabo Verde|Kabo Verde|desh|CV||Cabo Verde (Cape Verde)||Cabo Verde||||||||||||||Cabo Verde|Wyspy Zielonego Przylądka (Republika Zielonego Przylądka)
+Kabu Verdi|Kabu Verdi|desh|CV||Cabo Verde (Cape Verde)||Cabo Verde||||||||||||||Cabo Verde|Wyspy Zielonego Przylądka (Republika Zielonego Przylądka)
 kade|kade|biw|Gadus|eng:cod, ara:قد (qad)|cod|morue|bacalao||||鱈|鱈||||||||||dorsz
 kadem|kadem|mate|Cd||cadmium||cadmio|||||||||||||kadmio|kadmium|kadm
 kafe:|kafe*|||deu:Kaffee, fra:spa:por:café, rus:кофе, zho: 咖啡 (kāfēi), yue:咖啡 (gaa3 fe1), eng:coffee, hin:काफ़ी (kāfī), ben:কফি (kôphi), tur:kahve, tgl:kape, tha:กาแฟ (kafæ)|coffee|café|café|café|кофе|قَهْوَة|咖啡|コーヒー|||काफ़ी (क़हवा)||kopi|kahawa|kahve|kafo|kahvi|kawa
@@ -1559,8 +1559,8 @@ kamisi xake|kamisi xake||||sleeve|manche|manga|manga|||袖子|袖||||||||||ręka
 kamote|kamote|biw|Ipomoea batatas|spa:camote, tgl:kamote|sweet potato||camote (batata)|||||||||||||batato|bataatti|słodki ziemniak
 kampe|kampe|||eng:camp, spa:campamento, por:acampamento, tur:kamp, swa:kambi, hin:कैंप (kaimp), may:kem, jpn:キャンプ (kyanpu)|camp||campamento||||||||||||||leiri|obozowicz
 kamper|kamper||||camper||campista||||||||||||||retkeilijä|obóz
-kamri:i|kamrii||||Welsh||galés||||||||||||||walesilainen|walijski
-Kamri:|Kamri|desh|||Wales (Cambria)||Gales||||||||||||||Wales|Walia
+Kamr:ia|Kamria|desh|||Wales (Cambria)||Gales||||||||||||||Wales|Walia
+kamr:i|kamri||||Welsh||galés||||||||||||||walesilainen|walijski
 kan:|kan|||fas:خانه‎ (xâne), rus:-хана (-hana), hin:ख़ाना (xānā), ben:খানা (khana), tur:hane + zho:馆 (guǎn), kor:관 (gwan), jpn:館 (-kan), vie:quán|shop (store or workshop)||||||店 (馆)|店 (館)|관|quán|ख़ाना|খানা|||hane|farejo|paja (tekimö)|
 Kanada|Kanada|desh|CA||Canada||Canadá||||||||||||||Kanada|Kanada
 kanal|kanal|||eng:spa:por:fra:canal, rus:канал (kanal), ben:খাল (khal), may:kanal|channel||canal (cauce, acequia)|||||||||||||kanalo|kanava (kanaali)|kanał
@@ -1859,7 +1859,7 @@ kurem|kurem|mate|Cm||curium||curio|||||||||||||kuriumo|curium|kiur
 kurse|kurse|||ara:(kursiy), hin:कुरसी (kursī), urd:(kursī), pnb:ਕੁਰਸੀ (kursī), tel:(kurcī), may:som:kursi, fas:(korsi)|chair||silla|||||||||||||seĝo|tuoli|kszesło, fotel
 kurv:e|kurve|||eng:curve, fra:courbe, spa:por:curva|curve (bend)||curva|||||||||||||kurbo|mutka (kurvi)|wygiąć, wyginać, zgiąć, zginać, zakrzywić, zakrzywiać
 kurv:i|kurvi||||curvy (curved)||curvo||||||||||||||mutkikas|zakrzywiony
-Kuwait:e|Kuwaite|desh|KW||Kuwait||Kuwait||||||||||||||Kuwait|Kuwejt
+Kuwait:ia|Kuwaitia|desh|KW||Kuwait||Kuwait||||||||||||||Kuwait|Kuwejt
 kuxa|kuxa||||lay (lay down)|coucher|acostar (poner)|deitar|положить  (уложить)|||横たえる|||||||||panna jkn maate|położyć
 kuxen|kuxen||||cushion (pillow)||almohada||||||||||||||tyyny|poduszka
 kuxloke|kuxloke|||fra:eng:couchette, ita:cuccetta, pol:kuszetka|berth (couchette)|couch (couchette)||||||||||||||||kuszetka (koja)
@@ -1889,6 +1889,7 @@ lancografa|lancografa||||project (cast)|projeter (donner)|proyectar||||投射|�
 lancografer|lancografer||||image projector||proyector||||||||||||||projektori (videotykki, piirtoheitin)|projektor (rzutnik)
 lancovute|lancovute||||projectile (missile)|projectile|proyectil (misil)|projétil|снаряд||投掷物|飛翔体 (矢玉)||||||||||pocisk
 langan|langan|||zho:栏杆 (lángān), jpn:欄干 (rankan), kor:난간 (nan-gan)|banister (handrail)||barandilla (pasamanos)||||||||||||||kaide (reelinki)|poręcz (balustrada)
+Lanka|Lanka|desh|LK||Sri Lanka (Ceylon)||Sri Lanka||||||||||||||Sri Lanka|Sri Lanka
 lantan.em:|lantanem|mate|La||lanthanum||lantano||||鑭|ランタン|||||||||lantaani|lantan
 larve|larve|||deu:fra:larve, eng:tur:larva, hin:लार्वा (lārvā), urd:(lārvā), pol:larwa|larva (maggot, caterpillar)||larva||||||||||||||toukka|larwa, czerw, gąsienica
 lasti|lasti|||eng:elastic, spa:por:elástico, gla:lastaig, rus:эласти́чный (elastíčnyj), tur:may:elastik, jpn:エラスティック (erasutikku)|elastic||elástico (flexible)||||||||||||||joustava (elastinen)|elastyczny
@@ -1944,8 +1945,8 @@ lic:e|lice|||zho:荔枝 (lìzhī), hin:लीची (līcī), eng:lychee, rus:л
 lid:a|lida||||lead (direct)||dirigir (mandar, conducir, capitanear)||||||||||||||johtaa|prowadzić, dowodzić, kierować
 lid.er:|lider|||eng:fra:leader, spa:por:líder, rus:лидер (lider), tur:lider, hin:लीडर (līdar), jpn:リーダー (rīdā), kor:리더 (rideo)|leader (director)|dirigeant (leader)|dirigente (líder)|líder (chefe)|руководитель (лидер)||领导||||||||||johtaja (pomo)|dowódca, kierownik
 lid.o.kord:e|lidokorde||||leash (rein)||correa (rein)|||||リード (手綱)||||||||||smycz (cugiel, lejc, wodza)
-lietuva:i|lietuvai||||Lithuanian||lituano||||||||||||||liettualainen|litewski
 Lietuva:|Lietuva|desh|LT||Lithuania||Lituania||||||||||||||Liettua|Litwa
+lietuva: bax|lietuva bax||||Lithuanian||lituano||||||||||||||liettualainen|litewski
 lifaf:|lifaf|||ara:(lifāfa), fas:(lefâf), hin:लिफ़ाफ़ा (lifāfā)|wrapping (envelope, covering)||envoltura||||||||||||||kääre (kuori)|owinięcie (koperta, okładka)
 lifaf:a|lifafa||||wrap|envelopper (emballer)|envolver|embalar|||||||||||||kääriä (panna kääröön)|zawijać (zawinąć)
 lig:a|liga||||associate||asociar|||||||||||||aligi|liittää|stowarzyszać się (zrzeszać się)
@@ -2028,8 +2029,6 @@ lusun|lusun||||asparagus||espárrago||||||||||||||parsa|szparag; szparagia
 luta|luta|||hin:लूटना (lūṭnā), urd:(lūṭnā), ben:লুটা (luṭā), pnb:ਲੁੱਟ (luṭ), eng:loot, + zho:掠夺 (lüèduó), yue:掠 (loek6)|rob (loot, plunder, pillage, ransack)||saquear (desvalijar, robar)||||掠夺|||||||||rabi|ryöstää (ryövätä)|obrabować, splądrować
 luter|luter||||robber (plunderer)|brigand (bandit)|ladrón|ladrão|грабитель||强盗||||डाकू|||||rabisto|ryöväri (rosvo)|rabuś (grabieżca)
 lutetem|lutetem|mate|Lu||lutetium||lutecio|||||||||||||lutecio|lutetium|lutet
-luteristi|lutheristi||||Lutheran|luthérien|luterano|luterano|лютеранский||||||||||||luterilainen|luterański
-luteristia|lutheristia||||Lutheranism|luthéranisme|luteranismo|luteranismo|лютера́нство||||||||||||luterilaisuus|luteranizm
 luv:a|luva||||love (hold dear)|aimer|amar||любить||爱|||||||||ami (ŝati)|rakastaa (pitää, tykätä)|kochać
 luv:e|luve||eng:love, rus:любовь (l’ubov’), hin:लोभ (lobh), ltn:libido||love (liking, affection)|amour (affection)|amor|amor|любовь||愛|愛|||मुहब्बत (अनुराग, पसंद)||cinta (kasih, asmara)|penzi (ashiki, upendo)|sevda (aşk)|amo|rakkaus (tykkääminen)|miłość (afekt)
 luv:i|luvi||||dear (beloved)|cher|querido|querido (caro)|||亲爱的|愛しい|||प्यारा|||||kara|rakas (armas)|kochany (drogi)
@@ -2038,8 +2037,6 @@ M|M||||M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M
 m:e|me|pron.||eng:me, fra:por:spa:me, hindi:मैं (mẽ), swa:mimi|I (me)|je (me)|yo|eu (me)|я|أَنَا‎|我|私|||मैं||saya (aku)|mimi||mi|minä|ja, mnie
 m:i|mi||||my||mi|||||私の||||||||mia|minun|mój
 m.o.m:e|mome|pron.|||we|nous|nosotros|nós|мы|نَحْنُ|我们|私たち|||हम|আমরা|kami (kita)|||ni|me|my
-Madagaskar:|Madagaskar|desh|MG||Madagascar||Madagascar||||||||||||||Madagaskar|Madagaskar
-madagaskar:i|Madagaskari||||Malagasy||malgache||||||||||||||malagassi|madagaskarski; malagaski
 mafan|mafan||||trouble (disturbance, bother)||problema (disturio)||||||||||||||vaiva (haitta)|problem, kłopot, zakłócenie
 mafana|mafana|||zho:麻煩 (máfan), yue:麻煩 (maa4 faan4), wuu:麻煩 (mo ve3)|bother||molestar (preocupar)||утруждать||||||||||||vaivata|przeszkodzić, przeszkadzać, robić kłopot
 mafanu|mafanu||||be bothered by (bother to, take the trouble to)||molestar en||утруждай|||悩む (わざわざする)||||||||||przejmować się (zawracać sobie głowę)
@@ -2050,7 +2047,7 @@ magete|magete||||magnet||imán||||||||||||||magneetti|magnes
 mageti|mageti||||magnetic||magnético||||||||||||||magneettinen|magnetyczny
 magi|magi||||magical||magical||||||||||||||taianomainen (maaginen)|magiczny
 magia|magia|||eng:magic, spa:por:magia, fra:magie, rus:ма́гия (mágija), rus:マジック (majikku)|magic||magia|||||||||||||magio|taika (taikuus, magia)|magia
-Magribe|Magribe|desh|MA||Morocco|Maroc|Marruecos|Marrocos|Марокко|المغرب‎|摩洛哥|モロッコ|모로코|Ma-rốc|मोरक्को|মরোক্কো|Moroko (Maghribi)|Moroko|Fas||Marokko|Maroko
+Magrib:ia|Magribia|desh|MA||Morocco|Maroc|Marruecos|Marrocos|Марокко|المغرب‎|摩洛哥|モロッコ|모로코|Ma-rốc|मोरक्को|মরোক্কো|Moroko (Maghribi)|Moroko|Fas||Marokko|Maroko
 Magyar:ia|Magyaria|desh|HU||Hungary||Hungría||||||||||||||Unkari|Węgry
 maidan|maidan|||ara:(maydān), fas:(meydan), hin:मैदान (maidān), tur:meydan, swa:medani, rus:майдан (maydan)|field (square, plaza, maidan)|place|plaza|praça|площадь (сквер, майдан)||广场|広場|광장|quảng trường||||medani (uwazi)|meydan||kenttä (aukio)|skwer, plac
 maidanfobia|maidanfobia||||agoraphobia||agorafobia||||||||||||||agorafobia (avoimen paikan kammo)|agorafobia
@@ -2068,6 +2065,8 @@ Makaw|Makaw|desh|MO||Macao||Macao||||||||||||||Macao|Makau
 mal (mali)|mal (mali)|||eng:mal-, spa:fra:mal, por:mau, rus:моль (mol’)|bad||malo|||||悪い||||||||malbona|huono|zły
 mal zar|mal zar||||misfortune (bad luck)||infortunio (mala suerte)||||||||||||||epäonni|zły los
 mal.darj.a|maldarja||||downgrade||degradar||||||||||||||laskea tasoa|dezaktualizować (pogorszyć)
+Malagas:ia|Malagasia|desh|MG||Madagascar||Madagascar||||||||||||||Madagaskar|Madagaskar
+malagas:i|Malagasi||||Malagasy||malgache||||||||||||||malagassi|madagaskarski; malagaski
 malaria|malaria||||malaria||malaria (paludismo)||||||||||||||malaria|malaria
 Malawi|Malawi|desh|MW||Malawi||Malaui||||||||||||||Malawi|Malawi
 malayali|malayali|nas|||Malayali (Malayalam)||malayali (malabar, malayalam)||||||||||||||malajalam (eräs intialainen kieli)|malajski
@@ -2115,6 +2114,8 @@ Marian nesia|Marian nesia|desh|MP||Northern Mariana Islands||Islas Marianas|||||
 marka|marka||||mark (leave a mark)||marcar||||||||||||||merkitä (jättää jälki)|zaznaczyć, znaczy, oznaczyć, oznaczać, zostawić ślad, zostawiać ślad
 marke|marke|||eng:mark, spa:por:marca, fra:marque, kor:마크 (makeu), jpn:マーク (māku)|mark (trace)||marca (huella, mancha)||||||||||||||merkki (jälki)|znak, trop
 Marse|Marse|planete 4||eng:fra:tur:may:Mars, spa:por:Marte, rus:Марс (Mars)|Mars|Mars|Marte|Marte|Марс|المريخ|||||||||Mars||Mars|Mars
+martinluteristi|martinlutheristi||||Lutheran|luthérien|luterano|luterano|лютеранский||||||||||||luterilainen|luterański
+martinluteristia|martinlutheristia||||Lutheranism|luthéranisme|luteranismo|luteranismo|лютера́нство||||||||||||luterilaisuus|luteranizm
 Marxal nesia|Marxal nesia|desh|MH||Marshall Islands||Islas Marshall||||||||||||||Marshall-saaret|Wyspy Marshalla
 mas|mas|||eng:mass, deu:fra:masse, spa:masa, por:may:massa, rus:масса (massa)|mass (quantity of matter)|masse|masa (trozo, pedazo)|massa|масса|كتلة|质量|質量|질량|khối lượng|द्रव्यमान||massa||kütle|maso|massa|masa
 masaja|masaja||||knead (massage)||amasar (masajear)||||||||||||||vaivata (hieroa)|
@@ -2134,7 +2135,6 @@ matur|matur||||adult|adulte|adulto||взрослый||成年人|大人||||||||pl
 maturi|maturi|||eng:fra:mature, spa:por:maduro|mature (ripe, adult)||maduro (adulto, curado)|||||||||||||matura (plenkreska)|kypsä (aikuinen)|dorosły, dojrzały
 maturi fem|maturi fem||||woman (adult female)||mujer (señora)||||女人|女の人||||||||virino|nainen|kobieta, dorosła samica
 maturi man|maturi man||||man (adult male)||hombre (señor)||||男人|男の人||||||||viro|mies|mężczyzna, dorosły samiec
-Mauris|Mauris|desh|MU||Mauritius||Mauricio||||||||||||||Mauritius|Mauritius
 maw:|maw|biw||zho:猫 (māo), yue:貓 (maau), vie:mèo, swa:nyau|cat|chat|gato|gato|кошка||猫|猫|고양이|mèo|बिल्ली|বেড়াল|kucing|paka (nyau)|kedi|kato|kissa|kot
 max:|max|||spa:mas, por:mais + eng:fra:maximum, rus:максимум (maksimum), may:maksimum, fas: ماکسیمم‎ (mâksimom)|more|plus|más|mais||||||||||||pli|enemmän (myös, lisäksi, plus)|bardzie
 max: k:a bas:|max ka bas||||too much||demasiado|||||||||||||tro|liikaa|zbyt
@@ -2249,8 +2249,8 @@ misalo|misalo||||for example|par exemple|por ejemplo|por exemplo|наприме�
 miser|miser||||sender (transmitter)||remitente||||||||||||||lähettäjä (lähetin)|nadawca
 misia|misia||||mission (transmission, emission)||emisión||||||||||||||lähetys|misja
 miskini|miskini||||poor (miserable)||pobre (miserable)|||||||||||||mizera|kurja (raukka)|biedny, mizerny
-Misr:e|Misre|desh|EG|ara:(miṣr), tur:Mısır, swa:Misri, hin:मिस्र (misra), ben:মিশর (miśôr)|Egypt|Égypte|Egipto|Egipto (Egito)|Египет||埃及|エジプト|이집트|Ai Cập|मिस्र|মিশর|Mesir|Misri|Mısır|Egipto|Egypti|Egipt
 misr:i|misri||||Egyptian||egipcio|||||||||||||egipta|egyptiläinen|egipski
+Misr:ia|Misria|desh|EG|ara:(miṣr), tur:Mısır, swa:Misri, hin:मिस्र (misra), ben:মিশর (miśôr)|Egypt|Égypte|Egipto|Egipto (Egito)|Египет||埃及|エジプト|이집트|Ai Cập|मिस्र|মিশর|Mesir|Misri|Mısır|Egipto|Egypti|Egipt
 mita|mita||||meet||encontrar|encontrar|||聚会|会う|||मिलना||||||tavata|spotkać
 mite|mite|||eng:meet, fra:meeting, spa:mitin, jpn:ミーティング (mītingu), hin:मीटिंग (mīṭiṅg)|meeting (gathering)||reunión (junta, mitin)||||会议|会合 (会議, ミーティング)|회합 (회의)||बैठक (सभा, मीटिंग)||||||tapaaminen (kokous)|spotkanie, zebranie
 mitr:e|mitre|||eng:tur:metre, deu:may:meter, fra:mètre, spa:por:metro, rus:метр (metr), ara: متر‎ (mitr), zho:米 (mǐ), jpn:メートル (mētoru), kor:미터 (miteo), vie:mét, hin:मीटर (mīṭar), ben:মিটার (miṭar), swa:mita|meter (100 cm)|mètre|metro|metro|метр|متر‎|米 (公尺)|メートル|미터|mét|मीटर|মিটার|meter|mita|metre|metro|metri|metr
@@ -2283,6 +2283,7 @@ Mongolia|Mongolia|desh|MN||Mongolia||Mongolia|||||||||||||Mongolio|Mongolia|Mong
 monost.er:|monoster|||eng:monster, spa:por:monstro, fra:monstre, rus:монстр (monstr), jpn:モンスター (monsutā)|monster||monstro|||||||||||||monstro|hirviö|potwór, monstrum
 morf:e|morfe|||eng:morph, spa:morfo, rus:морф (morf)|morph||morfo||||||||||||||morfi|morf
 morf.em:|morfem||||morpheme||morfema||||||||||||||morfeemi|morfem
+Moris|Moris|desh|MU||Mauritius||Mauricio||||||||||||||Mauritius|Mauritius
 mort:a|morta||||kill||matar (morir, asesinar)|||||||||||||mortigi|tappaa|zabić, zabijać
 mort:e|morte||||death||muerte (fallecimiento)|||||||||||||morto|kuolema (kuolo)|śmierć
 mort:i|morti|||por:morto, fra:mort, spa:muerto, fas:(morde), urd:(murda), hin:मृत (mrta), rus:мёртвый (myortvïy), + may:mati, + ara:(mawt), amh:ሞት (mot)|dead (deceased)||muerto|||||||||||||morta|kuollut (vainaa)|martwy, nieżywy, zabity
@@ -2341,6 +2342,7 @@ nafas|nafas|||ara:fas:(nafas), may:napas, tur:nefes, hau:numfashi|breath||respir
 nagre|nagre|||hin:नगर (nagar), ben:নগর (nôgôr), tel:నగరము (nagaramu), kan:ನಗರ (nagara), tam:நகரம் (nakaram), khm:អង្គរ (ʾɑngkɔɔ), tha:นคร (na-khon)|town||pueblo|||||||||||||urbo|kaupunki|miasto
 nagri|nagri||||urban||urbano|||||||||||||urba|urbaani (kaupunkilais-)|miejski
 nahun|nahun|||fas:ناخن‎ (nâxon), hin:नाख़ुन m (nāxun), ben:নখ (nôkh), pan:नख (nakh), rus:нога́ (nogá)|nail (fingernail)||uña||||||||||||||kynsi|paznokieć
+Naijir:ia|Naijiria|desh|NG||Nigeria||Nigeria|||||||||||||Niĝerio|Nigeria|Nigeria
 najis|najis|||ara:نجس (najis), fas:نجس (najes), may:najis + eng:najis, rus:наджа́са (nadžása), tur:necis|corruption (filth, pollution, contamination, najis)|pollution|contaminación (corrupción, porquería, suciedad)|poluição|грязь (скверна)||污染物|汚れ (汚染)|||गंदगी (संदूषक, विकृति, दोष)||najis (pencemaran, polusi)|uchafu||||
 najisa|najisa||||corrupt (pollute, soil, defile, stain, taint)||corromper (contaminar)||||污染|汚す||||||-chafua||||
 najisbinde|najisbinde||||stain (spot)||mancha|||||染み (汚点)||||||||||
@@ -2372,8 +2374,8 @@ navmes|navmes|mese|||September||septiembre|||||９月|||||||||syyskuu|grudzień
 nawati|nawati||||Nahuatl (Nahua)||náhuatl (nahua)|||||||||||||naūatla|nahuatli|nahuatl
 naz.ist:e|nasiste|||rus:нацист (natsist), jpn:ナチ (nachi), kor:나치 (nachi), por:ita:nazista|Nazi||Nazi||||||||||||||natsi|nazista
 naz.ist:ia|nasistia||||Nazism||nazismo||||||||||||||natsismi|nazizm
-Nederland:e|Nederlande|desh|NL||Netherlands||Países Bajos||||||||||||||Alankomaat (Hollanti)|Holandia (Królestwo Niderlandów)
 Nederland:i Antil:|Nederlandi Antil|desh|AN||Netherlands Antilles||Antillas Neerlandesas||||||||||||||Alankomaiden Antillit|Antyle Holenderskie
+Nederland:ia|Nederlandia|desh|NL||Netherlands||Países Bajos||||||||||||||Alankomaat (Hollanti)|Holandia (Królestwo Niderlandów)
 nefre|nefre|||eng:fra:nephro-, spa:por:nefro-, deu:Niere|kidney|rein|riñon|rim|почка||肾脏|腎臓|콩팥 (신장)|thận|गुर्दा|বৃক্ক|ginjal||böbrek|reno|munuainen|nerka
 nefritis|nefritis||||nephritis||nefritis||||||||||||||munuaistulehdus (nefriitti)|zapalenie nerek
 nefte|nefte|||ara:نفط (nifṭ), heb:נֵּפְטְ‎ (neft), tur:aze:neft, rus:нефть (neft’), kar:ნავთი (navti) + fas:نفت (naft), eng:naphtha, spa:por:nafta, jpn:ナフサ (nafusa), kor:나프타 (napeuta), may:nafta|oil|huile (pétrole)|aceite (óleo)|aeite (óleo)|масло||油|油 (オイル)||||||||||olej
@@ -2403,8 +2405,7 @@ nic:a|nica||||go under||||||||||||||||alittaa|iść w dół (iść pod spód, i�
 nic:e|nice|||ben:নিচে (nice), hin:नीचे (nīce), urd:(nīce), rus:ниже (niže)|underside (underneath)|dessous|parte inferior|||||下|||||||||alapuoli|spód
 nic:i|nici||||lower (inferior)||inferior||||||||||||||ala-|poniższy
 nic:o|nico||||under||debajo||||||||||||||alla|pod (poniżej)
-Niger:ia|Nigeria|desh|NG||Nigeria||Nigeria|||||||||||||Niĝerio|Nigeria|Nigeria
-Niger:|Niger:|desh|NE||Niger||Níger|||||||||||||Niĝero|Niger|Niger
+Nijer:|Nijer|desh|NE||Niger||Níger|||||||||||||Niĝero|Niger|Niger
 Nikaragua|Nikaragua|desh|NI||Nicaragua||Nicaragua|||||||||||||Nikaragvo|Nikaragua|Nikaragua
 nikel|nikel|mate|Ni||nickel||níquel|||||||||||||nikelo|nikkeli|nikiel
 nilcentaur|nilcentaur|biw|Centaurea cyanus||cornflower|Centaurée bleuet|aciano (azulejo)|escovinha (centáurea)|василёк синий||矢車菊|ヤグルマギク||||||||||bławatek
@@ -2417,7 +2418,7 @@ niobem|niobem|mate|Nb||niobium||niobio|||||||||||||niobo|niobium|niob
 Nipon|Nipon|desh|JP||Japan|Japon|Japón|Japão|Япония||日本|日本|일본|Nhật Bản|जापान|জাপান|Jepang|Japani|Japonya|Japanio|Japani|Japonia
 niponem|niponem|mate|Nh||nihonium||nihonio|||||||||||||nihonio|nihonium|nihonium
 niponi|niponi||||Japanese||japonés|||||日本の (日本語, 日本人)||||||||japana|japanilainen|japoński
-Nistrov:ia|Nistrovia|desh|||Transnistria||Transnistria (Cisdniéster)||||||||||||||Transdnistria|Naddniestrze
+Nistr:ia|Nistria|desh|||Transnistria||Transnistria (Cisdniéster)||||||||||||||Transdnistria|Naddniestrze
 nitre|nitre|mate|N||nitrogen||nitrógeno|||||||||||||nitrogeno|typpi|azot
 Niue|Niue|desh|NU||Niue||Niue||||||||||||||Niue|Niue
 nix|nix|||fra:eng:niche, por:nicho, rus:ниша (niša)|niche (recess, alcove)|niche|hornacina|nicho|ниша||壁龛|壁龕|반침||||||||alkovi|nisza, alkowa
@@ -2428,7 +2429,7 @@ noce|noce|||spa:noche, por:noite, rus:ночь (nočʹ), pol:noc|night|noit|noc
 nocomode|nocomode||||night mode||modo nocturno||||||||||||||yömoodi|tryb nocny
 noda|noda||||tie a knot||hacer un nudo||||||||||||||solmia (tehdä solmu)|zawiązywać (zawiązać węzeł)
 node|node|||eng:node, spa:nudo, por:nó, fra:nœud|knot (node)||nudo|||||||||||||nodo|solmu|węzeł, zupeł
-Norfolke nes|Nofrolke|desh|NF||Norfolk Island||Isla Norfolk||||||||||||||Norfolkin saaret|Norfolk
+Norfolke nes|Norfolke|desh|NF||Norfolk Island||Isla Norfolk||||||||||||||Norfolkin saaret|Norfolk
 nol (noli)|nol (noli)|||rus:ноль (nol'), may:nol, deu:null, eng:null|zero (none)||cero (ninguno)|||||零 (０)|||||||||nolla (ei yhtään)|zero, nic, żaden
 nol jan|nol jan||||nobody (no-one)||ningunos||||||||||||||ei kukaan|nikt, żadna osoba
 nol sate|nol sate||||never||nunca||||||||||||||ei koskaan (ei kertaakaan)|nigdy
@@ -2467,7 +2468,7 @@ novi|novi|||rus:новый (novyy), por:novo, spa:nuevo, hin:नव (nav), eng:n
 Novi Kaledonia|Novi Kaledonia|desh|NC||New Caledonia||Nueva Caledonia||||||||||||||Uusi-Kaledonia|Nowa Kaledonia
 Novi Yorke|Novi Yorke||||New York|||||||||||||||||Nowy Jork
 Novi Yorke site|Novi Yorke site|cite|US||New York City|||||||||||||||||Stan Nowy Jork
-Novi Zelande|Novi Zelande|desh|NZ||New Zealand||Nueva Zelanda||||||||||||||Uusi-Seelanti|Nowa Zelandia
+Novi Zelandia|Novi Zelandia|desh|NZ||New Zealand||Nueva Zelanda||||||||||||||Uusi-Seelanti|Nowa Zelandia
 novike|novike||||novice (newbie)|néophyte|novato|novato (neófito)|новичок||新手|初心者|승진자|||||||novulo|noviisi (uusikko, vasta-alkaja)|nowicjusz (nowa osoba)
 novo|novo||||just (recently)||ahora mismo (justo)|||||||||||||ĵus|äsken (vasta, juuri)|właśnie, dopiero co, ostatnio, niedawno
 novyangi|novyangi||||modern||moderno|||||近代的||||||||||nowoczesne
@@ -2500,6 +2501,7 @@ okside|okside||||oxide|oxyde|óxide|óxide|окись (оксид)||氧化物|||
 Olande nesia|Olande nesia|desh|AX||Aland Islands||islas Aland||||||||||||||Ahvenanmaa (Oolanti)|Wyspy Alandzkie
 Oman|Oman|desh|OM||Oman||Omán||||||||||||||Oman|Oman
 onde|onde|||spa:por:ita:onda, fra:onde, may:ombak|wave|onde|onda|onda|||波浪|波||||||||ondo|aalto (laine)|fala
+Onduras:|Onduras|desh|HN||Honduras||Honduras|||||||||||||Honduro|Honduras|Honduras
 onor:|onor|||eng:pol:spa:honor, fra:honneur, por:honra, tur:onur|respect (honor, esteem)|honneur|respeto (honor)|honra|честь|شَرَف‎|||||सम्मान|সম্মান|hormat|heshima|saygı (hürmet, şeref, onur)|honoro (respekto)|kunnioitus (arvostus)|respekt, honor, szacunek, poważanie
 onor:a|onora||||respect (honor, think highly of)|honorer|honrar|honrar|чтить||||||||menghormati|kusharifu|||kunnioittaa|
 onor:i|onori||||honorable (respectable)||respetable (honorable)||||||||||mulia (yang terhormati)|||respektinda|kunnianarvoisa|honorowy
@@ -2908,7 +2910,7 @@ rol|rol|||eng:role, fra:rôle, deu:Rolle, rus:роль (rol’), tur:rol, kat:�
 rola|rola||||act (play a role)||actuar (hacer un papel)|||||||||||||ludi rolon|näytellä|grać, odgrywać rolę
 roler|roler||||actor (actress)||actor (actriz)|||||||||||||aktoro (aktorino)|näyttelijä|akt, scena
 Roma:|Roma|cite|IT||Rome|Rome|Roma|Roma|Рим|الروم|罗马|ローマ|||रोम||Roma|Roma|Roma|Romo|Rooma|Rzym
-roma:i imper:ia|romai imperia||||Roman Empire||Imperio romano||||||||||||||Rooman valtakunta|Imperium Rzymskie
+roma: imper:ia|roma imperia||||Roman Empire||Imperio romano||||||||||||||Rooman valtakunta|Imperium Rzymskie
 roma.kamil:|rom.kamil:|biw|Chamaemelum nobile||Roman camomile|Camomille Romaine|manzanilla romana (camomila común)|camomila-romana|ромашка римская||果香菊|ローマンカモミール||||||||||rumian rzymski
 Roman:ia|Romania|desh|RO||Romania||Rumania||||||||||||||Romania|Rumunia
 romans:a|romansa||||love romantically||amar románticamente||||||||||||||rakastaa romanttisesti|kochać romantycznie
@@ -2997,6 +2999,7 @@ salam yam|salam yam||||bon appetit!||buen provecho|||||||||||||bonan apetiton!|h
 salama|salama||||greet||saludar|||||||||||||saluti|tervehtiä|pozdrowić, pozdrawiać
 salame|salame|||ara:(salām), swa:salamu, may:selamat, hin:सलाम (salām), ben: সালাম (salam), zho:萨拉姆 (sàlāmǔ), jpn:サラーム (sarāmu), kor:살람 (sallam), vie:xa lam, rus:салям (salyam)|greeting (hello)|salut (salam)|saludo|saudação|приветствие|سَلَام|迎接|挨拶|인사|lời chào|सलाम|সালাম|selamat|salaam (salamu)|selam|saluto|tervehdys (terve!)|pozdrowienie
 salmon|salmon|biw||eng:may:salmon, spa:salmón, por:salmão, fra:saumon, swa:samoni, jpn:サーモン (sāmon)|salmon (trout)|truite|salmón (trucha)|||||鮭鱒|||||ikan salmon (ikan trout)|samoni||||łosoś (pstrąg)
+Salon:|Salon|desh|SL||Sierra Leone||Sierra Leona||||||||||||||Sierra Leone|Sierra Leone
 Salvador|Salvador|desh|SV||El Salvador||El Salvador||||||||||||||El Salvador|Salwador
 saman:|saman|||ara:(samāʾ), amh:ሰማይ (sämay), orm:samii, hau:sama, yor:sánmà, hin:आसमान (āsmān), fas:pnb:urd:(āsmān)|sky (heaven)|ciel|cielo|céu|небо|سَمَاء|天空|空|하늘|trời|आसमान (आकाश)|আকাশ|langit|mbingu|gök|ĉielo|taivas|niebo
 saman:i|samani||||celestial (heavenly)||celeste (celestial)|||||||||||||||niebieski, niebiański, podniebny
@@ -3092,7 +3095,7 @@ sesam|sesam|biw|Sesamum indicum|tur:susam, eng:sesame, rus:сезам (sezam), s
 set.yom:|setyom||||Sunday|dimanche|domingo|domingo|воскресенье|يوم الأحد|星期日 (禮拜日)|日曜日|일요일|chủ nhật|रविवार|রবিবার|minggu|jumapili|pazar|dimanĉosunnuntai|niedziela|niedziela
 seti|seti|||spa:siete, por:sete, fra:sept, hin:सात (sāt), ben:সাত (sat), tha:เจ็ด (chet), yue:七 (chat1), jpn:七 (shichi), tur:yedi|seven (7)|sept (7)|siete (7)|sete (7)|семь (7)|七 (7)|七 (7)|||||||||sep (7)|seitsemän (7)|siedem (7)
 setomes|setomes|mese|||July||julio|||||７月|||||||||heinäkuu|październik
-Seyxel nesia|Seyxel nesia|desh|SC||Seychelles||Seychelles||||||||||||||Seychellit|Seszele
+Sexel nesia|Sexel nesia|desh|SC||Seychelles||Seychelles||||||||||||||Seychellit|Seszele
 siah:i|siahi|rang||fas:سیاه‎ (siyâh), hin:सियाह (siyāh), urd:سیاہ (siyāh), pan:ਸਿਆਹ (siāh), tur:siyah|black|noir|negro|preto|чёрный|أَسْوَد|黑色|黒い|검다|đen|काला|কালো|hitam|eusi|kara (siyah)|nigra|musta|czarny
 sian:i|siani|||eng:cyan, spa:cian, rus:циан (tsian), ara:سيان (sayan), hin:क्यान (kyāna), jpn:シアン (shian), may:sian|cyan||cian||циан|||シアン|||||||||syaani|niebieskozielony (cyjan)
 Sibir:ia|Sibiria||||Siberia||Siberia||||||||||||||Siperia|Syberia
@@ -3100,7 +3103,6 @@ siborg.em:|seaborgem|mate|Sg||seaborgium||seaborgio|seabórgio|сиборгий|
 sida|sida|||rus:сидеть (sidet'), eng:sit, deu:sitzen, ita:sedere|sit (put down)||sentar||сидеть|||||||||||sidi|istua|siedzieć
 side|side||||seat (saddle)||silla (montura)||сиденье (седло)||座部 (马鞍)|座席 (鞍)||||||||||siedzenie (siodło)
 sidu|sidu||||sit down||sentarse|||||座る||||||||||usiąść
-Siera: Leon:|Siera Leon|desh|SL||Sierra Leone||Sierra Leona||||||||||||||Sierra Leone|Sierra Leone
 sif|sif|||hin:गुण (guṇ), ben:গুণ (guṇ), tel:గుణము (guṇamu), mya:ဂုဏ် (gun), may:guna, tha:คุณ (kun), khm:គុណ (kun)|attribute (charasteristic, quality, feature, description, property)||cualidad (atributo, descripción)||||||||||||||laatu (ominaisuus, ominaispiirre, määrite)|cecha, właściwość, parametr
 sifa|sifa||||qualify (describe)||definir||||||||||||||määritellä (luonnehtia)|opisać (zakwalifikować)
 sifi|sifi||||descriptive||descriptivo||||||||||||||kuvaileva (määrittelevä)|opisowy
@@ -3149,7 +3151,6 @@ sistemi|sistemi||||systemic||sistémico|||||||||||||||systemowy
 sit:e|site|||eng:city, fra:cité, por:cidade, spa:ciudad, ita:città + zho:市 (shì), kor:시 (si), jpn:都市 (toshi)|city (town)|ville|ciudad|cidade||||||||||||urbo|kaupunki|miast, miasteczko
 sivil:i|sivili|||eng:civil, por:civil, hin:सिविल (sivil), may:sipil|civilized (civil)||civilizado||||||||||||||sivistynyt|cywilizowany (ucywilizowany)
 sivil:ia|sivilia||||civilization||civilización||||||||||||||sivilisaatio|cywilizacja
-Skot:ia|Skotia|desh|||Scotland||Escocia||||||||||||||Skotlanti|Szkocja
 slavi|slavi||||Slavic||eslavo|eslavo|славянский||||||||||||slaavilainen|słowiański
 Slovakia|Slovakia|desh|SK||Slovakia||Eslovaquia||||||||||||||Slovakia|Słowacja
 Slovenia|Slovenia|desh|SI||Slovenia||Eslovenia||||||||||||||Slovenia|Słowenia
@@ -3172,8 +3173,8 @@ solful|solful|biw|Helianthus annus||sunflower|Tournesol|girasol|girassol|под�
 Solomon nesia|Solomon nesia|desh|SB||Solomon Islands||Islas Salomón||||||||||||||Salomon-saaret|Wyspy Salomona
 solsentaur|solsentaur|biw|Centaurea solstitialis||yellow starthistle|Centaurée du solstice|abrepuño|||||||||||||||chaber wełnisty
 solsistem|solsistem||||solar system||sistema solar||||太阳系|||||||||sunsistemo|aurinkokunta|układ słoneczny
-Somalia|Somalia|desh|SO||Somalia||Somalia||||||||||||||Somalia|Somalia
-Somalilande|Somalilande|desh|||Somaliland||Solamilandia||||||||||||||Somalimaa|Somaliland
+Somal:ia|Somalia|desh|SO||Somalia||Somalia||||||||||||||Somalia|Somalia
+Somal.dex:|Somaldex|desh|||Somaliland||Solamilandia||||||||||||||Somalimaa|Somaliland
 son|son|||rus:сон (son), por:sono, hin:सोना (sonā), ben:শোয়া (śoya)|sleep||sueño|||||||||||||dormo|nukkuminen (uni)|sen
 sonda|sonda||||sound (make a sound)||sonar||||||||||||||ääntää|brzmieć, wydać dźwięk, wydawać dźwięk
 sonde|sonde|||eng:sound,sonic, fra:son, spa:son,sonido, ita:suono, + kor:소리 (sori)|sound (audio)||sonido (audio)|||||||||||||sono|ääni|dźwięk, brzmienie
@@ -3194,12 +3195,12 @@ sub.o.den:|suboden||||forenoon||mañana (antes mediodía)|||||||||||||||przedpo�
 sub.yam:|subyam||||breakfast||desayuno|||||朝食|||||||||aamiainen|śniadanie
 sud:e|sude|||spa:sur, por:sul, fra:sud|south||sur|||||||||||||sudo|etelä|południe
 sud:i|sudi||||southern||sureño|||||||||||||||południowy
-Sud:i Afrik:e|Sudi Afrike|desh|ZA||South Africa||Sudáfrica||||||||||||||Etelä-Afrikka|Południowa Afryka
 Sud:i Amerik:e|sudi amerike||||South America||Sudamérica||||||||||||||Etelä-Amerikka|Ameryka Południowa
 Sud:i Cosen:|Sudi Cosen|desh|KR||South Korea (Republic of Korea)||Corea del Sur|||||||||||||Sudkoreio|Etelä-Korea|Korea Południowa
-Sud:i Georg:ia e Sud:i Sandwic:e nes:ia|Sudi Georgia e Sudi Sandwice nesia|desh|GS||South Georgia and the South Sandwich Islands||Georgias del Sur y Sándwich del Sur|||||||||||||||Wyspy Georgia Południowa i Sandwich Południowy
+Sud:i Jorj:ia e Sud:i Sanduic:e nes:ia|Sudi Jorjia e Sudi Sanduice nesia|desh|GS||South Georgia and the South Sandwich Islands||Georgias del Sur y Sándwich del Sur|||||||||||||||Wyspy Georgia Południowa i Sandwich Południowy
 Sud:i Iria (Alonia)|Sudi Iria (Alonia)|desh|||South Ossetia (Alania)||Osetia del Sur||||||||||||||Etelä-Ossetia|Osetia Południowa
 Sud:i Sudan:|Sudi Sudan|desh|SS||South Sudan||Sudán del Sur||||||||||||||Etelä-Sudan|Sudan Południowy
+Sud.afrik:e|Sudafrike|desh|ZA||South Africa||Sudáfrica||||||||||||||Etelä-Afrikka|Południowa Afryka
 sud.o.nord:ia|sudonordia||||latitude||latitud|||||||||||||||południk
 Sudan:|Sudan|desh|SD||Sudan||Sudán||||||||||||||Sudan|Sudan
 suede|suede|||eng:sweat, spa:sudor, por:suor, fra:sueur, san:स्वेद (sveda)|sweat (perspiration)|sueur|sudor|suor|||||||||||||hiki|pot
@@ -3220,8 +3221,8 @@ sundardake|sundardake||||decoration (ornament)||decoración (adorno)||украш
 sundari|sundari|||hin:सुन्दर (sundar), ben:সুন্দর (sundôr), guj:સુંદર (sundar),|beautiful (handsome, pretty)|beau|hermoso (bello, lindo)|belo (lindo)|красивый|جَمِيل|漂亮 (美)|美しい|아름답다|đẹp|सुन्दर (ख़ूबसूरत)|সুন্দর|indah (cantik)|zuri|güzel|bela|kaunis (komea, sievä)|piękny, przystojny
 sundaria|sundaria||||beauty|beauté|belleza (hermosura)|beleza|красота|جَمَال|美丽|美しさ|아름다움||सौन्दर्य|||uzuri (jamala, urembo)|güzellik|beleco|kauneus|piękno
 suno|suno|||eng:soon|soon||pronto||||||||||||||pian|wkrótce
-Suomi:|Suomi|desh|FI||Finland||Finlandia|||||||||||||Finnlando|Suomi|Finlandia
-suomi:i|suomii||||Finnish||finés|||||||||||||finna|suomalainen|fiński
+suom:i|suomi||||Finnish||finés|||||||||||||finna|suomalainen|fiński
+Suom:ia|Suomia|desh|FI||Finland||Finlandia|||||||||||||Finnlando|Suomi|Finlandia
 supe|supe|||spa:sopa, eng: soup, fra: soupe, deu: Suppe, swa: supu, rus:суп (sup), may:sup, jpn:スープ (sūpu)|soup (stew)||sopa|||||||||||||supo|keitto (soppa)|zupa
 superi|superi||||superb (wonderful, super)||maravilloso (magnífico)|||||||||||||bonega|upea (mahtava)|wspaniały, znakomity, cudowny, zdumiewający, zadziwiający, super
 supr:a|supra|||eng:super, spa:por:sobre, ita:sopra|surpass (go over)||sobrepasar|||||||||||||superiri|ylittää|przekroczyć, przekraczać, przejść nad, iść nad
@@ -3412,7 +3413,7 @@ tunike|tunike|||spa:túnica, eng:tunic, rus:туника (tunika)|tunic (gown)||
 Tunisia|Tunisia|desh|TN||Tunisia|Tunisie|Túnez||||||||||||||Tunisia|Tunezja
 turki|turki||||Turkish||turco||||||||||||||turkkilainen|turecki
 Turkia|Turkia|desh|TR||Turkey||Turquía|||||||||||||Turkio|Turkki|Turcja
-Turkmenia|Turkmenia|desh|TM||Turkmenistan||Turkmenistán||||||||||||||Turkmenistan|Turkmenistan
+Turkomenia|Turkomenia|desh|TM||Turkmenistan||Turkmenistán||||||||||||||Turkmenistan|Turkmenistan
 Tuvalu|Tuvalu|desh|TV||Tuvalu||Tuvalu||||||||||||||Tuvalu|Tuwalu
 tuze|tuze|bio|Lagomorpha|zho:兔子 (tùzi), yue:兔仔 (tou3zai2), kor:토끼 (tokki), vie:thỏ, tha:เถาะ (tho)|rabbit (hare)|lapin (lièvre)|conejo (liebre)|coelho (lebre)|кролик (заяц)||兔子|うさぎ|||खरगोश (शशक, सुस्सा)||arnab (kelinci)|sungura|tavşan||jänis|królik, zając
 U|U||||U|U|U|U|U|U|U|U|U|U|U|U|U|U|U|U|U|U
@@ -3434,7 +3435,7 @@ un.ik:i|uniki||||only (single, sole, lone)|seul (unique)|único|único (só)|е�
 un.ik:o|uniko||||only (solely, just)|uniquement|únicamente (solo)|unicamente|только (единственно)||只有 (惟独)|だけ|||सिर्फ़|||||sole (nur)|ainoastaan (vain)|jedynie (tylko)
 un.it:i|uniti||||united||unido||||||||||||||yhtenäinen|zjednoczony
 Un.it:i Arab:i Amir:ia (UAA)|Uniti Arabi Amiria (UAA)|desh|AE||United Arab Emirates||Emiratos Árabes Unidos||||||||||||||Yhdistyneet Arabiemiirikunnat|Zjednoczone Emiraty Arabskie
-Un.it:i Desh: D:a Amerike (UDA)|Uniti Desh Da Amerike (UDA)|desh|US||United States of America (USA)||Estados Unidos de América||||||||||||||Yhdysvallat (ns. Amerikka)|Stany Zjednoczone Ameryki
+Un.it:i Dex: D:a Amerike (UDA)|Uniti Dex Da Amerike (UDA)|desh|US||United States of America (USA)||Estados Unidos de América||||||||||||||Yhdysvallat (ns. Amerikka)|Stany Zjednoczone Ameryki
 un.jan:i|unjani||||alone (lonely, isolated, solitary, single)||solo (aislado, solitary, soltero)|só (solitário)|одинокий (единичный)||独自的 (孤单)|一人の (寂しい, ポツリ)|||एकाकी||seorangan (sendiri)|||||
 un.mar:o|unmaro||||once|une fois|una vez|uma vez|один раз||一次 (一遍)||一度 (一回, 一遍)|한번|एक बार|||||unufoje|kerran|raz (jeden raz)
 un.men:i|unmeni||||unambiguous||inequívoco||||||||||||||yksimerkityksinen|jednoznaczny
@@ -3512,7 +3513,7 @@ vinil:|vinil|||eng:vinyl, spa:vinilo, por:vinil, fra:vinyle, rus:винил (vin
 violet:i|violeti|||eng:por:fra:violet, spa:violeta, deu:violett, rus:фиолетовый (fioletovyy), jpn:バイオレット (baioretto), kor:보라 (bola)|purple (violet)|violet (pourpre)|morado (púrpura)|purpúreo (roxo)|фиолетовый (пурпурный)|||紫色 (パープル)||||||||||fioletowy
 vir:|vir|||hin:वीर (vīr), urd:(vīr), ben:বীর (bīr), tam:வீரன் (vīraṉ), tel:వీరుడు (vīruḍu), may:wira, tha:วีร (wi-ra), + fra:por:spa:viril, eng:virile|hero||héroe|||||||||||||heroo|sankari (urho)|bohater, heros
 vir:i|viri||||heroic||valiente (heroico)|||||||||||||heroa|urhea (sankarillinen)|bohaterski, heroiczny, odważny, brawurowy
-Virgin nesia|Virgin nesia|desh|VI||Virgin Islands, US||Islas Vírgenes|||||||||||||||Wyspy Dziewicze USA
+Virjin nesia|Virjin nesia|desh|VI||Virgin Islands, US||Islas Vírgenes|||||||||||||||Wyspy Dziewicze USA
 virus:|virus|||eng:spa:fra:may:virus, por:vírus, rus:вирус (virus), tur:virüs, hin:वाइरस (vāirasa), jpn:ウイルス (uirusu)|virus|virus|virus||вирус||||||||||||virus|wirus
 virus.loj:ia|viruslojia|||pol:wirusologia, rus:вирусология (virusologiya)|virology||virología||вирусология||||||||||||virologia|wirusologia
 vis:|vis||||alternative (substitute, replacement)||alternativa (sustituto)|||||代替||||||||||alternatywa (substytut, zastępstwo)
@@ -3582,7 +3583,7 @@ Xampan|Xampan|regia|||Champagne|Champagne|Champaña|Champagne|Шампань|||�
 Xampan vin|Xampan vin|alkohol|||champagne|Champagner|champagne|champaña|champanhe|шампанское|||||||||||ĉampano|samppanja
 xamyam|xamyam||||dinner||cena|||||夕食||||||||vespermanĝo|illallinen|kolacja
 xan|xan|||zho:山 (shān), jpn:山 (san), kor:산 (san), vie:sơn|mountain (hill)||montaña (colina)|||||||||||||monto|vuori (mäki)|góra, wzgórze
-Xanghai|Xanghai||||Shanghai||||||上海|||||||||||Szanghaj
+Xanghay|Xanghay||||Shanghai||||||上海|||||||||||Szanghaj
 xante|xante||||rest (relief, repose)|repos|descanso (alivio)|descanso (repouso)|отдых||||||||||||lepo|zostawić (zostawiać)
 xanti|xanti|||hin:शांति (shānti), ben:শান্তি (shānti), pan:ਸ਼ਾਂਤੀ (shāntī), mar:शांत (shānta), tel:శాంతి (shānti), guj:શાંતિ (shānti), khm:សន្តិ (sɑnte’), eng:por:shanti, rus:шанти (shanti), jpn:シャンティ (shanti)|calm (peaceful, quiet)|calme (tranquille)|tranquilo (calmado)|tranquilo (calmo)|спокойный||||||शांत|||||trankvila (serena)|rauhallinen (levollinen, tyyni)|spokojny
 xarke|xarke|biw|Selachimorpha|eng:shark, hin:शार्क (shaark), pan:ਸ਼ਾਰਕ (śāraka), mar:शार्क (śārka)|shark|requin|tiburón|tubarão|акула||鲨鱼 (shayu)|サメ||||||||||rekin
@@ -3633,7 +3634,6 @@ xite|xite|||eng:shit, zho:屎 (shǐ), yue:屎 (si2)|shit (feces)|merde|mierda|m
 xix|xix|||tur:şiş + eng:shish-, rus:шиш- (šiš-)|skewer|brochette|brocheta||||扦子|||xiên|||||şiş||varras|rożen (szpikulec)
 xixkababe|xixkababe||||shish kebab||||шиш-кебаб||||||||||şiş kebap||varraskebab|szisz kebab
 xixmanse|xixmanse||||shashlik|chachlik|||шашлык||串烧||||||sate||şişlik|ŝaŝliko|saslik|szaszłyk
-Xkip:ia|Xkipia|desh|AL||Albania||Albania||||||||||||||Albania|Albania
 xofa|xofa||||drive (steer)||conducir|conduzir|||开车|||||||||konduki|ajaa (kuskata)|prowadzić pojazd
 xofer|xofer|||fra:eng:deu:chauffeur, spa:por:chofer, rus:шофёр (šofjor), pol:szofer, tha: โชเฟอร์ (chofoe), tur:şoför, fas:(šofer)|chauffeur (driver)||conductor (chofer)|condutor (chofer, motorista)|шофёр||司机||||||||sürücü (şoför)|ŝoforo (kondukisto)|kuski (ajuri, ajaja)|szofer (kierowca)
 xogun|xogun|||jpn:将軍 (shōgun), eng:shogun|shogun||sogún|||||||||||||||szogun
@@ -3644,7 +3644,6 @@ xope|xope|||eng:fra:spa:shopping, jpn:ショッピング (shoppingu), kor:쇼핑
 xoper|xoper||||buyer||comprador|||||||||||||aĉetanto (aĉetisto)|ostaja|nabywca (kupiec)
 xow|xow|||eng:deu:fra:spa:por:show, rus:шоу (šou), tur:şov, swa:shoo, tha:โชว์ (choo), kor:쇼 (syo), jpn:ショー (shō), zho:秀 (xiù)|show (display, exhibition)||exposición (espectáculo)|||||||||||||montri (ekspozicii)|näytös (esitys, show)|pokaz, ekspozycja, wystawa
 xowa|xowa||||show (display, demonstrate)||mostrar||доказать (демонстрировать)|||見せる (示す, デモる)|||||||||näyttää|pokazać, pokazywać, wystawić, wystawiać
-Xri Lanka|Xri Lanka|desh|LK||Sri Lanka (Ceylon)||Sri Lanka||||||||||||||Sri Lanka|Sri Lanka
 xudu|xudu|||eng:should|should (ought)||deber (se recomienda)|||||||||||||devus|pitäisi|powinien
 xukar:|xukar|||ara:(sukkar), swa:sukari, por:açúcar, spa:azúcar, hin:शक्कर (śakkar), ben:শর্করা (śôrkôra), tur:şeker, tam:சக்கரை (cakkarai)|sugar|sucre|azúcar|açúcar|сахар|سُكَّر|糖|砂糖|||शक्कर|চিনি (শর্করা)|sakar|sukari|şeker|sukero|sokeri|cukier
 xukar:i|xukari||||sugary (sweet)||azucarado||||||||||||||sokerinen (makea)|słodki

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -832,7 +832,7 @@ Espan:ia|Espania|desh|ES||Spain||España|||||||||||||Hispanio|Espanja|Hiszpania
 espan.o.fon:i|espanofoni||||hispanophone (Spanish speaking)||||||||||||||||espanjaa puhuva|
 esperant:i|esperanti||||Esperanto||Esperanto|||||||||||||Esperanto|esperanto|Esperanto
 esponj:e|esponje|biw||ell:σφουγγάρι (sphoungári), eng:sponge, spa:por:esponja, tur:süngre, ara:إسفنج (ʾisfanj), fas:اسفنج‎ (esfanj), hin:स्पंज (spanja), jpn:スポンジ (suponji), may:spon|sponge|éponge|esponja|esponja|губка||海绵|スポンジ (海綿)|||||||||sienieläin|gąbka
-Est:e|Este|desh|EE||Estonia||Estonia|||||||||||||Estonio|Viro (Eesti)|Estonia
+Est:ia|Estia|desh|EE||Estonia||Estonia|||||||||||||Estonio|Viro (Eesti)|Estonia
 estad:ia|estadia|||fra:stade, por:estádio, spa:estadio, rus:стадион (stadion), eng:stadium, tur:stadyum, ara:(ʾistād), hin:स्टेडियम (sṭeḍiyam)|stadium (arena)||estadio (arena)|||||||||||||stadiono (areno)|stadioni (areena)|stadion, arena
 estan:|estan|mate|Sn|spa:estaño, por:estanho, fra:étain, ita:stagno, eng:tin|tin|étain|estaño|estanho|||锡|珍|||||||||tina|cynk
 estas:a|estasa||||hold (detain)||mantener (detener)||||||||||||||seisottaa|zatrzymać (zatrzymywać, wstrzymać, wstrzymywać)
@@ -2040,7 +2040,6 @@ m:i|mi||||my||mi|||||私の||||||||mia|minun|mój
 m.o.m:e|mome|pron.|||we|nous|nosotros|nós|мы|نَحْنُ|我们|私たち|||हम|আমরা|kami (kita)|||ni|me|my
 Madagaskar:|Madagaskar|desh|MG||Madagascar||Madagascar||||||||||||||Madagaskar|Madagaskar
 madagaskar:i|Madagaskari||||Malagasy||malgache||||||||||||||malagassi|madagaskarski; malagaski
-Madyar:ia|Madyaria|desh|HU||Hungary||Hungría||||||||||||||Unkari|Węgry
 mafan|mafan||||trouble (disturbance, bother)||problema (disturio)||||||||||||||vaiva (haitta)|problem, kłopot, zakłócenie
 mafana|mafana|||zho:麻煩 (máfan), yue:麻煩 (maa4 faan4), wuu:麻煩 (mo ve3)|bother||molestar (preocupar)||утруждать||||||||||||vaivata|przeszkodzić, przeszkadzać, robić kłopot
 mafanu|mafanu||||be bothered by (bother to, take the trouble to)||molestar en||утруждай|||悩む (わざわざする)||||||||||przejmować się (zawracać sobie głowę)
@@ -2052,6 +2051,7 @@ mageti|mageti||||magnetic||magnético||||||||||||||magneettinen|magnetyczny
 magi|magi||||magical||magical||||||||||||||taianomainen (maaginen)|magiczny
 magia|magia|||eng:magic, spa:por:magia, fra:magie, rus:ма́гия (mágija), rus:マジック (majikku)|magic||magia|||||||||||||magio|taika (taikuus, magia)|magia
 Magribe|Magribe|desh|MA||Morocco|Maroc|Marruecos|Marrocos|Марокко|المغرب‎|摩洛哥|モロッコ|모로코|Ma-rốc|मोरक्को|মরোক্কো|Moroko (Maghribi)|Moroko|Fas||Marokko|Maroko
+Magyar:ia|Magyaria|desh|HU||Hungary||Hungría||||||||||||||Unkari|Węgry
 maidan|maidan|||ara:(maydān), fas:(meydan), hin:मैदान (maidān), tur:meydan, swa:medani, rus:майдан (maydan)|field (square, plaza, maidan)|place|plaza|praça|площадь (сквер, майдан)||广场|広場|광장|quảng trường||||medani (uwazi)|meydan||kenttä (aukio)|skwer, plac
 maidanfobia|maidanfobia||||agoraphobia||agorafobia||||||||||||||agorafobia (avoimen paikan kammo)|agorafobia
 maidani|maidani||||open (wide, spacious)||abierto (extenso)||||||||||||||avara (aava)|otwarty (przestrzenny)

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -369,7 +369,7 @@ bind:e|binde|||hin:बिंदु (bindu), tha:พินทุ (pintu), eng:bin
 bir:|bir|||eng:beer, tur:bira, fra:bière, ara: بيرة (bīra), may:bir, hin:बियर (biyar), swa:bia, zho:啤(酒) pí(jiǔ), jpn:ビール (bīru)|beer|bière|cerveza (birra)|cerveja|пиво|بيرة|啤酒|ビール|||बियर||bir|bia||biero|olut (kalja)|piwo
 bir.kan:|birkan|||eng:bar, hin:बार (bār), spa:bar, zho:酒吧 (jiǔbā), rus:бар (bar)|bar (pub, beer house)||bar (pub)|||||||||||||drinkejo|baari (kapakka)|bar, knajpa
 bis:|bis|||bug:bissu|genderqueer (non-binary)||no binario (género)||||||||||||||muunsukupuolinen|genderqueer, niebinarny
-Bisau: Gin:ia|Bisau Ginia|desh|GW||Guinea-Bissau||Guinea-Bisáu||||||||||||||Guinea-Bissau|Guinea Bissau
+Bisaw: Gin:ia|Bisaw Ginia|desh|GW||Guinea-Bissau||Guinea-Bisáu||||||||||||||Guinea-Bissau|Guinea Bissau
 biskut:e|biskute|||eng:fra:biscut, por:biscoito, rus:бисквит (biskvit), tur:bisküvi, swa:biskuti, ara:بسكويت‎ (baskawīt), hin:बिस्कुट (biskuṭ), may:biskut, jpn:ビスケット (bisuketto)|biscuit (cookie)||galleta|||||||||||||biskvito (kuketo)|keksi (pikkuleipä)|biszkopt, ciastko
 bismut:e|bismute|mate|Bi||bismuth||bismuto|||||||||||||bismuto|vismutti|bizmut
 biw:|biw|||eng:deu:fra:spa:por:pol:may:swa:tur:bio-, rus:био- (bio-)|organism (organic life)|organisme|vida orgánica|organismo|организм||生物|生物|생물|sinh vật|जीव||organisme||organizma|organismo|orgaaninen elämä|życie organiczne
@@ -431,7 +431,7 @@ brox:|brox|||eng:brush, fra:brosse, ben:ব্রাশ (braś), hin:ब्र�
 brun:i|bruni|rang||fra:brun, ara:(bunniy), hin:भूरा (bhūrā), eng:brown|brown|brun (marron)|marrón|castanho (marrom)|коричневый|بُنِّيّ|棕色 (色)|茶色|갈색|nâu|भूरा||cokelat|kahawia|kahverengi|bruna|ruskea|brązowy, koloru kawy
 brun.alg:e|brunalge|biw|Phaeophyceae||brown algae|algues brunes|algas pardas||бурые водоросли|||褐藻||||||||||brunatnica
 brun.salmon:|brunsalmon|biw|Salmo trutta||brown trout|truite brune (truite de mer)|trucha marrón|truta-marrom|кумжа||褐鳟|ブラウントラウト|||||trout coklat|||||pstrąg potokowy
-Brunei:|Brunei|desh|BN||Brunei Darussalam||Brunei||||||||||||||Brunei|Brunei Darussalam
+Bruney:|Bruney|desh|BN||Brunei Darussalam||Brunei||||||||||||||Brunei|Brunei Darussalam
 buc:a|buca||||butcher|abattre|carnear (matar)|abater||||||||||||buĉi|teurastaa (lahdata)|
 buc.er:|bucer|||eng:butcher, fra:boucher, ita:beccaio, hin:बूचड़ (būcaṛ)|butcher|boucher|carnicero|açougueiro (talhante)|мясник|جَزَّار‎|屠夫|肉屋|푸주한|người hàng thịt|क़साई (बूचड़)||tukang daging|||buĉisto|teurastaja|
 buc.o.kan:|bucokan|||fas: سلاخ خانه‎ (sallâx-xâne), hin:बूचड़खाना (būcaṛkhānā), ben:কসাইখানা (kôśaikhana)|abattoir (slaughterhouse)|abattoir|matadero|matadouro|бойня||屠宰场|屠畜場|도살장|lò mổ|बूचड़खाना (कसाईखाना)|কসাইখানা|||mezbaha|buĉejo|teurastamo|
@@ -1418,7 +1418,7 @@ jam:a|jama||||collect (gather, bring together, assemble)||recoger (juntar, reuni
 jam:i|jami||||collective||colectivo|||||||||||||kolekta|kollektiivinen|zbiorowy, zbiorczy
 jam:ia|jamia|||ara:(jamʿiyya), hau:jam'iyya, swa:jamii, tur:camia|collection (congregation, assembly)||colección (grupo, conjunto, montón)||||||||||||||yhteisö (kokoontuminen, kollektiivi)|kolekcja, zbiór; zgromadzenie, zebranie
 jam.kard:e|||||trading card|carte à collectionner|cromo|cromo|||||||||||||keräilykortti|
-Jamai:ka|Jamaika|desh|JM||Jamaica||Jamaica|||||||||||||Jamajko|Jamaika|Jamajka
+Jamaika:|Jamaika|desh|JM||Jamaica||Jamaica|||||||||||||Jamajko|Jamaika|Jamajka
 jamp:a|jampa|||eng:jump, jpn:ジャンプ (janpu), kor:점프 (jŏmp), ben:ঝাঁপ (jhãpô), ass:জাঁপ (zãp)|jump||saltar (brincar)|||||||||||||salti|hypätä (hyppiä)|skoczyć, skakać
 jamul:|jamul|biw|Syzygium|hin:जामुन (jāmun), eng:jambul, por:jambolão, ara:جَمُّون (jammūn), swa:zambarau|jamul (jambul, rose apple)|prune de Java||jambolão (jambo)|джамболан||閻浮樹|フトモモ|||जामुन|||zambarau|||jambolaani|czapetka kuminowa
 jan:|jan|||zho:人 (rén), wuu人 (zén), jpn:人 (jin) + hin:जन (jan), ben:-জন (-jôn), tha:ชน (chon), khm:ជន (jon) + fra:gens, por:gente|person (people)|personne (gente)|persona (gente)|pessoa (gente)|||人|人||||||||persono|henkilö|osoba; ludzie
@@ -2907,14 +2907,13 @@ roketolancer|roketolancer||||rocket launcher|Lance-roquettes|lanzamisiles|lança
 rol|rol|||eng:role, fra:rôle, deu:Rolle, rus:роль (rol’), tur:rol, kat:როლი (roli), fas:رل‎ (rol)|role||papel||||||||||||||rooli (osa)|rola
 rola|rola||||act (play a role)||actuar (hacer un papel)|||||||||||||ludi rolon|näytellä|grać, odgrywać rolę
 roler|roler||||actor (actress)||actor (actriz)|||||||||||||aktoro (aktorino)|näyttelijä|akt, scena
-Roma|Roma|cite|IT||Rome|Rome|Roma|Roma|Рим|الروم|罗马|ローマ|||रोम||Roma|Roma|Roma|Romo|Rooma|
-Roma|Roma||||Rome||Roma||||||||||||||Rooma|Rzym
-Romania|Romania|desh|RO||Romania||Rumania||||||||||||||Romania|Rumunia
-romansa|romansa||||love romantically||amar románticamente||||||||||||||rakastaa romanttisesti|kochać romantycznie
-romansi|romansi||||romantic||romántico||романтический|||ロマンチック|||||romantik||romantik||romanttinen|romantyczny
-romansia|romansia||27 emotions|fra:eng:spa:por:romance, rus:роман (roman), tur:romans, may:roman, jpn:ロマンス (romansu), kor:로맨스 (romaenseu)|romance (romantic love)||romance||роман|||ロマンス|||||roman||romans||lempi (romanssi, rakkaus)|miłość romantyczna
-romi imperia|romi imperia||||Roman Empire||Imperio romano||||||||||||||Rooman valtakunta|Imperium Rzymskie
-romkamil|romkamil|biw|Chamaemelum nobile||Roman camomile|Camomille Romaine|manzanilla romana (camomila común)|camomila-romana|ромашка римская||果香菊|ローマンカモミール||||||||||rumian rzymski
+Roma:|Roma|cite|IT||Rome|Rome|Roma|Roma|Рим|الروم|罗马|ローマ|||रोम||Roma|Roma|Roma|Romo|Rooma|Rzym
+roma:i imper:ia|romai imperia||||Roman Empire||Imperio romano||||||||||||||Rooman valtakunta|Imperium Rzymskie
+roma.kamil:|rom.kamil:|biw|Chamaemelum nobile||Roman camomile|Camomille Romaine|manzanilla romana (camomila común)|camomila-romana|ромашка римская||果香菊|ローマンカモミール||||||||||rumian rzymski
+Roman:ia|Romania|desh|RO||Romania||Rumania||||||||||||||Romania|Rumunia
+romans:a|romansa||||love romantically||amar románticamente||||||||||||||rakastaa romanttisesti|kochać romantycznie
+romans:i|romansi||||romantic||romántico||романтический|||ロマンチック|||||romantik||romantik||romanttinen|romantyczny
+romans:ia|romansia||27 emotions|fra:eng:spa:por:romance, rus:роман (roman), tur:romans, may:roman, jpn:ロマンス (romansu), kor:로맨스 (romaenseu)|romance (romantic love)||romance||роман|||ロマンス|||||roman||romans||lempi (romanssi, rakkaus)|miłość romantyczna
 ros|ros|||fra:rosée, spa:rocío, rus:роса (rosa)|dew|rosée|rocío||роса|||||||||||roso|kaste|rosa
 rosta|rosta|||fra:rôtir, eng:roast, deu:rösten, ita:arrostare|roast|rôtir|asar (tostar)||||||||||||||paahtaa (paistaa)|piec
 rosti pang|rosti pang||||toast (toasted bread)||pan tostado||||||||||||||paahtoleipä|tost

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -219,7 +219,7 @@ avar:a|avara||||harm (damage)||dañar||||||||||||||vahingoittaa (vaurioittaa)|
 avar:i|avari||||damaged (corrupt)||dañado||||||||||||||vaurioitunut|
 avar.an:i|avarani||||harmful (damaging)||dañino (perjudicial)|||||||||||||damaĝa|vahingollinen (vaurioittava)|krzywdzący (szkodliwy)
 afgan:i|afgani||||Afghan|afghan|afgano|afegão|афганский||||||अफगानी|||||afgana|afgaani|afgański
-Afgan.istan:|Afganistan|desh|AF||Afghanistan|Afghanistan|Afganistán|Afeganistão|Афганистан||阿富汗|アフガニスタン|아프가니스탄||अफ़्ग़ानिस्तान||Afghanistan||Afganistan|Afganujo, Afganio|Afganistan|Afganistan
+Afgan:ia|Afgania|desh|AF||Afghanistan|Afghanistan|Afganistán|Afeganistão|Афганистан||阿富汗|アフガニスタン|아프가니스탄||अफ़्ग़ानिस्तान||Afghanistan||Afganistan|Afganujo, Afganio|Afganistan|Afganistan
 awakat:e|awakate|biw||nah:ahuakatl, spa:aguacate, por:abacate, tgl:abokado, jpn:アボカド (abokado), kor:아보카도 (abokado), fra:avocat, pol:awokado, kon:zavoká|avocado||aguacate|||||||||||||avokado|avokado|awokado
 Axur:|Axur|shefocite|||Assur||Assur (Ashur)||||||||||||||Assur|Aszur
 Axur:ia|Axuria|||akk:(aššur), ara:(aššur), hin:अश्शूर (aśśūr), fas:(āšūr)|Assyria||Asiria||||||||||||||Assyria|Asyria
@@ -1638,7 +1638,7 @@ kax.er:|kaxer||||cashier||cajero||||||||||||||kassanhoitaja|kasjer
 kay:a|kaya||||open||abrir|||||||||||||malfermi|aukaista (avata)|otworzyć, otwierać
 kay:i|kayi|||zho:开 (kāi), wuu:開 (khe1), jpn:開 (kai), kor:개 (gae), vie:khai, tha:ไข (kǎi), lao:ໄຂ (khai)|open (not closed)||abierto|||||||||||||malferma|auki (avoin)|otwarty, niezamknięty
 kay:u|kayu||||become open||abirse|||||||||||||malfermiĝi|aueta (avautua)|otworzyć się, otwierać się
-Kazak.istan|Kazakistan|desh|KZ||Kazakhstan||Kazajistán (Kazakistan)||||||||||||||Kazakstan|Kazachstan
+Kazak:ia|Kazakia|desh|KZ||Kazakhstan||Kazajistán (Kazakistan)||||||||||||||Kazakstan|Kazachstan
 kecape|kecape|||yue:茄汁 (kezap), eng:ketchup, hin:केचप (kecap), rus:кетчуп (ketčup), jpn:ケチャップ (kechappu), tgl:ketsap|ketchup||kétchup|||||||||||||keĉupo|ketsuppi|keczup
 keci|keci|||zho:客气 (kèqì), yue:客氣 (haak3 hei3), wuu:客氣 (khaq qi4)|polite||educado||||客气|||||||||ĝentila|kohtelias (kiltti)|uprzejmy
 keg:a|kega||||visit||visitar|||||||||||||vizito|käydä (vierailla)|odwiedzić, odwiedzać


### PR DESCRIPTION
zayo, dexnam kitabu no autosamo.  me suja mome nova lole pa uza ci kanun:

- Use the pronunciation of the place in the local language.
  - **Aiti**, **Kabu Verdi**, **Naijiria**
- Modify letters to match the native spelling, if that pronunciation is historical and forbidden by the local language's phonotactics. Also modify letters to match existing Pandunia words.
  - **Arhentina** -> **Argentina** (matches **argente**)
  - **Ostrailia** -> **Australia** (/au/ and /aː/ are the historical Latin pronunciations)
  - **Lihtenxtain** -> **Lihtenstain** (/s/ is the Proto-Germanic pronunciation and forbidden by German phonotactics)
- Replace any suffix that means "land" and is dropped in the demonym with **-ia**.
  - **Magyarorsag** -> **Magyaria** (**-orsag** means "land")
  - **Kanada** stays the same (**-a** does not mean "land")
  - **Island** stays the same (**-land** is not dropped in the demonym)
- Remove any prefix or circumfix that means "land" and is not present in the demonym.
  - **Bocwana** -> **Cwana** (**bo-** means "land")
  - **Sakartvelo** -> **Kartvel** (**sa- -o**) means "land")
- Remove any articles, as well as English, French, and Dutch plural suffixes.
  - **Alurdun** -> **Urdun** (**al-** means "the")
  - **El Salvador** -> **Salvador** (**el** means "the")
  - **Sexelz** -> **Sexel** (**-z** means "many")
- Use **-ia** if the official English name with **-ia**.
  - **Bosna** -> **Bosnia**
  - **Osteraih** -> **Ostria**
  - **Jayer** -> **Jayeria**
- Add epenthesis so that no syllable starts with more than two consonants or ends with more than one soft consonant.
  - **Nederland** -> **Nederlandia**
  - **Polske** okeyi
  - **Svenia** okeyi
