### PR TITLE
nove name ba baze di kimi mate

### DIFF
--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -8,7 +8,7 @@ achar|||fas:آچار (âčâr), hin:अचार (acār), ara:اچار‎ (əča
 achar di||||pickled|décapé (mariné)|encurtido||марино́ванный||||||||||||säilötty|kiszony (marynowany)
 achar hiyar||||gherkin (pickle)|concombre confit (cornichon)|pepinillo||||||||||||||suolakurkku (etikkakurkku)|korniszon
 achi|||spa:achís, zho: 阿嚏 (ātì), kor:에취 (echwi), rus:апчхи, vie:hắt xì, eng:achoo, fra:atchoum|sneeze (achoo)|éternuer (atchoum)|estornudar (achís)|espirrar|чихать||打喷嚏 (阿嚏)|||hắt xì||||||terni|aivastaa (atsii!)|kichać (apsik!)
-acini yum|yum 089|Ac||actinium|actinium|actinio|actínio|актиний|اكتنيوم|锕|アクチニウム|악티늄|actini|एक्टिनियम|অ্যাক্টিনিয়াম|aktinium|aktini|aktinyum|aktinio|aktinium|aktyn
+acini yum|yum 089|Ac|eng:actinium, fra:actinium, spa:actinio, por:actínio, rus:актиний, zho:锕 (ā), jpn:アクチニウム, kor:악티늄, vie:actini, hin:एक्टिनियम, ben:অ্যাক্টিনিয়াম, may:aktinium, swa:aktini|actinium|actinium|actinio|actínio|актиний|اكتنيوم|锕|アクチニウム|악티늄|actini|एक्टिनियम|অ্যাক্টিনিয়াম|aktinium|aktini|aktinyum|aktinio|aktinium|aktyn
 ada|||ara: عادة (ʿāda), hin:आदत (ādat), may:adat, tur:adet, swa:ada|habit (custom)|coutume|costumbre (hábito)|costume (hábito)|обычай (привычка)|عادة|习惯 (风俗)|習慣 (風俗)|습관 (풍속)|tập quán (phong tục)|आदत||adat|ada|adet|kutimo|tapa|nawyk (przyzwyczajenie)
 ada di||||ordinary (customary, habitual, normal)|ordinaire (habituel, normal)|ordinario (habitual)||||||||||beradat||||tavallinen|zwyczajny (rutynowy, normalny)
 adil|||ara: عدل (’adl), may:tur:adil, swa:adili + hin:अदालत (adālat)|just (fair, righteous)|juste|justo|justo|справедливый|عدل|公正地||||उचित||adil|adili|adil|justa|oikeudenmukainen|sprawiedliwy
@@ -60,7 +60,7 @@ alo romanse di||||heteroromantic|hétéroromantique (hétéromantique)|heterorro
 alo sekse di||||heterosexual|hétérosexuel|heterosexual|||||||||||||samseksema|heteroseksuaali|heteroseksualny
 alo sifa||||difference|différence|diferencia||||||||||||||erilaisuus (ero)|różnica
 alo sifa di||||different|différent|diferente||||||||||||||erilainen|różny (inny)
-alumin|yum 013|Al||aluminium|aluminium|aluminio|alumínio|алюминий|الومينيوم|铝|アルミニウム|알루미늄|nhốm|एल्युमिनियम|অ্যালুমিনিয়াম|aluminium|alumini|alüminyum|aluminio|alumiini|glin (aluminium)
+alumin|yum 013|Al|eng:aluminium, fra:aluminium, spa:aluminio, por:alumínio, rus:алюминий, zho:铝 (lǚ), jpn:アルミニウム, kor:알루미늄, vie:nhốm, hin:एल्युमिनियम, ben:অ্যালুমিনিয়াম, may:aluminium, swa:alumini|aluminium|aluminium|aluminio|alumínio|алюминий|الومينيوم|铝|アルミニウム|알루미늄|nhốm|एल्युमिनियम|অ্যালুমিনিয়াম|aluminium|alumini|alüminyum|aluminio|alumiini|glin (aluminium)
 alumin mate||||alum|alun|alumbre||||||||||||||aluna|
 alumin okside||||alumina (aluminum oxide)|alumine (oxyde d'aluminium)|alúmina||||||||||||||alumiinioksidi|
 ama|||spa:por:amar, fra:aimer|love (liking, affection)|amour (affection)|amor|amor|любовь||爱|愛|||मुहब्बत (अनुराग, पसंद)||cinta (kasih, asmara)|penzi (ashiki, upendo)|sevda (aşk)|amo|rakkaus (tykkääminen)|miłość (afekt)
@@ -76,7 +76,7 @@ amen shin di||||trusted|fiable (de confiance, fidèle, sûr, crédible)|||||||||
 Amerika|||eng:America, spa:por:América, rus:Америка (Amerika), tur:swa:may:Amerika, ara:أمريكا‎ (ʾamrīkā), hin:अमेरिका (amerikā), ben:আমেরিকা (amerika), jpn:アメリカ (amerika)|America (continent)|Amérique|América|||||||||||||Ameriko|Amerikka|Ameryka (kontynent)
 Amerika di||||American|américain|americano|||||||||||||amerika|amerikkalainen|amerykański
 Amerika Samoa|desha|AS||American Samoa|Samoa américaines|Samoa Americana||||||||||||||Amerikan Samoa|Amerykańska Samoa
-amerika yum|yum 095|Am||americium|américium|americio|amerício|америций|أمريكيوم|镅|アメリシウム|아메리슘|amerixi|अमेरिशियम|অ্যামেরিসিয়াম|amerisium|ameriki|amerikyum|americio|amerikium|ameryk
+amerika yum|yum 095|Am|eng:americium, fra:américium, spa:americio, por:amerício, rus:америций, zho:镅 (méi), jpn:アメリシウム, kor:아메리슘, vie:amerixi, hin:अमेरिशियम, ben:অ্যামেরিসিয়াম, may:amerisium, swa:ameriki|americium|américium|americio|amerício|америций|أمريكيوم|镅|アメリシウム|아메리슘|amerixi|अमेरिशियम|অ্যামেরিসিয়াম|amerisium|ameriki|amerikyum|americio|amerikium|ameryk
 amir|||ara: أَمْر‎ (ʾamr), fas: امر‎ (amr), tur:emir, swa:amiri, hau:umarni + eng:admiral, fra:amiral, spa:por:emir rus:эмир (emir)|order (command)||orden (mando, comando)|||||||||||amri|emir|ordono|käsky (komento)|rozkaz, komenda
 amir desha||||emirate|émirat|emirato||||||||||||||emiirikunta|emirat
 amir haki||||authority (power to give orders)||||||||||||||||käskyvalta|
@@ -149,9 +149,9 @@ arena|||spa:ita:arena, por:areia + eng:tur:arena, fra:arène, rus:арена (ar
 arena estade||||arena (stadium with a sand floor)|arène|||арена||||||||arena||||areena|
 arena petra||||sandstone|grès||||||砂岩|||||||||hiekkakivi|piaskowiec
 arena topo||||desert||desierto|||||||||||||dezerto|aavikko (hiekkaerämaa)|pustynia
-argente|yum 048|Ag|por:ita:argento, fra:argent, may:argentum|silver|argent|plata|prata|серебро|فضة|银|銀|은|bạc|चाँदी|রূপা|perak|agenti|gümüş|arĝento|hopea|srebro
+argente|yum 048|Ag|por:ita:argento, fra:argent, may:argentum, swa:agenti|silver|argent|plata|prata|серебро|فضة|银|銀|은|bạc|चाँदी|রূপা|perak|agenti|gümüş|arĝento|hopea|srebro
 Argentina|desha|AR||Argentina|Argentine|Argentina|||||||||||||Argentino|Argentiina|Argentyna
-argon|yum 018|Ar||argon|argon|argón|argon|аргон|أرجون|氩|アルゴン|아르곤|agon|ऑर्गन|আর্গন|argon|arigoni|argon|argono|argon|argon
+argon|yum 018|Ar|eng:argon, fra:argon, spa:argón, por:argon, rus:аргон, jpn:アルゴン, kor:아르곤, vie:agon, hin:ऑर्गन, ben:আর্গন, may:argon, swa:arigoni|argon|argon|argón|argon|аргон|أرجون|氩|アルゴン|아르곤|agon|ऑर्गन|আর্গন|argon|arigoni|argon|argono|argon|argon
 argu||||argument (rationale, grounds)|argument|argumento|argumento|аргумент (обосновани)|||||lí lẽ|||||||perustelu (argumentti)|argument
 Ariel|planete 7 lun 2|||Ariel||||||||||||||||Ariel|
 arka|||eng:arch, spa:por:arco, fra:arc, rus:арка (arka), may:arka|bow (arch, arc)|arc|arco|arco|лук (арка)||弓 (琴弓, 拱)|弓 (弓なり)|||||||||kaari|łuk
@@ -163,7 +163,7 @@ aroma||||smell (sniff)|sentir qqch|oler (olfatear)||понюхать||闻到|嗅
 aroma|||eng:spa:por:may:aroma, fra:arôme, deu:Aroma, rus:аромат (aromat), jpn:アロマ (aroma)|scent (odor, fragrance, aroma)|odeur|olor (aroma)|cheiro|запах (аромат)||气味|香り (匂い, 臭い)|||||||||haju|zapach (aromat, smród, odór)
 aroma||||smell (reek)|sentir qqch (avoir l'odeur de qqch)|oler (apestar)|cheirar|пахнуть||发臭|香る (匂う, 臭う)|||||||||haista|pachnieć
 aroma melon|bio|Cucumis melo, Makuwa||Korean melon||melón coreano|melão coreano|||香瓜|マクワウリ||||||||||melon koreański
-arsen yum|yum 033|As||arsenic|arsenic|arsénico|arsénic|мышьяк|زرنيخ|砷|ヒ素|비소|asen|आर्सेनिक|আর্সেনিক|arsen|aseniki|arsenik|arseno|arseeni|arsen
+arsen yum|yum 033|As|eng:arsenic, fra:arsenic, spa:arsénico, por:arsénic, zho:砷 (shēn), vie:asen, hin:आर्सेनिक, ben:আর্সেনিক, may:arsen, swa:aseniki|arsenic|arsenic|arsénico|arsénic|мышьяк|زرنيخ|砷|ヒ素|비소|asen|आर्सेनिक|আর্সেনিক|arsen|aseniki|arsenik|arseno|arseeni|arsen
 arte ja||||artist|artiste|artista|artista|художник (артист)||美术家||||कलाकार||seniman|mwanasanaa|sanatçı|artisto|taiteilija|artysta
 Artika|desha|||Arctic|arctique|Ártico||||||||||||||Arktis|Arktyka
 Artika Hai||||Arctic Ocean|océan Arctique|océano Ártico||||||||||||||Jäämeri|Ocean Arktyczny
@@ -183,7 +183,7 @@ Asia|||eng:spa:Asia, rus:Азия (Aziya), tur:Asya, ara:آسيا (ʾāsiyā), f
 askete|||eng:ascetic, spa:por:asceta, fra:ascéte, rus:аскет (asket)|ascetic|ascète|asceta|||||||||||||ascetiko|askeett|asceta
 asma|||fra:asthme, eng:asthma, spa:por:may:asma, pol:astma|asthma|asthme|asma|asma|астма||气喘||||श्वासरोग||bengek||astım|astmo|astma|astma
 aspirin|||eng:aspirin, spa:por:aspirina, fra:aspirine, rus:аспирин (aspirin), ara:أسبرين‎ (ʾasbirīn), hin:एस्पिरिन (espirin), zho:阿司匹林 (āsīpǐlín),  jpn:アスピリン (asupirin), swa:aspirini|aspirin|aspirine|aspirina|aspirina|аспирин||阿司匹林||||||aspirin|aspirini|aspirin|aspirino|aspiriini|aspiryna
-astatin|yum 085|As||astatine|astate|ástato|astato|астат(ин)|استاتين|砹|アスタチン|아스타틴|astatin|एस्टाटिन|অ্যাস্টাটিন|astatin|astatini|asatatin||astatiini|astat
+astatin|yum 085|As|eng:astatine, fra:astate, spa:ástato, por:astato, rus:астат(ин), zho:砹 (ài), jpn:アスタチン, kor:아스타틴, vie:astatin, hin:एस्टाटिन, ben:অ্যাস্টাটিন, may:astatin, swa:astatini|astatine|astate|ástato|astato|астат(ин)|استاتين|砹|アスタチン|아스타틴|astatin|एस्टाटिन|অ্যাস্টাটিন|astatin|astatini|asatatin||astatiini|astat
 astro||fra:astre, por:astro, eng:astro-||celestial body|astre (corps céleste)|cuerpo celeste|astro (corpo celeste)|небесное тело||天体|天体 ||||||||astro|taivaankappale|
 astro nave||||starship|astronef|astronave (nave estelar)|astronave|звездолёт||||||||||||tähtialus|
 astro nave ja||||astronaut|astronaute|astronauta|astronauta|астронавт||宇航员||||||||astronot|astronaŭto|astronautti (tähtimatkaaja)|astronauta
@@ -196,7 +196,7 @@ Atlanti Hai|||eng:Atlantic, spa:Atlántico, por:Atlântico, rus:Атлантич
 atlanti salmon|bio|Salmo salar||Atlantic salmon|saumon altentique|salmón del Atlántico||Атлантический лосось (сёмга)||大西洋鮭|タイセイヨウサケ|||||salmon Atlantik|||||łosoś atlantycki
 atom|||eng:tur:may:atom, spa:por:átomo, rus:атом (atom), swa:atomi, jpn:アトム (atomu)|atom|atome|átomo|||||||||||||atomo|atomi|atom
 audi|||eng:spa:fra:audio, por:áudio|hear (listen)||oír (escuchar)|||||||||||||aŭdi (aŭskulti)|kuulla (kuunnella)|usłyszeć, słyszeć; słuchać
-auro|yum 079|Au|ltn:aurum, por:ouro, spa:oro, fra:or, rus:аурум (aurum), may:aurum|gold|or|oro|ouro|золото|ذهب|金|金|금|vàng|सोना|গোল্ড|emas|dhahabu (auri)|altın|oro|kulta|złoto
+auro|yum 079|Au|ltn:aurum, por:ouro, spa:oro, fra:or, rus:аурум (aurum), may:aurum, swa:auri|gold|or|oro|ouro|золото|ذهب|金|金|금|vàng|सोना|গোল্ড|emas|dhahabu (auri)|altın|oro|kulta|złoto
 Australia|desha|AU||Australia|Australie|Australia|||||||||||||Aŭstralio|Australia|Australia
 Austronesi||||Austronesia|Austronésie|Austronesia|Austronésia|Австронезия||南岛|オーストロネシア|오스트로네시아|||||||Aŭstronezio|Austronesia|
 auto|||ell:αὐτός (aftós), eng:fra:spa:por:auto-, rus:авто- (avto-)|self (identity)||mismo (yo)|||||自己|||||||||itseys|jaźń (tożsamość)
@@ -275,7 +275,7 @@ barde|||fra:barbe, spa:por:barba, deu:Bart, eng:beard, rus:борода (boroda)
 bari|||hin:भारी (bhārī), ben:ভারী (bharī), may:berat, tel:బరువు (baruvu), fas: بار‎ (bâr), ell: βαρύς (barýs) + kor:바리 (bari)|heavy (requiring much effort, hard, difficult, serious, important, etc.)||||||||||||||||raskas (kova, vaativa, vaikea, jne.)|
 bari fon||||accent (stress)|accent|acento|acento|ударение||重音符号||||स्वर का चढ़ाव उतार||aksen|||akcento|painotus (aksentti)|akcent, nacisk
 bari metal||||heavy metal|métaux lourds|metal pesado|||||||||||||pezmetalo|raskasmetalli|metal ciężki
-bari yum|yum 056|Ba||barium|baryum|bario|bário|барий|باريوم|钡|バリウム|바륨|bari|बेरियम|বেরিয়াম|barium|bari|baryum|bario|barium|bar
+bari yum|yum 056|Ba|eng:barium, fra:baryum, spa:bario, por:bário, rus:барий, zho:钡 (bèi), jpn:バリウム, kor:바륨, vie:bari, hin:बेरियम, ben:বেরিয়াম, may:barium, swa:bari|barium|baryum|bario|bário|барий|باريوم|钡|バリウム|바륨|bari|बेरियम|বেরিয়াম|barium|bari|baryum|bario|barium|bar
 barka|||hau:barka, may:berkah, tur:tebrik, fas:(tabrik), ara:urd:(mubārak), swa:baraka, yor:alubarika|congratulate (bless)|féliciter|felicitar|||||||||||||gratuli|onnitella (siunata)|gratulować; błogosławić
 barka||||congratulations! (blessing, benediction)|Félicitations !|¡Felicitaciones!|||||||||||baraka|||onneksi olkoon!|gratulacje!
 Barti|desha|IN||India|Inde|India|||||||||||||Baratio|Intia|Indie
@@ -400,8 +400,8 @@ Benin|desha|BJ||Benin||Benín||||||||||||||Benin|Benin
 benzin|||deu:Benzin, spa:bencina, rus:бензин (benzin), tur:benzin, ara:بنزين (banzīn), hin:बेंज़ीन (benzīn), may:bensin, jpn:ベンジン (benjin), swa:benzini|gasoline (petrol)||gasolina (bencina)|||||||||||benzini|benzin|benzino|bensiini (bensa)|benzyna
 bere|||fra:béret, tur:bere, eng:beret, jpn:ベレー帽 (berē bō), zho:贝雷帽 (zh) (bèiléimào), rus:берет (beret)|beret||boina|||||||||||||bereto|baskeri (baretti)|beret
 beri|||deu:Beere, eng:berry, may:beri, hin:बेरी (berī), ben:বেরি (beri), jpn: ベリー (berī)|berry|baie|baya|baga|ягода|توت|浆果 (莓)|漿果 (ベリー )|||बेरी||beri||||marja|jagoda
-beril yum|yum 004|Be||beryllium|béryllium|berilio|berílio|бериллий|بيريليوم|铍|ベリリウム|베릴륨|berili|बेरिलियम|বেরিলিয়াম|berilium|berili|berilyum|berilio|beryllium|beryl
-berkli yum|yum 097|Bk||berkelium|berkélium|berkelio|berqueélio|берклий|بركليوم|锫|バークリウム|버클륨|beckeli|बर्केलियम|বার্কেলিয়াম|berkelium|berkeli|berkelyum|berkelio|berkelium|berkel
+beril yum|yum 004|Be|eng:beryllium, fra:béryllium, spa:berilio, por:berílio, rus:бериллий, zho:铍 (pí), jpn:ベリリウム, kor:베릴륨, vie:swa:berili, hin:बेरिलियम, ben:বেরিলিয়াম, may:berilium|beryllium|béryllium|berilio|berílio|бериллий|بيريليوم|铍|ベリリウム|베릴륨|berili|बेरिलियम|বেরিলিয়াম|berilium|berili|berilyum|berilio|beryllium|beryl
+berkli yum|yum 097|Bk|eng:berkelium, fra:berkélium, spa:berkelio, por:berqueélio, rus:берклий, zho:锫 (péi), jpn:バークリウム, kor:버클륨, vie:beckeli, hin:बर्केलियम, ben:বার্কেলিয়াম, may:berkelium, swa:berkeli|berkelium|berkélium|berkelio|berqueélio|берклий|بركليوم|锫|バークリウム|버클륨|beckeli|बर्केलियम|বার্কেলিয়াম|berkelium|berkeli|berkelyum|berkelio|berkelium|berkel
 Berlin|xefsite|DE||Berlin|||||||||||||||Berlino|Berlin|
 Bermuda|desha|BM||Bermuda||Bermuda||||||||||||||Bermuda|Bermudy
 bete|bio|Beta vulgaris subsp. vulgaris, Conditiva|eng:beet, spa:betabel, por:beterraba, fra:betterave, deu:Bete, jpn:ビート (bīto)|beetroot|betterave|remolacha||свёкла||甜菜頭|テーブルビート|||||||||juurikas|burak
@@ -431,7 +431,7 @@ bir|||eng:beer, tur:bira, fra:bière, ara: بيرة (bīra), may:bir, hin:बि
 bir kan|||eng:bar, hin:बार (bār), spa:bar, zho:酒吧 (jiǔbā), rus:бар (bar)|bar (pub, beer house)||bar (pub)|||||||||||||drinkejo|baari (kapakka)|bar, knajpa
 Bisau Ginia|desha|GW||Guinea-Bissau||Guinea-Bisáu||||||||||||||Guinea-Bissau|Guinea Bissau
 biskute|||eng:fra:biscuit, por:biscoito, rus:бисквит (biskvit), tur:bisküvi, swa:biskuti, ara: بسكويت‎ (baskawīt), hin:बिस्कुट (biskuṭ), ben:বিস্কুট (biśkuṭ), may:biskut, jpn:ビスケット (bisuketto), kor:비스켓 (biseuket)|biscuit (cookie)|biscuit|galleta|biscoito|печенье (бисквит)||饼干 (曲奇饼)|ビスケット (クッキー)|비스켓 (쿠키)||बिस्कुट|মিষ্ট রূটি (বিস্কুট)|beskit (kue, kuih)|biskuti|bisküvi|biskvito (kuketo)|keksi (pikkuleipä)|biszkopt, ciastko
-bismute|yum 083|Bi||bismuth|bismuth|bismuto|bismuto|висмут|بزموث|铋|ビスマス|비스무트|bitmut, bismut|बिस्मथ|বিসমাথ|bismut|bismuthi|bizmut|bismuto|vismutti|bizmut
+bismute|yum 083|Bi|eng:bismuth, fra:bismuth, spa:bismuto, por:bismuto, rus:висмут, zho:铋 (bì), jpn:ビスマス, kor:비스무트, vie:bitmut, bismut, hin:बिस्मथ, ben:বিসমাথ, may:bismut, swa:bismuthi|bismuth|bismuth|bismuto|bismuto|висмут|بزموث|铋|ビスマス|비스무트|bitmut, bismut|बिस्मथ|বিসমাথ|bismut|bismuthi|bizmut|bismuto|vismutti|bizmut
 bizar|||eng:fra:bizarre, por:bizarro, deu:bizarr|odd (strange, weird)||raro (extraño)|||||||||||||stranga|outo (kummallinen)|dziwny
 biznes|||eng:business, rus:бизнес (biznes), may:bisnes, jpn:ビジネス (bijinesu)|business (commercial activity)||negocios (comercio)||предприятие (бизнес)|||業務 (営業, ビジネス)|||व्यवसाय|||||negoco|liiketoiminta (bisnes)|biznes, interes (aktywność komercyjna)
 biznes ja||||businessperson (businessman)||empresario|||||||||||||komercisto|liikemies|osoba biznesu, biznesman
@@ -466,10 +466,10 @@ bon sifa ta||||excellence (quality, virtue)||calidad (excelencia, mérito, virtu
 bon sin di||||auspicious (promising)|propice|auspicioso (propicio)||благоприятный||吉利的||||||||||lupaava (hyvältä vaikuttava)|obiecujący (dobrze wróżący)
 bon vide di||||beautiful (handsome, good-looking)||guapo (bien parecido)||||好看|||||||||bonaspekta|hyvännäköinen (kaunis, komea)|przystojny, atrakcyjny, ładny
 bon zar||||good luck||buena suerte||||||||||||||hyvä onni (tuuri, säkä, lykky)|dobry los, szczęście
-bor yum|yum 107|Bh||bohrium|bohrium|bohrio|bóhrio|борий|بوريوم||ボーリウム|보륨|bohri|बोरियम|বোহরিয়াম|bohrium|bohri|bohriyum|borio|bohrium|bohr
+bor yum|yum 107|Bh|eng:bohrium, fra:bohrium, spa:bohrio, por:bóhrio, rus:борий, zho: (bō), jpn:ボーリウム, kor:보륨, vie:bohri, hin:बोरियम, ben:বোহরিয়াম, may:bohrium, swa:bohri|bohrium|bohrium|bohrio|bóhrio|борий|بوريوم||ボーリウム|보륨|bohri|बोरियम|বোহরিয়াম|bohrium|bohri|bohriyum|borio|bohrium|bohr
 bori||27 emotions||boredom||aburrimiento||||||||बोरियत|||||enuo|tylsyys (pitkästys)|nuda (znudzenie)
 bori di|||eng:bored, spa:aburrido, hin:(bhorī)|bored||aburrido|||||||||||||enui|pitkästynyt|znudzony
-boron|yum 005|B||boron|boron|boro|boro|бор|بورون|硼|ホウ素|붕소|bo|बोरॉन्|বোরন|boron|boroni|bor|boro|boori|bor
+boron|yum 005|B|eng:boron, fra:boron, spa:boro, por:boro, rus:бор, vie:bo, hin:बोरॉन्, ben:বোরন, may:boron, swa:boroni|boron|boron|boro|boro|бор|بورون|硼|ホウ素|붕소|bo|बोरॉन्|বোরন|boron|boroni|bor|boro|boori|bor
 Bosna e Hercegovina|desha|BA||Bosnia and Herzegovina||Bosnia y Herzegovina||||||||||||||Bosnia ja Hertsegovina|Bośnia i Harcegowina
 Bote|desha||tib:བོད (bod, phø)|Tibet||Tíbet|||||||||||||Tibeto|Tiibet|Tybet
 botel|||eng:bottle, fra:bouteille, spa:botella, por:botelha, rus:бутылка (butylka), hin:बोतल (botal), ben:বোতল (botôl), may:botol|bottle|bouteille|botella|garrafa (botelha)|бутылка||瓶|瓶|병|chai|शीशी (बोतल)|বোতল|botol|chupa|şişe|botelo|pullo|butelka
@@ -483,7 +483,7 @@ Brazavil Kongo|desha|CG||Congo (Brazzaville)||República del Congo||||||||||||||
 Brazil|desha|BR||Brazil||Brasil|||||||||||||Brazilo|Brasilia|Brazyla
 briko|pal||ara:(barqūq), pa:albaricoque, fra:abricot, rus:абрикос (abrikos), tgl:albarikoke, swa:aprikoti|apricot (plum, peach)|abricot (prune)|albaricoque (ciruela)|damasco (abricó, ameixa)|абрикос (слива)||杏子 (李子)|アンズ (梅, モモ, プラム)|자두|mận|ख़ूबानी (आलूचा)|খুবানি||aprikoti|kayısı (zerdali, erik)|abrikoto (pruno)|aprikoosi (luumu)|morela (śliwka)
 Britan|desha|GB||United Kingdom||Reino Unido||||||||||||||Iso-Britannia (Yhdistyneet Kuningaskunnat)|Zjednoczone Królestwo
-brom|yum 035|Br||bromine|brome|bromo|bromo|бром|بروم|溴|臭素|브롬, 2브로민|brom|ब्रोमिन|ব্রোমিন|brom|bromi|brom|bromo|bromi|brom
+brom|yum 035|Br|eng:bromine, fra:brome, spa:bromo, por:bromo, rus:бром, kor:브롬, vie:brom, hin:ब्रोमिन, ben:ব্রোমিন, may:brom, swa:bromi|bromine|brome|bromo|bromo|бром|بروم|溴|臭素|브롬|brom|ब्रोमिन|ব্রোমিন|brom|bromi|brom|bromo|bromi|brom
 brosha|||eng:brush, fra:brosse, spa:por:brocha, jpn:ブラシ (burashi), kor:브러시 (beureosi), hin:ब्रश (braś), ben:ব্রাশ (braś), hau:swa:burashi, fas:(boros), may:berus, ara: فُرْشَاة‎ (furšāh), tur:fırça|brush|brosse|cepillo (brocha)|brocha (pincel)|щётка|فُرْشَاة‎|笔||||ब्रश|ব্রাশ||burashi|fırça|broso|harja|szczotka
 brosha kalam||||inkbrush (calligraphy brush)||||||毛笔|筆 (毛筆)|||||||||mustesivellin|
 Brunei|desha|BN||Brunei Darussalam||Brunei||||||||||||||Brunei|Brunei Darussalam
@@ -517,8 +517,8 @@ buyu|bio||swa:mbuyu, wol:buy, sna:muuyu, zul:isimuhu|baobab||baobab|||||||||||||
 C||||C|C|C|C|C|C|C|C|C|C|C|C|C|C|C|C|C|C
 celsius darje|unomete|°C||degree Celsius||grado Celsius||||||||||||||celsiusaste|stopień Celsjusza
 Ceres||||Ceres (dwarf planet)||Ceres (planeta enano)|||||||||||||Cereso|Ceres|Ceres (planeta karłowata)
-ceres yum|yum 058|Ce||cerium|cérium|cerio|cério|церий|سيريوم|铈|セリウム|세륨|xeri|सेरियम|সেরিয়াম|serium|seri|seryum|cerio|cerium|cer
-cesi yum|yum 055|Cs||caesium|césium|cesio|césio|цезий|سيزيوم|铯|セシウム|세슘|xezi, xêzi|सीज़ियम|সিজিয়াম|sesium|sizi|sezyum|cezio|cesium|cez
+ceres yum|yum 058|Ce|eng:cerium, fra:cérium, spa:cerio, por:cério, rus:церий, zho:铈 (shì), jpn:セリウム, kor:세륨, vie:xeri, hin:सेरियम, ben:সেরিয়াম, may:serium, swa:seri|cerium|cérium|cerio|cério|церий|سيريوم|铈|セリウム|세륨|xeri|सेरियम|সেরিয়াম|serium|seri|seryum|cerio|cerium|cer
+cesi yum|yum 055|Cs|eng:caesium, fra:césium, spa:cesio, por:césio, rus:цезий, zho:铯 (sè), jpn:セシウム, kor:세슘, vie:xezi, hin:सीज़ियम, ben:সিজিয়াম, may:sesium, swa:sizi|caesium|césium|cesio|césio|цезий|سيزيوم|铯|セシウム|세슘|xezi, xêzi|सीज़ियम|সিজিয়াম|sesium|sizi|sezyum|cezio|cesium|cez
 chabi|||por:chave, spa:llave, hin:चाबी (cābī), ben:চাবি (cabi), kon:nsapi|key|clef|llave|chave|ключ|مِفْتَاح‎|钥匙|鍵|열쇠|chìa khoá|चाबी|চাবি|kunci|ufunguo|anahtar|ŝlosilo|avain|klucz
 Chade|desha|TD||Chad||Chad||||||||||||||Tšad|Czad
 chai|||zho: 茶 (chá), jpn: (cha), kor:차 (cha), vie:trà, tur:çay, swa:chai, rus:чай (čay), hin:चाय (cāy), ara:(šāy), por:chá|tea|thé|té|chá|чай|شَاي|茶|茶|다 (차)|chè(trà)|चाय||teh|chai|çay|teo|tee|herbata
@@ -590,7 +590,7 @@ Chosen|desha||kor:조선 (Joseon), jpn:朝鮮 (chōsen), zho:朝鲜 (zh) (Cháox
 chosen di||||Korean||coreano||||||||||||||korealainen|koreański
 chum|||hin:चूमना (cūmnā), urd:(cūmnā), mal:ചുംബനം (cumbanaṃ), may:cium, jpn:チュー (chū), tha:จูบ (cup)|kiss||beso|||||||||||||kiso|suukko (pusu)|całus
 chun|||zho:村 (cūn), yue:村 (cyun1), jpn:村 (son), kor:촌 (chon), vie:thôn|village|village|aldea|aldeia (vila)|деревня (село)|قَرْيَة‎|村|村|마을 (촌락)|làng (thôn)|गांव (देहात)|গ্রাম|desa|kijiji|köy|vilaĝo|kylä|wieś, wioska
-chupa|||spa:por:chupar, khm:ជប់ (cup)|suck (absorb)||chupar (succionar)|||||||||||||suĉi|imeä|ssać
+chupu|||spa:por:chupar, khm:ជប់ (cup)|suck (absorb)||chupar (succionar)|||||||||||||suĉi|imeä|ssać
 chuti|||zho:出 (chū), yue:出 (ceot1), wuu:出 (tsheq4), hak:出 (chut), jpn:出 (shutsu), kor:출 (chul), vie:xuất, hin:छूटना (chūtnā) + tur:çıkmak|exit (leaving)||escapatoria|||||||||||||eliro|poistuminen|wyjśćie, opuszczenie
 chuti mun||||exit door||salida|||||||||||||elirejo|uloskäynti|drzwi wyjściowe
 chuze|||eng:choose, + hin:चुनना (cunnā), + vie:chọn|choose (elect, select, pick)||elegir (escoger, seleccionar)|||||||||||||elekti|valita|wybrać, wybierać, selekcjonować
@@ -642,7 +642,7 @@ darja|||ara:(daraja), hin:दर्जा (darjā), swa:daraja, tur:derece, fas:
 darja di||||gradual||||||||||||||||asteittainen (porrastettu)|stopniowy
 darja medan||||gradient (gradation, incline)||||||||||||||||kaltevuus|gradient (gradacja, stopniowanie)
 darja mute||||development|développement|desarrollo|desenvolvimento|развитие||发展 (开发)|発展 (開発)|발전 (개발)|sự phát triển|विकास|||||disvolvi|kehitys|rozwój
-darmestadi yum|yum 110|Ds||darmstadtium|darmstadtium|darmstatio|darmstádio|дармштадтий|دارمشتاتيوم||ダームスタチウム|다름슈타튬|darmstadti|डार्म्स्टेडशियम|ডারমস্টাডটিয়াম|darmstadtium|darmstadti|darmstadtiyum||darmstadtium|darmsztadt
+darmestadi yum|yum 110|Ds|eng:darmstadtium, fra:darmstadtium, spa:darmstatio, por:darmstádio, rus:дармштадтий, zho: (dá), jpn:ダームスタチウム, kor:다름슈타튬, vie:darmstadti, hin:डार्म्स्टेडशियम, ben:ডারমস্টাডটিয়াম, may:darmstadtium, swa:darmstadti|darmstadtium|darmstadtium|darmstatio|darmstádio|дармштадтий|دارمشتاتيوم||ダームスタチウム|다름슈타튬|darmstadti|डार्म्स्टेडशियम|ডারমস্টাডটিয়াম|darmstadtium|darmstadti|darmstadtiyum||darmstadtium|darmsztadt
 darte|||eng:dirt, hin:धरती (dhartī), urd:(dhartī), vie:đất, may:darat|soil (dirt)||tierra (barro)|||||土|||||||||maa (multa)|grunt (ziemia, próchnica)
 darte bon ja||||fertilizer||||||||||||||||lannoite|nawóz
 darte di||||soily (dirty)||sucio||||||||||||||likainen (mutainen)|ziemny (glebowy, gruntowy)
@@ -719,7 +719,7 @@ diorite|||eng:fra:diorite, spa:diorita, rus:диорит (diorit), tur:diyorit, 
 disha|||hin:mar:दिशा (diśā), urd:(diśā), mal:ദിശ (diśa), khm:ទិស (tɨh), tha:ทิศทาง (tit-taang)|direction||dirección||||||||||||||suunta|kierunek
 disha di||||directly||directamente||||||||||||||suoraan|wprost (bezpośrednio)
 diske|||eng:tur:disk, fra:disque, spa:por:disco, rus:диск (disk), hin:डिस्क (ḍisk), ben:ডিস্ক (ḑisk), jpn:ディスク (disuku), kor:디스크 (diseukeu)|disc (disk)|disque|disco|disco|диск|قُرْص|圆盘|ディスク (円盤)|디스크 (원반)|đĩa|डिस्क|ডিস্ক|cakram||disk|disko|kiekko (levy)|dysk
-disprosi yum|yum 066|Dy||dysprosium|dysprosium|disprosio|disprósio|диспрозий|ديسبروسيوم|镝|ジスプロシウム|디스프로슘|đysprosi, đisprozi|डिस्प्रोसियम|ডিসপ্রোসিয়াম|disprosium|disprosi|disprosyum|disprozio|dysprosium|dysproz
+disprosi yum|yum 066|Dy|eng:dysprosium, fra:dysprosium, spa:disprosio, por:disprósio, rus:диспрозий, zho:镝 (dī), jpn:ジスプロシウム, kor:디스프로슘, vie:đysprosi, hin:डिस्प्रोसियम, ben:ডিসপ্রোসিয়াম, may:disprosium, swa:disprosi|dysprosium|dysprosium|disprosio|disprósio|диспрозий|ديسبروسيوم|镝|ジスプロシウム|디스프로슘|đysprosi, đisprozi|डिस्प्रोसियम|ডিসপ্রোসিয়াম|disprosium|disprosi|disprosyum|disprozio|dysprosium|dysproz
 Divehi|desha|MV||Maldives||Maldivas||||||||||||||Malediivit|Malediwy (Republika Malediwów)
 do|prep.||rus:до (do) pol:do + zho:到 (dào), yue:到 (dou3)|to (toward, till, until, for)||a (hacia)||||到|||||||||al (ĝis, por)|luokse (tykö, kohti, asti)|do, dopóki, dla
 do ekso||||outward (external)||||||||||||||||ulkoinen|
@@ -776,7 +776,7 @@ du she sim||||dualism||dualismo||||||||||||||dualismi|dualizm
 du soni di||||stereophonic||||||||||||||||stereofoninen|
 dua||||pray (beg, entreat, implore)||rezar (orar)|||||||cầu nguyện||||||preĝi|rukoilla (anoa)|pomodlić się, modlić się
 dua|||ara: دُعَاء‏  (duʿāʾ), hin:दुआ (duā), swa:tur:dua, may:doa + zho:祈祷 (dǎo), jpn:禱 (tō), kor:도 (do)|prayer||rezo (oración)||||祈祷|祈祷|기도|||||||preĝo|rukous|modlitwa
-dubna yum|yum 105|Db||dubnium|dubnium|dubnio|dúbnio|дубний, ²нильсборий|دبنيوم||ドブニウム|더브늄|dubni|डब्नियम|ডুবনিয়াম|dubnium|dubni|dubniyum|dubnio|dubnium|dubn
+dubna yum|yum 105|Db|eng:dubnium, fra:dubnium, spa:dubnio, por:dúbnio, rus:дубний, ²нильсборий, zho: (dù), jpn:ドブニウム, kor:더브늄, vie:dubni, hin:डब्नियम, ben:ডুবনিয়াম, may:dubnium, swa:dubni|dubnium|dubnium|dubnio|dúbnio|дубний, ²нильсборий|دبنيوم||ドブニウム|더브늄|dubni|डब्नियम|ডুবনিয়াম|dubnium|dubni|dubniyum|dubnio|dubnium|dubn
 dudu|bio|Insecta|swa:mdudu, ara: دُود (dūd)|insect|insecte|insecto|inseto|насекомое||昆虫|昆虫|곤충|sâu bọ (côn trùng)|कीड़ा||serangga|mdudu|böcek|insekto|hyönteinen (ötökkä)|owad
 duka|||hin:दुःख (duḥkh), ben:দুঃখ (dukhô), tha:ทุกข์ (tuk), may:duka, eng:dukkha|grief (sorrow)||pena (tristeza)|||||||||||||malĝojo|suru (murhe)|żal, smutek
 duka di||||sad||triste|||||||||||||malĝoja|surullinen|smutny
@@ -812,7 +812,7 @@ E||||E|E|E|E|E|E|E|E|E|E|E|E|E|E|E|E|E|E
 e|funsi||fra:et, por:e, spa:y;e, zho:和 (hé)|and|et|y|e|||和|||||||||kaj|ja (sekä)|i, oraz
 e mas||||also (too)||además|||||||||||||ankaŭ|lisäksi (myös)|
 eglisa|||eng:ecclesia-, fra:église, spa:iglesia, por:igreja, hin:गिरजा (girjā), may:gereja, ara:(kanisā), swa:kanisa, tur:kilise|church||iglesia|||||||||||||preĝejo|kirkko|kościół
-einstein yum|yum 099|Es||einsteinium|einsteinium|einsteinium|einstânio|эйнштейний|انيشتنيوم|锿|アインスタイニウム|아인시타이늄 or 아인슈타이늄|ensteni|आइन्स्टाइनियम|আইনস্টাইনিয়াম|einsteinium|einsteni|eınsteınyum|ejnŝtejnio|einsteinium|einstein
+einstein yum|yum 099|Es|eng:einsteinium, fra:einsteinium, spa:einsteinium, por:einstânio, rus:эйнштейний, zho:锿 (āi), jpn:アインスタイニウム, kor:아인시타이늄, vie:ensteni, hin:आइन्स्टाइनियम, ben:আইনস্টাইনিয়াম, may:einsteinium, swa:einsteni|einsteinium|einsteinium|einsteinium|einstânio|эйнштейний|انيشتنيوم|锿|アインスタイニウム|아인시타이늄|ensteni|आइन्स्टाइनियम|আইনস্টাইনিয়াম|einsteinium|einsteni|eınsteınyum|ejnŝtejnio|einsteinium|einstein
 eko|||eng:spa:por:eco-, fra:éco-, deu:öko-, rus:эко-, tur:may:eko-|environment (nature)||medioambiente (naturaleza)|||||||||||||naturo|luonto|natura, środowisko
 eko di||||environmental (natural)||ambiental (ecológico, natural)||||||||||||||ympäristö- (luonto-)|środowiskowy, naturalny
 eko jene di||||wild (savage)|sauvage|salvaje||дикий|||野生|||||||||villi (villinä syntynyt)|dziki
@@ -859,14 +859,14 @@ english margarita|bio|Bellis perennis||English daisy|pâquerette|margarita comú
 eni|||eng:any|any (no matter which)||qualquier|||||||||||||iu ajn|mikä tahansa|jakikolwiek, którykolwiek
 enjener|||eng:engineer, spa:ingeniero, por:engenheiro, rus:инженер (inzhener), hin:mar:इंजीनियर (iñjīniyar), jpn:エンジニア (enjinia)|engineer||ingeniero||||||||||||||insinööri|inżynier
 enzim|||eng:fra:enzyme, spa:por:enzima, rus:энзим (enzim), tur:may:enzim, ara:انزيم‎, fas:آنزیم‎ (ânzim)|enzyme||enzima||||||||||||||entsyymi|enzym
-erbi yum|yum 068|Er||erbium|erbium|erbio|érbio|эрбий|إربيوم|铒|エルビウム|에르븀, 2어븀|eribi|अर्बियम|ইরবিয়াম|erbium|erbi|erbiyum|erbio|erbium|erb
+erbi yum|yum 068|Er|eng:erbium, fra:erbium, spa:erbio, por:érbio, rus:эрбий, zho:铒 (ěr), jpn:エルビウム, kor:에르븀, vie:eribi, hin:अर्बियम, ben:ইরবিয়াম, may:erbium, swa:erbi|erbium|erbium|erbio|érbio|эрбий|إربيوم|铒|エルビウム|에르븀|eribi|अर्बियम|ইরবিয়াম|erbium|erbi|erbiyum|erbio|erbium|erb
 Eris||||Eris (dwarf planet)||Eris (planeta enano)|||||||||||||Eris (planedeto)|Eris (kääpiöplaneetta)|Eris (planeta karłowata)
 Eritra|desha|ER||Eritrea||Eritrea|||||||||||||Eritreo|Eritrea|Erytrea
 esai|||eng:essay, spa:ensayo, por:ensaio, fra:essai, deu:Essay, rus:эссе (esse), jpn:エッセイ (essei)|essay||ensayo (redacción)||||||||||||||essee|esej
 eskale||||climb (get on)||escalar||подниматься|||上る (乗る, よじ登る)|||||||||kiivetä|wspinać się (wspiąć się)
 eskale|||fra:escalier, spa:escalera, por:escada, + eng:scale, deu:Skale, rus:шкала (škala)|stairs (ladder)||escalera|||||||||||||ŝtuparo|portaat (rappuset, tikkaat)|schody (drabina)
 eskale tana||||vine|vigne|enredadera|||||蔓草|||||||||köynnös|pnącz
-eskandi yum|yum 021|Sc||scandium|scandium|escandio|escândio|скандий|سكانديوم|钪|スカンジウム|스칸듐|scandi|स्काण्डियम|স্ক্যান্ডিয়াম|skandium|skandi|skandiyum|skandio|skandium|skand
+eskandi yum|yum 021|Sc|eng:scandium, fra:scandium, spa:escandio, por:escândio, rus:скандий, zho:钪 (kàng), jpn:スカンジウム, kor:스칸듐, vie:scandi, hin:स्काण्डियम, ben:স্ক্যান্ডিয়াম, may:skandium, swa:skandi|scandium|scandium|escandio|escândio|скандий|سكانديوم|钪|スカンジウム|스칸듐|scandi|स्काण्डियम|স্ক্যান্ডিয়াম|skandium|skandi|skandiyum|skandio|skandium|skand
 Eskandinavia||||Scandinavia|Scandinavie|Escandinavia||||||||||||||Skandinavia|Skandynawia
 Eskote|desha|||Scotland||Escocia||||||||||||||Skotlanti|Szkocja
 eskulte||||sculpture (statue)||escultura (estatua)|||||||||||||statuo (skultaĵo)|veistos (patsas)|rzeźba
@@ -879,12 +879,12 @@ esponje|bio||eng:sponge, spa:por:esponja, ara:إسفنج (ʾisfanj), fas:اسف�
 esporte|||eng:deu:fra:sport, spa:deporte, por:esporte, rus:спорт (sport), jpn:スポーツ (supōtsu), kor:스포츠 (seupocheu), hin:स्पोर्ट (sporṭ), swa:spoti, tur:spor|sport (athletics)|sport|deporte|esporte|спорт||||||स्पोर्ट|||spoti|spor|sporto|urheilu|sport, lekkoatletyka
 esporte ja||||athlete (sportsman)||deportista||||||||||||||urheilija|hałas
 estadi|||fra:stade, por:estádio, spa:estadio, rus:стадион (stadion), eng:stadium, tur:stadyum, ara:(ʾistād), hin:स्टेडियम (sṭeḍiyam)|stadium (arena)||estadio (arena)|||||||||||||stadiono (areno)|stadioni (areena)|stadion, arena
-estan|yum 050|Sn|spa:estaño, por:estanho, fra:étain, ita:stagno, eng:tin|tin|étain|estaño|estanho|олово|قصدير|锡|スズ|주석|thiếc|त्रपु|টিন|timah|stani (bati)|kalay||tina|cynk
+estan|yum 050|Sn|spa:estaño, por:estanho, fra:étain, ita:stagno, eng:tin, swa:stani|tin|étain|estaño|estanho|олово|قصدير|锡|スズ|주석|thiếc|त्रपु|টিন|timah|bati (stani)|kalay||tina|cynk
 estasi|||tur:istasyon, por:estação, spa:estación, tgl:estasyon, urd:(isṭeśan), eng:fra:station, hin:स्टेशन (sṭeśan), rus:станция (stantsiya)|station||estación|||||||||||||stacio|asema|stacja
 estasi di||||static (stationary)||estático (estacionario)||||||||||||||seisova (staattinen)|statyczny, stacjonarny, nieruchomy
 Esti|desha|EE||Estonia||Estonia|||||||||||||Estonio|Viro (Eesti)|Estonia
-estibi yum|yum 051|Sb||antimony|antimoine|antimonio|antimónio|сурьма|انتيمون|锑|アンチモン アンチモカ|안티몬, 2안티모니|antimon|एन्टिमोनी|অ্যান্টিমনি|antimon|stibi|antimon||antimoni|antymon
-estronti yum|yum 038|Sr||strontium|strontium|strontium|estrôncio|стронций|سترانشيوم|锶|ストロンチウム|스트논듐 or 스트론튬|stronti|स्ट्रोन्सियम|স্ট্রনসিয়াম|strontium|stronti|stronsiyum|stroncio|strontium|stront
+estibi yum|yum 051|Sb|zho:锑 (tī), swa:stibi|antimony|antimoine|antimonio|antimónio|сурьма|انتيمون|锑|アンチモン|안티몬|antimon|एन्टिमोनी|অ্যান্টিমনি|antimon|stibi|antimon||antimoni|antymon
+estronti yum|yum 038|Sr|eng:strontium, fra:strontium, spa:strontium, por:estrôncio, rus:стронций, zho:锶 (sī), jpn:ストロンチウム, kor:스트논듐, vie:stronti, hin:स्ट्रोन्सियम, ben:স্ট্রনসিয়াম, may:strontium, swa:stronti|strontium|strontium|strontium|estrôncio|стронций|سترانشيوم|锶|ストロンチウム|스트논듐|stronti|स्ट्रोन्सियम|স্ট্রনসিয়াম|strontium|stronti|stronsiyum|stroncio|strontium|stront
 estude||||study (work made in order to practise or demonstrate)|étude|||этюд||||||||||||tutkielma|
 estude ja||||student|étudiant|estudiante|estudante|студент||||||विद्यार्थी (स्टूडेंट)|ছাত্র (তালিব)|pelajar (murid)|mwanafunzi|öğrenci|studento|opiskelija|student
 estude kan||||studio||estudio||||||||||||||ateljee (studio)|studio (pracownia)
@@ -898,12 +898,12 @@ eu topo||||utopia||||||||||||||||utopia|
 Eurasia|||eng:spa:may:Eurasia, por:Eurásia, fra:Eurasie, rus:Евразия (Evraziya), tur:Avrasya, ევრაზია (evrazia), hye:Եվրասիա (Evrasia), ara:يُورَاسِيَا‎ (yūrāsiyā), hin:यूरेशिया (yūreśiyā), ben:ইউরেশিয়া (iureśiẏa), zho:歐亞大陸 (Ōuyà dàlù), jpn:ユーラシア (yūrashiya)|Eurasia||Eurasia|||||||||||||Eŭrazio|Euraasia|Eurazja
 eureka|||ell:ευρίσκω (evrísko), eng:spa:eureka, por:eureca, fra:eurêka, rus:эврика (evrika), tur:efreka, jpn:ユーレカ (yūreka)|find (discover)||econtrar (hallar)|||||||||||||trovi|löytää (keksiä)|znaleźć, znajdywać, odkryć, odkrywać
 euro||||euro (€)||euro|||||||||||||eŭro|euro (€)|euro (€)
-Europa|||eng:fra:Europe, spa:por:deu:pol:Europa, ell:Ευρώπη (Evrópi) rus:Европа (Evropa), tur:Avrupa, swa:Uropa, hin:यूरोप (yūrop), may:Eropah, zho:歐洲 (Ōuzhōu), jpn:ヨーロッパ (yōroppa)|Europe|Europe|Europa|||||||||||||Eŭropo|Eurooppa|Europa
-europa baluta|bio|Quercus robur||English oak|chêne pédonculé|roble común|carvalho-roble|дуб черешчатый||夏櫟|ヨーロッパナラ|||||||||tammi|dąb szypułkowy
-europa di||||European|européen|europeo|||||||||||||Eŭropa|eurooppalainen|europejski
-Europa luna|planete 5 lun 2|||Europa||||||||||||||||Europa-kuu|
-Europa Unta||||European Union (EU)||Unión Europea|||||||||||||Eŭropa Unio (EU)|Euroopan unioni|Unia Europejska (EU)
-europa yum|yum 063|Eu||europium|europium|europio|európio|европий|يروبيوم|铕|ユウロピウム|유로퓸|europi|युरोपियम|ইউরোপিয়াম|europium|europi|europyum|eŭropio|europium|europ
+Europa|planete 5 lun 2|||Europa||||||||||||||||Europa-kuu|
+europa yum|yum 063|Eu|eng:europium, fra:europium, spa:europio, por:európio, rus:европий, jpn:ユウロピウム, kor:유로퓸, vie:europi, hin:युरोपियम, ben:ইউরোপিয়াম, may:europium, swa:europi|europium|europium|europio|európio|европий|يروبيوم|铕|ユウロピウム|유로퓸|europi|युरोपियम|ইউরোপিয়াম|europium|europi|europyum|eŭropio|europium|europ
+Europe|||eng:fra:Europe, spa:por:deu:pol:Europa, ell:Ευρώπη (Evrópi) rus:Европа (Evropa), tur:Avrupa, swa:Uropa, hin:यूरोप (yūrop), may:Eropah, zho:歐洲 (Ōuzhōu), jpn:ヨーロッパ (yōroppa)|Europe|Europe|Europa|||||||||||||Eŭropo|Eurooppa|Europa
+europe baluta|bio|Quercus robur||English oak|chêne pédonculé|roble común|carvalho-roble|дуб черешчатый||夏櫟|ヨーロッパナラ|||||||||tammi|dąb szypułkowy
+europe di||||European|européen|europeo|||||||||||||Eŭropa|eurooppalainen|europejski
+Europe Unta||||European Union (EU)||Unión Europea|||||||||||||Eŭropa Unio (EU)|Euroopan unioni|Unia Europejska (EU)
 F||||F|F|F|F|F|F|F|F|F|F|F|F|F|F|F|F|F|F
 fa|||fra:faire, por:fazer, ita:fare + ara: فَعَلَ‎ (faʿala) + swa:fanya|do|faire|hacer|fazer|делать|فَعَلَ|作|する|하다|làm|करना|করা|buat|kufanya|yapmak|fari|tehdä (toimia)|zrobić (stworzyć, wykreować)
 fa achar||||pickle (preserve in vinegar or brine)||encurtir|||||酢漬けある|||||mengasamkan||||säilöä|kisić (marynować)
@@ -1191,8 +1191,8 @@ fen|||zho:分 (fèn), wuu:分 (fén), yue:分 (fan), vie:phần, tha:ปัน (
 fen di||||partial||parcial|||||部分的|||||||||osittainen|
 fen gata||||analysis (dissection)|analyse|análisis (disección)|análise|анализ||分析|分析 (解析)|||विश्लेषण||||analiz|analizo|analyysi|analiza
 fendona||||contribute||contribuir||||||||||||||osallistua (tehdä osansa)|wnieć wkład (przyczynić się)
-fermi yum|yum 100|Fm||fermium|fermium|fermio|férmio|фермий|فرميوم|镄|フェルミウム|페르뮴|fecmi|फर्मियम|ফার্মিয়াম|fermium|fermi|fermiyum|fermio|fermium|ferm
-feru|yum 026|Fe|spa:hierro, por:ferro, fra:fer, may:ferum|iron|fer|hierro|ferro|железо|حديد|铁|鉄|철|sắt|लोहा|আয়রন|besi|feri (chuma)|demir|fero|rauta|żelazo
+fermi yum|yum 100|Fm|eng:fermium, fra:fermium, spa:fermio, por:férmio, rus:фермий, zho:镄 (fèi), jpn:フェルミウム, kor:페르뮴, vie:fecmi, hin:फर्मियम, ben:ফার্মিয়াম, may:fermium, swa:fermi|fermium|fermium|fermio|férmio|фермий|فرميوم|镄|フェルミウム|페르뮴|fecmi|फर्मियम|ফার্মিয়াম|fermium|fermi|fermiyum|fermio|fermium|ferm
+feru|yum 026|Fe|spa:hierro, por:ferro, fra:fer, may:ferum, swa:feri|iron|fer|hierro|ferro|железо|حديد|铁|鉄|철|sắt|लोहा|আয়রন|besi (ferum)|chuma (feri)|demir|fero|rauta|żelazo
 festa|||por:festa, spa:fiesta, fra:fête, deu:Fest, eng:festival, rus:фестиваль (festival'), may:pesta|party (celebration, festival)||celebración (fiesta)||||||||||pesta|||festo|juhlat|przyjęcie, święto, festiwal
 festa den||||holiday||día festivo (feriado)||||||||||||||juhlapäivä|święto
 figur|||eng:fra:figure, spa:por:figura|figure (representation)||representación (figura)|||||||||||||figuro|hahmo (figuuri)|figura, reprezentacja
@@ -1226,8 +1226,8 @@ fizika shuta|||eng:physics, spa:por:física, rus:физика (fizika), tur:may:
 flame|||eng:fra:inflammation + zho:炎 (yán), yue:炎 (jim4), kor:염 (yeom), vie:viêm|inflammation (-itis)|inflammation|inflamación|inflamaçao|воспаление||炎症||||||||||tulehdus|zapalenie
 fleche|||spa:por:flecha, fra:flèche, eng:fletch|arrow (bolt)|flèche|flecha|flecha (seta)|стрела (стрелка)||箭|矢 (矢印)|||||||||nuoli|strzała (bełt)
 fleche ja||||fletcher||||||||||||||||nuolentekijä|wytwórca łuków i strzał
-flerof yum|yum 114|Fl||flerovium|flérovium|flerovio|fleróvio|флеровий|ٲنون كواديوم||フレロビウム|플레로븀|flerovi|||flerovium|flerovi|fleroviyum||flerovium|flerow
-flur|yum 009|F||fluorine|fluor|flúor|flúor|фтор|فلور|氟|フッ素|플루오르|flo|फ्लोरीन|ফ্লুরিন|fluor|florini|fluor|fluoro|fluori|fluor
+flerof yum|yum 114|Fl|eng:may:flerovium, fra:flérovium, spa:flerovio, por:fleróvio, rus:флеровий, zho: (fū), jpn:フレロビウム, kor:플레로븀, vie:flerovi, swa:flerovi|flerovium|flérovium|flerovio|fleróvio|флеровий|ٲنون كواديوم||フレロビウム|플레로븀|flerovi|||flerovium|flerovi|fleroviyum||flerovium|flerow
+flur|yum 009|F|eng:fluorine, fra:fluor, spa:flúor, por:flúor, rus:фтор, zho:氟 (fú), jpn:フッ素, kor:플루오르, vie:flo, hin:फ्लोरीन, ben:ফ্লুরিন, may:fluor, swa:florini|fluorine|fluor|flúor|flúor|фтор|فلور|氟|フッ素|플루오르|flo|फ्लोरीन|ফ্লুরিন|fluor|florini|fluor|fluoro|fluori|fluor
 fobi|||eng:-phobia, spa:por:may:-fobia, fra:deu:-phobie, rus:-фобия (-fobiya), tur:-fobi|fear (phobia)||miedo (-fobia)|||||||||||||timo (fobio)|kammo (fobia)|strach, fobia
 fobi di||||afraid (scared)||||||||||||||||pelokas|
 fobi ja||||scary (frightening)|effrayant|asustador|assustador|||||||||||korkutucu|timiga|pelottava|
@@ -1270,7 +1270,7 @@ France fon dunia||||Francophonie|francophonie|||||||||||||||ranskankielinen maai
 France Guyana|desha|GF||French Guiana||Guyana Francesa||||||||||||||Ranskan Guiana|Gujana Francuska
 france krepe|yam|||crepe|crêpe|crepa (crep, tortilla de trigo)|crepe||||||||||||franca krepo|kreppi|francuski naleśnik (crêpe)
 France Polinesi|desha|PF||French Polynesia|Polynésie française|Polinesia Francesa||||||||||||||Ranskan Polynesia|Polinezja Francuska
-france yum|yum 087|Fr||francium|francium|francio|frâncio|франций|فرنسيوم|钫|フランシウム|프랑슘|franxi|फ्रान्सियम|ফ্রান্সিয়াম|fransium|fransi|fransiyum|franciumo|frankium|frans
+france yum|yum 087|Fr|eng:francium, fra:francium, spa:francio, por:frâncio, rus:франций, zho:钫 (fāng), jpn:フランシウム, kor:프랑슘, vie:franxi, hin:फ्रान्सियम, ben:ফ্রান্সিয়াম, may:fransium, swa:fransi|francium|francium|francio|frâncio|франций|فرنسيوم|钫|フランシウム|프랑슘|franxi|फ्रान्सियम|ফ্রান্সিয়াম|fransium|fransi|fransiyum|franciumo|frankium|frans
 frem|||eng:frame, ben:ফ্রেম (phrēma), pan:ਫਰੇਮ (pharēma), mar:फ्रेम (phrēma), swa:fremu|frame|cadre|marco|moldura|рама||框|額||||||fremu|frame|kadro|kehys (raamit)|rama
 frike|||eng:friction, spa:por:friccionar, fra:frictionner + ara:فرك (farak)|rub (scrape, scrub)||raspar (arañar)||царапать||擦伤|擦る (擦り傷する)|||||||||hangata|trzeć (pocierać, obetrzeć, pucować)
 frute|||eng:fra:fruit, spa:por:fruta, rus:фрукт (frukt), jpn:フルーツ (furūtsu)|fruit|fruit|fruta|fruta|плод (фрукт)||果|果実 (フルーツ)|과일|quả|फल|ফল|buah|tunda|meyve|frukto|hedelmä|owoc
@@ -1305,11 +1305,11 @@ Gabon|desha|GA||Gabon||Gabón||||||||||||||Gabon|Gabon
 gabur|||ara:(qabr), hin:क़ब्र (qabra), ben:কবর (kôbôr), may:kubur, swa:kaburi, tur:kabir + deu:Grab, pol:grób, rus:гроб (grob)|grave (tomb, bury)|tombe (enterrer)|tumba (sepultura, enterrar)|sepultura (túmulo, enterrar)|могила (гроб, хоронить)||坟墓 (埋葬)|墓 (埋葬, 葬る)|무덤|mộ (phần mộ)|क़ब्र|কবর|kubur|kaburi|mezar (kabir)|tombo (enterigi)|hauta|grób (mogiła, grobowiec, zakopać, pochować)
 gabur bagi||||graveyard (cemetery, burial ground)|cimetière|cementerio|cemitério|кладбище|مقبرة‎|公墓 (墓地)|墓 (墓地)|묘지|nghĩa trang|क़ब्रिस्तान|কারবালা|pekuburan|makaburi|mezarlık (kabristan, mezaristan)|tombejo|hautausmaa|cmentarz
 gabur sheku||||tombstone (gravestone)|pierre tombale|lápida|lápide|надгробие||墓石 (墓碑)|墓石 (墓碑)|묘석|bia mộ|कब्र का पत्थर||batu nisan||mezartaşı|tomboŝtono|hautakivi|nagrobek
-gadolin yum|yum 064|Gd||gadolinium|gadolinium|gadolinio|gadolínio|гадолиний|جدولينيوم|钆|ガドリニウム|가돌리늄|gađolini|ग्याडोलिनियम|গ্যাডোলিনিয়াম|gadolinium|gadolini|gadolinyum|gadolinio|gadolinium|gadolin
+gadolin yum|yum 064|Gd|eng:gadolinium, fra:gadolinium, spa:gadolinio, por:gadolínio, rus:гадолиний, zho:钆 (gá), jpn:ガドリニウム, kor:가돌리늄, vie:gađolini, hin:ग्याडोलिनियम, ben:গ্যাডোলিনিয়াম, may:gadolinium, swa:gadolini|gadolinium|gadolinium|gadolinio|gadolínio|гадолиний|جدولينيوم|钆|ガドリニウム|가돌리늄|gađolini|ग्याडोलिनियम|গ্যাডোলিনিয়াম|gadolinium|gadolini|gadolinyum|gadolinio|gadolinium|gadolin
 gaja|||hin:गज (gaj), tel:గజము (gajamu), kan:ಗಜ (gaja), may:gajah, tgl:gadya|elephant||elefante|||||||||||||elefanto|norsu (elefantti)|słoń
 galaksi|||eng:galaxy, spa:galaxia, por:galáxia, fra:galaxie, rus:галактика (galaktika), tur:may:galaksi, hin:गैलेक्सी (gaileksī)|galaxy|galaxie|galaxia|galáxia|галактика||恆星系|銀河|은하|thiên hà|गैलेक्सी|ছায়াপথ|galaksi||galaksi|galaksio|galaksi|galaktyka
 galeri|||eng:gallery, spa:galería, por:galeria, fra:galerie, rus:галерея (galereya), tur:galeri, hin:गैलरी (gailrī), jpn:ギャラリー (gyararī)|gallery (exhibition hall)||galería|||||||||||||galerio (ekspozicio)|galleria|galeria, sala wystawowa
-gali yum|yum 031|Ga||gallium|gallium|galio|gálio|галлий|جاليوم|镓|ガリウム|갈륨|gali|गैलियम|গ্যালিয়াম|galium|gali|galyum|galiumo|gallium|gal
+gali yum|yum 031|Ga|eng:gallium, fra:gallium, spa:galio, por:gálio, rus:галлий, zho:镓 (jiā), jpn:ガリウム, kor:갈륨, vie:gali, hin:गैलियम, ben:গ্যালিয়াম, may:galium, swa:gali|gallium|gallium|galio|gálio|галлий|جاليوم|镓|ガリウム|갈륨|gali|गैलियम|গ্যালিয়াম|galium|gali|galyum|galiumo|gallium|gal
 Galia||||Gaul|Gaule|Galia|Gália|Галлия||高卢|ガリア||||||||Gaŭlio|Gallia|Galia
 galope|||eng:gallop, fra:galop, spa:por:galope, rus:галоп (galop)|canter and gallop|galop|galope|galope|кентер и галоп||||||||||||laukka|cwał (galop)
 galte|||ara:(ğalṭa), hin:ग़लती (ġaltī), swa:ghalati, tur:galat, fas:(ğalat),|mistake (error, fault, blunder, bug)|faute (erreur)|error|erro (falta)|||错误|間違い (誤り, バグ)|||ग़लती (भूल)||||yanlışlık (galat, erör)|eraro (miso)|virhe (erhe)|błąd (pomyłka)
@@ -1395,7 +1395,7 @@ geo politi||||geopolitics|géopolitique|geopolítica|geopolítica|геополи
 geo sismo||||earthquake||terremoto|||||||||||||tertremo|maanjäristys|trzęsienie Ziemi
 geo termo||||geothermal|géothermique|geotérmico||геотерма́льный||地热的||||||||||geoterminen (maalämpö-)|
 geo tika||||lot (plot of land)||terreno (solar)||||||||||||||tontti (maakaistale)|działka (teren)
-german yum|yum 032|Ge||germanium|germanium|germanio|germânio|германий|جرمانيوم|锗|ゲルマニウム|게르마늄, 2저마늄|gecmani|जर्मेनियम|জার্মেনিয়াম|germanium|gerimani|germanyum|germaniumo|germanium|german
+german yum|yum 032|Ge|eng:germanium, fra:germanium, spa:germanio, por:germânio, rus:германий, jpn:ゲルマニウム, kor:게르마늄, vie:gecmani, hin:जर्मेनियम, ben:জার্মেনিয়াম, may:germanium, swa:gerimani|germanium|germanium|germanio|germânio|германий|جرمانيوم|锗|ゲルマニウム|게르마늄|gecmani|जर्मेनियम|জার্মেনিয়াম|germanium|gerimani|germanyum|germaniumo|germanium|german
 Germania||||Germania|Germanie|Germania|Germânia|||||||||||||Germania|
 Gernezi|desha|GG||Guernsey||Guernesey||||||||||||||Guernsey|Guernsey
 gi|||zho:機 (jī), wuu:機 (ji1), yue:機 (gei1), jpn:機 (ki), kor:기 (gi), tha:กี่ (gìi) + jpn:器 (ki)|machine (device, aparatus)||máquina (dispositivo, aparato)|||||装置 (機, 器)||||||||maŝino|kone|maszyna
@@ -1488,7 +1488,7 @@ habar|||ara:(xabar), tur:haber, may:kabar, swa:habari, hin:ख़बर (xabar),
 habar gazeta||||newspaper (gazette)||periódico (diario)|||||||||||||gazeto|sanomalehti|gazeta
 habasha||||Abyssinian||abisinio||||||||||||||abyssinialainen|abisyński
 Habasha||||Abyssinia|Abyssinie|Abisinia|Abissínia|Абиссиния|الْحَبَشَة‎|阿比西尼亚|アビシニア|아비시니아||हबश||||Habeşistan||abyssinia|Abisynia
-hafen yum|yum 072|Hf||hafnium|hafnium|hafnio|háfnio|гафний|هفنيوم|铪|ハフニウム|하프늄|hafini|हाफ्नियम|হাফনিয়াম|hafnium|hafni|hafniyum|hafnio|hafnium|hafn
+hafen yum|yum 072|Hf|eng:hafnium, fra:hafnium, spa:hafnio, por:háfnio, rus:гафний, zho:铪 (hā), jpn:ハフニウム, kor:하프늄, vie:hafini, hin:हाफ्नियम, ben:হাফনিয়াম, may:hafnium, swa:hafni|hafnium|hafnium|hafnio|háfnio|гафний|هفنيوم|铪|ハフニウム|하프늄|hafini|हाफ्नियम|হাফনিয়াম|hafnium|hafni|hafniyum|hafnio|hafnium|hafn
 hafiza|||ara:(ḥafiẓa), fas:urd:(hāfiz), tur:muhafaza, hin:हाफ़िज़ (hāfīz), swa:hifadhi|keep (preserve, conserve, retain, spare)||conservar (preservar, mantener)||||||||||||||säilyttää (varjella, säästää)|zachować, zakonserwować, zachować, utrzymać
 hafiza ja||||keeper (preserver)||guarda (preservador, conservador)||||||||||||||säilyttäjä|przechowawca, kustosz, opiekun
 haha|||eng:fra:por:tur:haha, spa:jaja, rus:ха-ха (ha-ha), zho:哈哈 (hāhā), jpn:わはは (wa-ha-ha), ara:(hahah)|laugh|rire|reír|rir|смеяться||笑|笑う|웃다|cười|हँसना|হাসা|tawa|kuseka|gülmek|ridi|nauraa|śmiać się
@@ -1554,7 +1554,7 @@ Hayaki|desha|AM||Armenia||Armenia||||||||||||||Armenia|Armenia
 he|||eng:huh, fra:hein, por:hã, vie:hả, deu:hä|huh? (eh?, pardon?)|hein?|cómo? (eh?)|||||||||||||ĉu?|häh (-ko, -kö)|hę?, co?, pardon?
 Helen|desha|GR||Greece||Grecia|||||||||||||Grekio|Kreikka|Grecja
 Helen||||Greek (Hellenic)||griego (helénico)|||||||||||||greka|kreikkalainen|gracki, helleński; Grek
-heli yum|yum 002|He||helium|hélium|helio|hélio|гелий|هيليوم|氦|ヘリウム|헬륨|heli|हिलियम|হিলিয়াম|helium|heli|helyum|helio|helium|hel
+heli yum|yum 002|He|eng:helium, fra:hélium, spa:helio, por:hélio, rus:гелий, zho:氦 (hài), jpn:ヘリウム, kor:헬륨, vie:swa:heli, hin:हिलियम, ben:হিলিয়াম, may:helium|helium|hélium|helio|hélio|гелий|هيليوم|氦|ヘリウム|헬륨|heli|हिलियम|হিলিয়াম|helium|heli|helyum|helio|helium|hel
 helis|||ell: ἕλιξ (helix), eng:helix, fra:por:spa:hélice, pol:helisa, ara:(ḥalazūn), tur:helezon|spiral (helix, corkscrew, twist)||espiral (hélice)||||螺旋||||||||||kierre (spiraali)|helisa
 helis babul|bio|Vachellia tortilis||umbrella thorn acacia tree|acacia faux-gommier|acacia de copa plana||акация кручёная|||||||||||||
 helis fei gi||||helicopter|hélicoptère|helicóptero|hélicoptero|вертолёт||直升机|ヘリコプター|헬리콥터 (헬기)||हेलिकॉप्टर|হেলিকোপটার||||helikoptero|helikopteri|helikopter
@@ -1569,17 +1569,17 @@ hero di||||heroic||valiente (heroico)|||||||||||||heroa|urhea (sankarillinen)|bo
 hero kata||||saga (heroic tale)||||||||||||||||sankaritaru (legenda)|
 herze|unomete|Hz||hertz (Hz)||hercio (Hz)||||||||||||||hertsi (Hz)|herc
 Hese||||Hesse|Hesse|Hesse (Hessia)|Hesse (Héssia)|Гессен||黑森|ヘッセン|||||||||Hessen|
-hese yum|yum 108|Hs||hassium|hassium|hasio|hássio|хассий|هاسيوم||ハッシウム|하슘|hassi|हसियम|হ্যাসিয়াম|hassium|hassi|hassiyum|hasio|hassium|has
+hese yum|yum 108|Hs|eng:hassium, fra:hassium, spa:hasio, por:hássio, rus:хассий, zho: (hēi), jpn:ハッシウム, kor:하슘, vie:hassi, hin:हसियम, ben:হ্যাসিয়াম, may:hassium, swa:hassi|hassium|hassium|hasio|hássio|хассий|هاسيوم||ハッシウム|하슘|hassi|हसियम|হ্যাসিয়াম|hassium|hassi|hassiyum|hasio|hassium|has
 hibride|||eng:hybrid, spa:por:híbrido, fra:hybride, rus:гибрид (gibrid)|hybrid (mongrel)||híbrido (mestizo)|||||||||||||miksulo|risteytys (hybridi)|hybryda; kundel
-hidrargente|yum 080|Hg||mercury (quicksilver)|mercure|mercurio|mercúrio|ртуть|زئبق|汞|水銀|수은|thuỷ ngân|पारा|পারদ (মৌল)|raksa|zaibaki (hidrajiri)|civa||elohopea|rtęć
-hidro|yum 001|H||hydrogen|hydrogène|hidrógeno|hidrogéno|водород|هيدروجين|氢|水素|수소|hyđrô, hiđro|हाइड्रोजन|হাইড্রোজেন|hidrogen|hidrojeni|hidrojen|hidrogeno|vety|wodór
+hidrargente|yum 080|Hg|swa:hidrajiri|mercury (quicksilver)|mercure|mercurio|mercúrio|ртуть|زئبق|汞|水銀|수은|thuỷ ngân|पारा|পারদ (মৌল)|raksa|zaibaki (hidrajiri)|civa||elohopea|rtęć
+hidro|yum 001|H|eng:fra:hydro-, spa:por:may:swa:hidro-, vie:hyđrô|hydrogen|hydrogène|hidrógeno|hidrogéno|водород|هيدروجين|氢|水素|수소|hyđrô|हाइड्रोजन|হাইড্রোজেন|hidrogen|hidrojeni|hidrojen|hidrogeno|vety|wodór
 hijabu|||ara:(ḥijāb), fas:(hejâb), swa:hijabu, hau:hijabi, hin:हिजाब (hijāb), ben:হিজাব (hijab), eng:por:hijab, fra:hidjab, spa:hiyab, rus:хиджаб (xidžab)|veil (cover, screen)|voile|velo|véu|вуаль|حِجَاب|面纱||||||||hijabu (veli, shela)||verho (huntu, peite)|welon (woalka)
 hima|||hin:हिमपात (himpāt), tha:หิมะ (hima), tel:(himamu)|snow|neige|nieve|neve||||||||||||neĝo|lumi|śnieg
 hima rose||||frost||escarcha|||||||||||||frosto|kuura|szron
 Himalaya||||Himalayas||Himalaya|||||||||||||Himalajo|Himalaja|Himalaje
 hin|||hin:-हीन (hīn), ben:-হীন (-hin), guj:-હીન (-hīn)|lack (miss, be without)||faltar (sin)|sem|без|||||||||||sen (manki)|puuttua (ilman, vailla)|bez
 hin di||||lacking (-less)|||||||||||||||ne havanta (sen~a)|ilman oleva (-ton)|
-hindi yum|yum 049|In||indium|indium|indium|índio|индий|انديوم|铟|インジウム|인듐|indi|इण्डियम|ইন্ডিয়াম|indium|indi|i̇ndiyum|indio|indium|ind
+hindi yum|yum 049|In|eng:indium, fra:indium, spa:indium, por:índio, rus:индий, zho:铟 (yīn), jpn:インジウム, kor:인듐, vie:indi, hin:इण्डियम, ben:ইন্ডিয়াম, may:indium, swa:indi|indium|indium|indium|índio|индий|انديوم|铟|インジウム|인듐|indi|इण्डियम|ইন্ডিয়াম|indium|indi|i̇ndiyum|indio|indium|ind
 Hindu||||Hindu||hindú|||||||||||||hinduo|hindu|hinduistyczny
 Hindu basha||||Hindi (Hindustani)||||||||||हिंदी (हिंदुस्तानी)|হিন্দি|||||hindin kieli|
 Hindu desh||||Hindustan|Hindustan|Indostán||Индостан||印度斯坦||||हिंदुस्तान|হিন্দুস্তান|||||Hindustan|
@@ -1609,7 +1609,7 @@ hogo sheku||||flint|silex|pedernal (sílex)|pederneira|кремень||燧石|�
 hogo tehni||||fireworks (pyrotechnics)|feu d’artifice|dispositivo pirotécnico|fogos de artifício|фейерверк||烟火|花火|||||||||pyrotekniikka|pirotechnika
 hoki|||eng:fra:spa:hockey, por:hóquei, rus:хоккей (hokkey),  jpn:ホッケー (hokkē), hin:हाकी (hākī), ben:হকি (hôki), ara:(hūkī), swa:hoki|hockey|hockey|hockey|hóquei|хоккей||曲棍球|ホッケー|khúc côn cầu||हाकी|হকি|hoki||hokey|hokeo|hockey (jääkiekko)|hokej
 holera|||eng:cholera, spa:por:cólera, fra:choléra, rus:холера (holera), tur:kolera, ara:كُولِيرَا‎ (kōlīrā), hin:कॉलरा (kŏlrā), zho:虎列拉 (hǔlièlā), jpn:コレラ (korera)|cholera||cólera||||||||||||||kolera|cholera
-holme yum|yum 067|Ho||holmium|holmium|holmio|hólmio|гольмий|هلميوم|钬|ホルミウム|홀뮴|holmi, honmi|होल्मियम|হলমিয়াম|holmium|homi|holmiyum|holmio|holmium|holm
+holme yum|yum 067|Ho|eng:holmium, fra:holmium, spa:holmio, por:hólmio, rus:гольмий, zho:钬 (huǒ), jpn:ホルミウム, kor:홀뮴, vie:honmi, hin:होल्मियम, ben:হলমিয়াম, may:holmium, swa:homi|holmium|holmium|holmio|hólmio|гольмий|هلميوم|钬|ホルミウム|홀뮴|holmi, honmi|होल्मियम|হলমিয়াম|holmium|homi|holmiyum|holmio|holmium|holm
 holo|||eng:whole, spa:por:fra:tur:may:holo-, rus:голо- (golo-), jpn:ホロ (horo-)|whole (entire)||entero (todo)||||||||||||||koko (kokonainen)|cały
 holo grafi||||hologram||holograma||||||||||||||hologrammi|hologram
 holo ta||||wholeness (integrity)||totalidad (integridad)||||||||||||||kokonaisuus|całość (integralność)
@@ -1688,13 +1688,13 @@ insulte|||eng:insult, fra:insulte, spa:por:insulto, rus:инсульт (insul’
 insulte di||||rude (offensive)||grosero (maleducado)||||||||||||||törkeä|obraźliwy, niemiły, obelżywy
 internete||||internet||Internet||||||||||||||internet|internet
 Io|planete 5 lun 1|||Io||||||||||||||||Io|
-iode|yum 053|I||iodine|iode|yodo (iodo)|iodo|йод|يود|碘|ヨウ素|요오드, 2아이오딘|iot, iođ|आयोडिन|আয়োডিন|yodium|iodini (aidini)|i̇yod|jodo|jodi|jod; jodyna
+iode|yum 053|I|eng:iodine, fra:iode, spa:yodo (iodo), por:iodo, rus:йод, jpn:ヨウ素, kor:요오드, vie:iot, hin:आयोडिन, ben:আয়োডিন, may:yodium, swa:iodini|iodine|iode|yodo (iodo)|iodo|йод|يود|碘|ヨウ素|요오드|iot, iođ|आयोडिन|আয়োডিন|yodium|iodini (aidini)|i̇yod|jodo|jodi|jod; jodyna
 ion|||eng:fra:spa:ion, rus:ион (ion), tur:iyon|ion||ion|||||||||||||iono|ioni|jon
 ion radi||||radioactivity (ionizing radiation)||radiación ionizante||||||||||||||radioaktiivisuus|radioaktywność
 ion radi di||||radioactive||radiactivo||||||||||||||radioaktiivinen|radioaktywny
 Iraki|desha|IQ||Iraq||Iraq|||||||||||||Irakio|Irak|Irak
 Iran|desha|IR||Iran||Irán|||||||||||||Iranio|Iran|Iran
-iris yum|yum 077|Ir||iridium|iridium|iridio|irídio|иридий|إريديوم|铱|イリジウム|이리듐|iriđi|इरिडियम|ইরিডিয়াম|iridium|iridi|i̇ridyum|iridio|iridium|iryd
+iris yum|yum 077|Ir|eng:iridium, fra:iridium, spa:iridio, por:irídio, rus:иридий, jpn:イリジウム, kor:이리듐, vie:iriđi, hin:इरिडियम, ben:ইরিডিয়াম, may:iridium, swa:iridi|iridium|iridium|iridio|irídio|иридий|إريديوم|铱|イリジウム|이리듐|iriđi|इरिडियम|ইরিডিয়াম|iridium|iridi|i̇ridyum|iridio|iridium|iryd
 ironi|||eng:irony, spa:ironía, por:ironia, fra:ironie, rus:иро́ния (ironija), jpn:アイロニー (aironī)|irony|ironie|ironía|ironia|ирония|||反語 (皮肉)|||||||||ironia|ironia
 ironi di||||ironic||irónico|||||反語的|||||||||ironinen|ironiczny
 islam|||ara:(ʾislām), fas:(taslim), tur:teslim|submission (surrender)|soumission|sumisión (rendición)||||||||||||||alistuminen (antautuminen)|poddanie się, uległość, pokora, posłuszeństwo
@@ -1811,7 +1811,7 @@ kababu nama||||grilled meat (kebab)||||кебаб|كباب|||||कबाब|ক�
 kabin|||eng:cabin, spa:cabaña, por:cabana, fra:cabane, ben:কেবিন (kebin)|cabin (booth)||cabaña||||||||||||||koppi (maja)|kabina, budka
 kaboga|bio|Cucurbita|tur:kabak, swa:boga, jpn:カボチャ (kabocha)|squash (pumpkin, gourd)|citrouille|calabaza|abóbora (jerimun)|тыква||南瓜|カボチャ||||||||||kabaczek (dynia, tykwa)
 Kabu Verde|desha|CV||Cabo Verde (Cape Verde)||Cabo Verde||||||||||||||Cabo Verde|Wyspy Zielonego Przylądka (Republika Zielonego Przylądka)
-kadim yum|yum 048|Cd||cadmium|cadmium|cadmio|cádmio|кадмий|كادميوم|镉|カドミウム|카드뮴|catmi, cađimi|काडमियम|ক্যাডমিয়াম|kadmium|kadimi|kadmiyum|kadmio|kadmium|kadm
+kadim yum|yum 048|Cd|eng:cadmium, fra:cadmium, spa:cadmio, por:cádmio, rus:кадмий, zho:镉 (gé), jpn:カドミウム, kor:카드뮴, vie:catmi, hin:काडमियम, ben:ক্যাডমিয়াম, may:kadmium, swa:kadimi|cadmium|cadmium|cadmio|cádmio|кадмий|كادميوم|镉|カドミウム|카드뮴|catmi, cađimi|काडमियम|ক্যাডমিয়াম|kadmium|kadimi|kadmiyum|kadmio|kadmium|kadm
 kafe|||deu:Kaffee, fra:spa:por:café, rus:кофе, zho: 咖啡 (kāfēi), yue:咖啡 (gaa3 fe1), eng:coffee, hin:काफ़ी (kāfī), ben:কফি (kôphi), tur:kahve, tgl:kape, tha:กาแฟ (kafæ)|coffee|café|café|café|кофе|قَهْوَة|咖啡|コーヒー|||काफ़ी (क़हवा)||kopi|kahawa|kahve|kafo|kahvi|kawa
 kafe alga|bio|Phaeophyceae||brown algae|algues brunes|algas pardas||бурые водоросли|||褐藻||||||||||brunatnica
 kafe kan||||cafe (coffee shop)|café|café (cafetería)|café|кафе (кофейня)||咖啡馆|カフェ (コーヒー店)|카페 (커피점)|quán cà phê|कॉफ़ीख़ाना (कैफ़े)|হোটেল (ক্যাফে)|kedai kopi|mkahawa|kahvehane|kafejo|kahvila|kawiarnia
@@ -1837,15 +1837,15 @@ kali||||alkaline|basique|alcalino|alcalino||||||||||||alkaleca|emäksinen (alkal
 kali guste||||bitter|amer|amargo|amargo|горький||苦的|苦い||||||||amara|kitkerä (karvas)|gorzki
 kali melon|bio|Momordica charantia||bitter melon||melón amargo||горький огурец (китайская горькая тыква)||苦瓜|ツルレイシ (ニガウリ)||||||||||przepękla ogórkowata (balsamka ogórkowata)
 kali oranje|bio|Citrus × aurantium||bitter orange|orange amère|naranjo amargo||померанец|||ダイダイ||||||||||gorzka pomarańcza
-kali yum|yum 019|K||potassium|potassium|potasio|potássio|калий|بوتاسيوم|钾|カリウム|칼륨, 2포타슘|kali|पोटैशियम|পটাসিয়াম|kalium|kali|potasyum|kalio|kalium|potas
-kaliforni yum|yum 098|Cf||californium|californium|californio|califórnio|калифорний|كاليفورنيوم|锎|カリホルニウム|칼리포르늄 or 칼리포늄|califoni|कैलीफोर्नियम|ক্যালিফোর্নিয়াম|kalifornium|kalifoni|kaliforniyum|kaliforniumo|kalifornium|kaliforn
+kali yum|yum 019|K|eng:potassium, fra:potassium, spa:potasio, por:potássio, rus:калий, jpn:カリウム, vie:kali, hin:पोटैशियम, ben:পটাসিয়াম, may:kalium, swa:kali|potassium|potassium|potasio|potássio|калий|بوتاسيوم|钾|カリウム|칼륨|kali|पोटैशियम|পটাসিয়াম|kalium|kali|potasyum|kalio|kalium|potas
+kaliforni yum|yum 098|Cf|eng:californium, fra:californium, spa:californio, por:califórnio, rus:калифорний, zho:锎 (kāi), jpn:カリホルニウム, kor:칼리포르늄, vie:califoni, hin:कैलीफोर्नियम, ben:ক্যালিফোর্নিয়াম, may:kalifornium, swa:kalifoni|californium|californium|californio|califórnio|калифорний|كاليفورنيوم|锎|カリホルニウム|칼리포르늄|califoni|कैलीफोर्नियम|ক্যালিফোর্নিয়াম|kalifornium|kalifoni|kaliforniyum|kaliforniumo|kalifornium|kaliforn
 Kalisto|planete 5 lun 4|||Callisto|||||||||||||||||
 kalkul|||fra:calcul, spa:cálculo, eng:calculus, hin:कलन (kalan)|calculus (manipulation of symbolic expressions)||cálculo||||||||||||||kalkyyli|rachunek (formalny system obliczeń)
 kalmar|bio|Decapodiformes|ell:καλαμάρι (kalamári), spa:por:calamar, fra:calmar, ita:eng:calamari, rus:кальмар (kal’mar), tur:kalamar, ara:كلاماري‎ (klamāri)|squid (cuttlefish)|calmar (encornet, calamar)|calamar|lula (calamar)|кальмар||鱿鱼|イカ||||||fuu||||kałamarnica (mątwa)
-kalse bilor||||marble|marbre|marmól|mármore|мрамор|رُخَّام|大理石|大理石|대리석|đá hoa|संगमरमर||marmer||mermer|marmoro|marmori|marmur
-kalse mate||||lime|chaux|cal|cal|известь||石灰|石灰|석회||||||kireç|kalko|kalkki|wapno
-kalse petra||||limestone|calcaire|caliza|calcário|известняк||石灰岩||||||batu kapur||kireç taşı|kalkoŝtono|kalkkikivi|wapień
-kalsi yum|yum 020|Ca||calcium (Ca)|calcium|calcio|cálcio|кальций|كلسيوم|钙|カルシウム|칼슘|canxi|कैल्शियम|ক্যালসিয়াম|kalsium|kalisi|kalsiyum|kalcio|kalsium|wapń
+kalsi bilor||||marble|marbre|marmól|mármore|мрамор|رُخَّام|大理石|大理石|대리석|đá hoa|संगमरमर||marmer||mermer|marmoro|marmori|marmur
+kalsi mate||||lime|chaux|cal|cal|известь||石灰|石灰|석회||||||kireç|kalko|kalkki|wapno
+kalsi petra||||limestone|calcaire|caliza|calcário|известняк||石灰岩||||||batu kapur||kireç taşı|kalkoŝtono|kalkkikivi|wapień
+kalsi yum|yum 020|Ca|eng:calcium (Ca), fra:calcium, spa:calcio, por:cálcio, rus:кальций, zho:钙 (gài), jpn:カルシウム, kor:칼슘, vie:canxi, hin:कैल्शियम, ben:ক্যালসিয়াম, may:kalsium, swa:kalisi|calcium (Ca)|calcium|calcio|cálcio|кальций|كلسيوم|钙|カルシウム|칼슘|canxi|कैल्शियम|ক্যালসিয়াম|kalsium|kalisi|kalsiyum|kalcio|kalsium|wapń
 kalsite||CaCO3||calcite|calcite|calcita|calcita|кальцит||方解石||||||||kalsit|kalcito|kalsiitti (kalkkisälpä)|kalcyt
 kama||27 emotions|hin:काम (kām), ben:কাম (kam), tha:กาม (gaam)|lust (desire, libido, sexual passion)|luxure (libido)|lujuria (deseo)|luxúria||شَهْوَة‎|情欲|色欲|성욕 (정욕)||काम (कामना, वासना)|কাম|||||himo (seksuaalinen halu)|pożądanie, żadza
 kama deu||||god of love (Eros, Kamadeva)|||||||カーマ|||||||||rakkaudenjumala|
@@ -1900,7 +1900,7 @@ karate||||karate|karaté|karate|caratê|каратэ||空手道|空手|가라데
 karate ka||||karateka (practitioner of karate)|karatéka|||каратист (каратэка)|||空手家|||||||||karateka (karaten harrastaja)|
 karavi|bio|Carum carvi|ara:(karāwiya), eng:caraway, fra:carvi, spa:alcaravea, por:alcaravia|caraway||carvis (alcaravea)|alcaravia (cariz)||||||||||||karvio|kumina|kminek
 karbau|bio|Bubalus bubalis|spa:carabao, may:kerbau, jav:kebo, khm:ក្របី (krɑbəy)|water buffalo||búbalo (arni)||||||||||||||vesipuhveli|bawół domowy
-karbon|yum 006|C||carbon (coal)|carbone|carbón|carbono|углерод|كربون|碳|炭素|탄소|cacbon|कार्बन|কার্বন|karbon|kaboni|karbon|karbono|hiili|węgiel
+karbon|yum 006|C|eng:carbon, fra:carbone, spa:carbón, por:carbono, vie:cacbon, hin:कार्बन, ben:কার্বন, may:karbon, swa:kaboni|carbon (coal)|carbone|carbón|carbono|углерод|كربون|碳|炭素|탄소|cacbon|कार्बन|কার্বন|karbon|kaboni|karbon|karbono|hiili|węgiel
 karbon duokside||||carbon dioxide|dioxyde de carbone|dióxido de carbono|dióxido de carbono|двуокись углерода||二氧化碳||||प्रांगार द्विजारेय|||||karbona dioksido|hiilidioksidi|dwutlenek węgla
 karbon kalam||||pencil|crayon|lápiz|lápis|карандаш||铅笔|鉛筆|연필|bút chì|अंकनी (पेंसिल)|অঙ্কনী (পেনসিল)|pensil|penseli|kurşun kalem|krajono|lyijykynä|
 karbon sui||||carbohydrate (saccharide)||carbohidrato||углевод|||炭水化物||||||||||
@@ -1979,6 +1979,7 @@ kilomitre|unomete|km||kilometer (km)||kilometre|||||||||||||kilometro|kilometri|
 kimi|||eng:chemistry, fra:chimie, spa:por:química, rus:химия (himiya), ara:(kīmiyāʾ), may:kimia, swa:kemia, tur:kimya|substance (physical material from which something is made)|substance|sustancia|substância|вещество||物质|物質|물질|vật chất|पदार्थ|পদার্থ|||||aine (aines, materia)|
 kimi di||||chemical||químico||||||||||||||kemikaali|chemiczny
 kimi logi||||chemistry|chimie|química|química|химия|كِيمِيَاء‎|化学|化学|화학|hóa học|रसायन शास्त्र|রসায়ন|kimia|kemia|kimya|ĥemio (kemio)|kemia|chemia
+kimi so||||chemical element|élément chimique|elemento químico|elemento químico|химический элемент||元素|元素|원소|nguyên tố|रासायनिक तत्व||unsur kimia||kimyasal element|kemia elemento|alkuaine|
 kimono||||kimono|kimono|quimono|quimono|кимоно||和服|着物|기모노|kimono||||||kimono|kimono|kimono
 kinar|||hin:किनारा (kinārā), ben:কিনারা (kinara), tur:kenar, fas: کنار‎ (kenâr)|border (edge, fringe, margin, rim, side, shore, periphery)|bord|frontera (límite, borde, periferia)|margem (borda)|край (грань)||边|際 (端)||rìa|किनारा|কিনারা|||kenar|rando (orlo)|reuna (raja, ääri)|granica, skraj, brzeg, krawędź
 kinar baryer||||fence||valla (cerca)|cerca|забор (ограда)||篱笆|柵 (垣)||||||||||płot
@@ -2020,11 +2021,11 @@ klima logi||||climatology||climatología|||||||||||||klimatscienco|ilmastotiede 
 klima mute||||climate change|changement climatique|cambio climático|mudança climática|изменение климата||气候变化|気候変動|기후 변화|biến đổi khí hậu|||||iklim değişikliği||ilmastonmuutos|zmiana klimatu
 klin|||eng:-cline, fra:-cliner, por:spa:-clinar, rus:склонить (sklonit’)|slope (tilt, slant, bias, inclination, tendency)|tendance|cuesta (inclinación, pendiente, predisposición, tender)|tendência|тенденция (склонить)||趋势|斜め (傾向)|경향||||cenderung (condonkan)|mwelekeo|eğilim (meyletmek)|emo (inklino, tendenco)|taipumus|tendencja (być skłonnym)
 klon|||en:por:fra:clone, spa:clon rus:клон (klon), may:klon, jpn:クローン (kurōn)|clone (replica)||clonar|||||||||||||klono|klooni (identtinen kopio)|klon, replika
-klor|yum 017|Cl||chlorine|chlore|cloro|cloro|хлор|كلور|氯|塩素|염소|clo|क्लोरीन|ক্লোরিন|klor|klorini|klor|kloro|kloori|chlor
+klor|yum 017|Cl|eng:chlorine, fra:chlore, spa:cloro, por:cloro, rus:хлор, vie:clo, hin:क्लोरीन, ben:ক্লোরিন, may:klor, swa:klorini|chlorine|chlore|cloro|cloro|хлор|كلور|氯|塩素|염소|clo|क्लोरीन|ক্লোরিন|klor|klorini|klor|kloro|kloori|chlor
 klube|||eng:spa:fra:club, por:clube, rus:клуб, tur:kulüp, swa:klabu, hin:क्लब (klab), may:kelab, zho:俱乐部 (jùlèbù), jpn:クラブ (kurabu)|club||club|||||||||||||klubo|kerho (klubi)|klub
 klus||||closed||||||||||||||||suljettu|zamknięty
 klus|||eng:fra:spa:por:-clus-, rus:ключить (-klyučítʹ)|close (shut)||||||||||||||||sulkea|
-kobalte|yum 027|Co||cobalt|cobalt|cobalto|cobalto|кобальт|كوبلت|钴|コバルト|코발트|coban|कोबाल्ट|কোবাল্ট|kobalt|kobalti|kobalt|kobalto|koboltti|kobalt
+kobalte|yum 027|Co|eng:cobalt, fra:cobalt, spa:cobalto, por:cobalto, rus:кобальт, zho:钴 (gǔ), jpn:コバルト, kor:코발트, vie:coban, hin:कोबाल्ट, ben:কোবাল্ট, may:kobalt, swa:kobalti|cobalt|cobalt|cobalto|cobalto|кобальт|كوبلت|钴|コバルト|코발트|coban|कोबाल्ट|কোবাল্ট|kobalt|kobalti|kobalt|kobalto|koboltti|kobalt
 koda|||eng:coda, spa:coda,cola, por:cauda, fra:côté, jpn:コーダ (kōda)|tail (coda)|queue (côté )|cola (rabo, coda)||хвост||尾巴 (尾部)|尾 (尾翼)|||पूंछ (दुम)|লেজ|ekor (kotek, basian)|mkia|kuyruk|vosto|häntä|ogon
 kode||||encode (encrypt)||codificar (cifrar)||||||||||||||koodata|kodować
 kode|||eng:code, spa:por:código, ru:код, fas:کد‎ (kod), hin:कोड (koḍ), jpn:コード (kōdo)|code (cipher)||código (cifra)|||||||||||||kodo|koodi|kod, szyfr
@@ -2070,7 +2071,7 @@ kong fuzi sim||||Confucianism||confucianismo||||||||||||||Kungfutselaisuus|konfu
 Konkani|nas|||Konkani||konkani||||||||||||||konkani (eräs intialainen kieli)|konkani
 konserte|||eng:fra:concert, spa:concierto, por:concerto, deu:Konzert, rus:концерт (koncert), may:tur:konser, jpn:コンサート (konsāto), kor:콘서트 (konseoteu), hin:कॉन्सर्ट (kŏnsarṭ)|concert|concert|concierto|concerto|концерт||音乐会|コンサート (音楽会)|콘서트 (음악회)||कॉन्सर्ट|সঙ্গীতানুষ্ঠান|konser||konser|koncerto|konsertti|koncert
 kontra|coverb|||go against||estar en contra|||||||||||||kontraŭi|mennä vasten|być przeciw
-koperni yum|yum 112|Cn||copernicium|copernicium|copérnico|copernício|коперниций|ٲنون بيوم||コペルニシウム|코페르니슘|copernici|||copernicium|kopernici|koperniciyum|kopernicio|copernicium|kopernik
+koperni yum|yum 112|Cn|eng:fra:copernicium, spa:copérnico, por:copernício, rus:коперниций, jpn:コペルニシウム, kor:코페르니슘, vie:copernici, may:copernicium, swa:kopernici|copernicium|copernicium|copérnico|copernício|коперниций|ٲنون بيوم||コペルニシウム|코페르니슘|copernici|||copernicium|kopernici|koperniciyum|kopernicio|copernicium|kopernik
 kopi|||eng:copy, fra:copie, spa:por:copia, rus:копия (kopiya), hin:कापी (kāpī), tur:kopya, may:kopi, zho:拷貝 (kǎobèi), jpn:コピー (kopī)|copy (duplicate, replica)|copie|copia (réplica)|cópia|копия||摹本 (拷貝)|コピー|||कापी (प्रति)||salinan (turunan, kopi)|nakala|kopya (suret, nüsha)|kopio|kopio (jäljennös)|kopia, replika
 kopi haki||||copyright||derechos de autor (copyright)||||||||||||||kopiointioikeus (tekijänoikeus)|prawa autorskie
 koral|bio||eng:spa:por:coral, fra:corail, deu:Koralle, rus:коралл|coral|corail|coral|coral|коралл||珊瑚|サンゴ|||मूंगा||karang|matumbawe (marijani)||||koral
@@ -2110,12 +2111,12 @@ krevete|||eng:fra:crevette, ita:gamberetto, rus:креветка (krevetka)|shri
 krim|||eng:fra:por:crime, spa:crimen, tgl:krimen|crime||crimen (delito)|||||||||||||krimo|rikos|przestępstwo
 krim di||||criminal||criminal|||||||||||||krima|rikos- (rikollinen)|kryminalny, przestępczy
 krita|||eng:cry, spa:por:gritar, fra:crier, rus:крича́ть (kričátʹ)|cry (shout)||gritar||||||||||||||huutaa|krzyknąć, krzyczeć
-kriton|yum 036|Kr||krypton|krypton|criptón (kriptón)|krípton|криптон|كربتون|氪|クリプトン|크립톤|kripton|क्रिप्टन|ক্রিপ্টন|kripton|kriptoni|kripton|kriptono|krypton|krypton
+kriton|yum 036|Kr|eng:krypton, fra:krypton, spa:criptón (kriptón), por:krípton, rus:криптон, zho:氪 (kè), jpn:クリプトン, kor:크립톤, vie:kripton, hin:क्रिप्टन, ben:ক্রিপ্টন, may:kripton, swa:kriptoni|krypton|krypton|criptón (kriptón)|krípton|криптон|كربتون|氪|クリプトン|크립톤|kripton|क्रिप्टन|ক্রিপ্টন|kripton|kriptoni|kripton|kriptono|krypton|krypton
 krizi|||eng:crisis, fra:por:crise, deu:Krise, rus:кризис (krizis), spa:crisis|crisis||crisis|||||||||||||krizo|kriisi (käännekohta)|kryzys
 krizi||||critical (pertaining to crisis)||crítico (fundamental)||||||||||||||kriittinen (kriisi-)|kryzysowy
 krokodil|bio|Crocodilia|ell:κροκόδειλος, eng:crocodilian, fra:crocodilien, spa:crocodilio, por:crocodiliano, rus:крокодил (krokodil), jpn:クロコダイル, kor:크로커다일 (keulokeodail)|crocodillian|crocodilien|crocodilio|crocodiliano|крокодил||鳄|ワニ||||||||||krokodyl
 krokroke|bio||eng:croak, deu:gribbit, spa:croac croac, fin:kurr kurr, jpn:ケロケロ (kero kero), tur:vrak vrak, may:krok krok, tgl:kokak kokak|frog|grenouille|rana|rã|лягушка||蛙|蛙||||||||||żaba
-krom yum|yum 024|Cr||chromium|chrome|cromo|crómo|хром|كروم|铬|クロム|크롬, 2크로뮴|crom|क्रोमियम|ক্রোমিয়াম|krom|kromi|krom|kromo|kromi|chrom
+krom yum|yum 024|Cr|eng:chromium, fra:chrome, spa:cromo, por:crómo, rus:хром, jpn:クロム, kor:크로뮴, vie:crom, hin:क्रोमियम, ben:ক্রোমিয়াম, may:krom, swa:kromi|chromium|chrome|cromo|crómo|хром|كروم|铬|クロム|크로뮴|crom|क्रोमियम|ক্রোমিয়াম|krom|kromi|krom|kromo|kromi|chrom
 krote|bio|Talpinae|rus:крот (krot), pol:kret|mole (burrowing animal)|taupe|topo|toupeira|крот||鼹鼠|田鼠|||छछूंदर||tikus mondok|fuko|छछूंदर||kontiainen (maamyyrä)|kret
 kruasan|yam||fra:eng:croissant, por:croassã, spa:cruasán, rus:круассан, jpn:クロワッサン (kurowassan), kor:크루아상 (keruasang), hin:क्रोइसैन (kroisain)|croissant|croissant|cruasán|croassã|круассан||牛角包|クロワッサン|크루아상|bánh sừng bò|क्रोइसैन||||kruvasan|korna bulko|voisarvi (kroissantti)|croissant
 krus|||eng:cross, por:spa:cruz, deu:Kreuz, fra:croix, jpn:クロス (kurosu), rus:крест (krest), kon:kuluzi, hin:क्रूश (krūś)|cross|croix|cruz|cruz|крест||||||||||çarpı (haç)|kruco|risti|krzyż
@@ -2143,10 +2144,10 @@ kultur|||eng:fra:culture, spa:por:cultura, rus:культу́ра (kulʹtúra), 
 kupa|||eng:cup, fra:coupe, spa:copa, por:copo, ara: كُوب‎ (kūb), tur:kupa, hin:कप (kap), jpn:コップ (koppu), kor:컵 (keop) + fas:(koppe), ara:قبة (qubba), may:kubah, rus:купол (kupol), deu:Kuppel|drinking vessel (cup, glass, mug, goblet, chalice)|coupe (tasse, verre)|vaso (taza, copa)|copo (taça)|чаша (чашка, стакан)|كُوب‎|杯子|コップ|컵|ly (chén)|प्याला|পেয়ালা|cangkir (cawan, gelas)|kikombe (glas)|kase (fincan, bardak, kupa)|taso|malja (kuppi, muki, lasi)|kubek
 kupa chati||||dome||cúpula||||||||||||||kupoli (holvikatto)|kopuła
 kupon|||eng:fra:coupon, spa:cupón, por:cupom, rus:купо́н (kupón), may:kupon, jpn:クーポン (kūpon), kor:쿠폰 (kupon), swa:kuponi|coupon||cupón (vale)|||||||||||kuponi|||kuponki|kupon
-kupre|yum 029|Cu||copper|cuivre|cobre|cobre|медь|نحاس|铜|銅|구리|đồng|ताम्र|কপার|tembaga|nahasi (kupri)|bakır|kupro|kupari|miedź
+kupre|yum 029|Cu|eng:copper, fra:cuivre, spa:cobre, por:cobre, swa:kupri|copper|cuivre|cobre|cobre|медь|نحاس|铜|銅|구리|đồng|ताम्र|কপার|tembaga|nahasi (kupri)|bakır|kupro|kupari|miedź
 kuran||||Quran (Koran)||Corán||||||||||||||koraani|Koran
 kurban|||ara: قُرْبَان‎ m (qurbān), hin:कुरबानी (kurbānī), ben:কোরবানি (korbani), may:tur:kurban|sacrifice (offer)|sacrifice|sacrificio|sacrifício|жертва|قُرْبَان‎|牺牲|犠牲|희생|lễ vật|निसार (क़ुर्बानी)|কোরবানি (ত্যাগ)|kurban|dhabihu|kurban (feda)|ofero|uhri (uhraus)|ofiara
-kuri yum|yum 096|Cm||curium|curium|curio|cúrio|кюрий|كوريوم|锔|キュリウム|퀴륨|curi|क्यूरियम|কুরিয়াম|kurium|kuri|curiyum|kuriumo|curium|kiur
+kuri yum|yum 096|Cm|eng:curium, fra:curium, spa:curio, por:cúrio, rus:кюрий, jpn:キュリウム, kor:퀴륨, vie:curi, hin:क्यूरियम, ben:কুরিয়াম, may:kurium, swa:kuri|curium|curium|curio|cúrio|кюрий|كوريوم|锔|キュリウム|퀴륨|curi|क्यूरियम|কুরিয়াম|kurium|kuri|curiyum|kuriumo|curium|kiur
 kursi|||ara:(kursiy), hin:कुरसी (kursī), urd:(kursī), pnb:ਕੁਰਸੀ (kursī), tel:(kurcī), may:som:kursi, fas:(korsi)|chair||silla|||||||||||||seĝo|tuoli|kszesło, fotel
 kurva|||eng:curve, fra:courbe, spa:por:curva, swa:kuruba + rus:кривая (krivaya)|curve (bend)|courbe|curva|curva|кривая|||||||||kuruba||kurbo|mutka (kurvi)|wygiąć, wyginać, zgiąć, zginać, zakrzywić, zakrzywiać
 kurva di||||curvy (curved)||curvo||||||||||||||mutkikas|zakrzywiony
@@ -2181,7 +2182,7 @@ lanse|||eng:launch, ita:lanciare, por:lançar, fra:lancer, spa:lanzar, deu:lanci
 lanse grafi||||projection (image)|projection|proyección|projeção|||投影|投影|||||||||projektio (diakuva)|rzut (projekcja)
 lanse grafi||||project (cast)|projeter (donner)|proyectar||||投射|映す (投影する)|||||||||heijastaa kuvia (projisoida)|wyświetlać
 lanse she||||projectile (missile)|projectile|proyectil (misil)|projétil|снаряд||投掷物|飛翔体 (矢玉)||||||||||pocisk
-lantan yum|yum 057|La||lanthanum|lanthane|lantano|lantâno|лантан|لنثانوم|镧|ランタン|란탄, 2란타넘|lantan|लाञ्थनम|ল্যান্থানাম|lantanium|lanthani|lantan||lantaani|lantan
+lantan yum|yum 057|La|eng:lanthanum, fra:lanthane, spa:lantano, por:lantâno, rus:лантан, zho:镧 (lán), jpn:ランタン, kor:란탄, vie:lantan, hin:लाञ्थनम, ben:ল্যান্থানাম, may:lantanium, swa:lanthani|lanthanum|lanthane|lantano|lantâno|лантан|لنثانوم|镧|ランタン|란탄|lantan|लाञ्थनम|ল্যান্থানাম|lantanium|lanthani|lantan||lantaani|lantan
 larva|||deu:fra:larve, eng:tur:larva, hin:लार्वा (lārvā), urd:(lārvā), pol:larwa|larva (maggot, caterpillar)||larva||||||||||||||toukka|larwa, czerw, gąsienica
 lashe|||fra:laisser,lâcher, ita:lasciare, deu:lassen|leave behind (abandon, let go)|laisser|dejar|deixar|||落 (留下)|残す|||||||||jättää (hylätä)|pozostawiać (pozostawić)
 lashe she||||leftover (residue, vestige)||vestigio (sobrante, residuo)||||||||||||||jäte (hylkytavara)|pozostałość (szczątek)
@@ -2196,7 +2197,7 @@ Lau|desha|LA||Laos||Laos||||||||||||||Laos|Laos
 lau|||zho:老 (lǎo), yue:老 (lau2), wuu:老 (lau3), jpn:老 (rō), vie:lão|old (aged, elderly)|vieux (âgé, ancien)|viejo (anciano)|idoso|пожилой||老 (老年, 年歲大)|年配||già (lão)||||||||stary (sędziwy, wiekowy)
 lau di||||Lao (Laotian)||laosiano||||||||||||||laoslainen|laotański
 lau jan||||elder||viejo (anciano)|||||||||||||||starzec
-laurence yum|yum 103|Lr||lawrencium|lawrencium|laurencio|lawrêncio|лоуренсий|لورنسيوم|铹|ローレンシウム|로렌슘|lorenxi, lawrenci|लॉरेंशियम|লরেনসিয়াম|lawrensium|lawirensi|lawrenciyum, ²lorentiyum|laŭrencio|lawrencium|lorens
+laurence yum|yum 103|Lr|eng:lawrencium, fra:lawrencium, spa:laurencio, por:lawrêncio, rus:лоуренсий, zho:铹 (láo), jpn:ローレンシウム, kor:로렌슘, vie:lorenxi, lawrenci, hin:लॉरेंशियम, ben:লরেনসিয়াম, may:lawrensium, swa:lawirensi|lawrencium|lawrencium|laurencio|lawrêncio|лоуренсий|لورنسيوم|铹|ローレンシウム|로렌슘|lorenxi, lawrenci|लॉरेंशियम|লরেনসিয়াম|lawrensium|lawirensi|lawrenciyum, ²lorentiyum|laŭrencio|lawrencium|lorens
 lazanya|||fra:lasagne, eng:lasagna, spa:lasaña, por:lasanha, rus:лазанья (lazanya), ara:(lazanyā), jpn:ラザニア (razania), kor:라자냐 (lajanya), hin:लज़ैन्या (lazenyā)|lasagna|lasagne|lasaña|lasanha|лазанья|لَازَانْيَا|千层面|ラザニア|라자냐||लज़ैन्या||||lazanya||lasagne|lazania
 lazur|rang|||azure|azur|azur (blao)|azur (blau)|лазурь|||||||||||||
 lazur petra|||fas:لاجورد (lājevard), eng:lazuli, spa:lapislázuli, rus:лазурит (lazurit), ara:لازورد (lāzaward), hin:लाजवर्द (lājavarda), jpn:ラピスラズリ (rapisurazuri), may:lazuardi, tur:lazur taşı|lapis lazuli|lapis-lazuli|lapislázuli|lápis-lazúli|лазурит|لَازَوَرْد|青金岩|ラピスラズリ (瑠璃)|||लाजवर्द (वैडूर्य)||||lazur taşı||lapislatsuli|lapis lazuli
@@ -2262,9 +2263,9 @@ lipa side||||crouch (squat)|s’accroupir|agacharse|agacharse|сесть на к
 lis|||fra:lisse, spa:por:liso, fas:(liz), may:licin|smooth||suave (liso)|||||||||||||glata|sileä|gładki
 lisan|||ara: لِسَان‎ (lisān), hin:लिसान (lisān), swa:lisani, may:tur:lisan, amh:ልሳን (ləsan)|tongue|langue|lengua|língua|язык|لِسَان‎|舌头|舌|혀|lưỡi|जीभ (ज़बान)|জিহ্বা|lidah (lisan)|ulimi (lisani)|dil (lisan)|lango|kieli (elin)|język
 liste|||eng:list, spa:por:lista, rus:лист (list), deu:fra:liste, fas:(list), hin:लिस्ट (lisṭ), urd:(lisṭ), jpn:リスト (risuto)|list (listing, catalogue)|liste|lista|lista|список||单子||||लिस्ट|||||listo|lista (luettelo)|lista, spis, wykaz
-lito yum|yum 003|Li||lithium|lithium|litio|lítio|литий|ليثيوم|锂|リチウム|리튬|lithi, liti|लिथियम|লিথিয়াম|litium|lithi|lityum|litio|litium|lit
+lito yum|yum 003|Li|eng:lithium, fra:lithium, spa:litio, por:lítio, rus:литий, zho:锂 (lǐ), jpn:リチウム, kor:리튬, vie:swa:lithi, hin:लिथियम, ben:লিথিয়াম, may:litium, swa:lithi|lithium|lithium|litio|lítio|литий|ليثيوم|锂|リチウム|리튬|lithi, liti|लिथियम|লিথিয়াম|litium|lithi|lityum|litio|litium|lit
 litre|||eng:fra:tur:litre, deu:may:liter, spa:por:litro, rus:литр (litr), pol:litr, ara: لتر‎(litr), hin:लीटर (līṭar), ben:লিটার (liṭar), jpn:リットル (rittoru), kor:리터 (riteo), vie:lít, swa:lita|litre (liter)|litre|litro|litro|литр|لتر‎|升|リットル|리터|lít|लीटर|লিটার|liter|lita|litre|litro|litra|litr
-livermor yum|yum 116|Lv||livermorium|livermorium|livermorio|livermório|ливерморий|ليفرموريوم||リバモリウム|리버모륨|livermori|||livermorium|livermori|livermoriyum||livermorium|liwermor
+livermor yum|yum 116|Lv|eng:fra:livermorium, spa:livermorio, por:livermório, rus:ливерморий, zho: (lì), jpn:リバモリウム, kor:리버모륨, vie:livermori, may:livermorium, swa:livermori|livermorium|livermorium|livermorio|livermório|ливерморий|ليفرموريوم||リバモリウム|리버모륨|livermori|||livermorium|livermori|livermoriyum||livermorium|liwermor
 loba|bio|Raphanus raphanistrum|zho:萝卜 (luóbo), yue:蘿蔔 (lobaak), may:lobak|radish||rábano|||||||||||||rafaneto|retikka (retiisi)|rzodkiewka
 loga||||say (speak, talk)|parler|decir (hablar)|falar|говорить|تَكَلَّمَ|说话 (讲)|話す|말하다||बोलना|বলা|berbicara|kuongea||paroli|sanoa (puhua)|mówić, rozmawiać
 loga|||ell:λόγος (logos), eng:fra:-logue, spa:por:-logo, rus:-лог (-log), fas:(loğat), ara:(luğa), hin:लुग़त (luġat), swa:lugha, tur:lügat, may:logat|speech (talk, words)|parole (mots)|habla (palabras)|fala (palavras)|речь||语言|演説|말|ngôn từ|बात (बोल)|জবান|||söz|parolo|puhe (sanat)|słowo (mowa)
@@ -2317,7 +2318,7 @@ luta|||hin:लूटना (lūṭnā), urd:(lūṭnā), ben:লুটা (lu�
 luta ja||||robber (plunderer)|brigand (bandit)|ladrón|ladrão|грабитель||强盗||||डाकू|||||rabisto|ryöväri (rosvo)|rabuś (grabieżca)
 Luter din||||Lutheranism|luthéranisme|luteranismo|luteranismo|лютера́нство||||||||||||luterilaisuus|luteranizm
 Luter din ja||||Lutheran|luthérien|luterano|luterano|лютеранский||||||||||||luterilainen|luterański
-luteti yum|yum 071|Lu||lutetium|lutécium|lutecio|lutécio|лютеций|لوتيتيوم|镥|ルテニウム|루테튬|lutexi|लुटेटियम|লুটেসিয়াম|lutetium|luteti|lutesyum|lutecio|lutetium|lutet
+lutesi yum|yum 071|Lu|eng:lutetium, fra:lutécium, spa:lutecio, por:lutécio, rus:лютеций, zho:镥 (lǔ), jpn:ルテニウム, kor:루테튬, vie:lutexi, hin:लुटेटियम, ben:লুটেসিয়াম, may:lutetium, swa:luteti|lutetium|lutécium|lutecio|lutécio|лютеций|لوتيتيوم|镥|ルテニウム|루테튬|lutexi|लुटेटियम|লুটেসিয়াম|lutetium|luteti|lutesyum|lutecio|lutetium|lutet
 M||||M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M
 ma|||por:mãe + zho:妈 (mā), vie:má, ben:মা (ma), hin:मां (mã) + eng:swa:mama, spa:mamá, fra:maman, rus:мама (mama), jpn:ママ (mama), kor:엄마 (eomma)|mother (mom, mama)|mère (maman)|madre (mamá)|mãe|мать (мама)|أُمّ‎|妈妈|お母さん (母, ママ)|엄마|mẹ (má)|माता (मां, मादर)|মাতা (মা)|ibu (emak)|mzazi (mama)|anne|patrino|äiti (emä)|matka, mama
 ma di||||motherly (maternal)|maternel|maternal|maternal|материнский||||||||||||äidillinen|
@@ -2326,7 +2327,7 @@ ma su pa||||maternal grandfather||||||外公 (外祖父)||||नाना||||||ä
 Madagasi|desha|MG||Madagascar||Madagascar||||||||||||||Madagaskar|Madagaskar
 madagasi di||||Malagasy||malgache||||||||||||||madagaskarilainen (malagassi)|madagaskarski; malagaski
 maf|||ara: مُعَاف‎ (muʿāf), hin:माफ़ (māf), ben:মাফ (maph), may:maaf, swa:afu, tur:af, hau:yafe|pardon (forgiveness; sorry)||perdón|||||ごめんなさい|||माफ़||maaf||af (affetme)|pardono|anteeksi|przepraszam!
-magen yum|yum 012|Mg||magnesium|magnésium|magnesio|magnésio|магний|مغنيسيوم|镁|マグネシウム|마그네슘|magiê|मैग्नेशियम|ম্যাগনেসিয়াম|magnesium|magnesi|magnezyum|magnezio|magnesium|magnez
+magen yum|yum 012|Mg|eng:magnesium, fra:magnésium, spa:magnesio, por:magnésio, rus:магний, zho:镁 (měi), jpn:マグネシウム, kor:마그네슘, vie:magiê, hin:मैग्नेशियम, ben:ম্যাগনেসিয়াম, may:magnesium, swa:magnesi|magnesium|magnésium|magnesio|magnésio|магний|مغنيسيوم|镁|マグネシウム|마그네슘|magiê|मैग्नेशियम|ম্যাগনেসিয়াম|magnesium|magnesi|magnezyum|magnezio|magnesium|magnez
 magi|||fas: مغ‎ (moğ), ara: مُوغِيّ‎ (mūḡiyy), ell:μάγος (magos), eng:magic, fra:magie, spa:por:magia, rus:магия (magiya) + zho:魔 (mó), jpn:魔 (ma), kor:마 (ma), vie:ma|magic||magia|||||||||||||magio|taikuus (magia)|magia
 magi asar||||spell (enchantment)||||||||||||||||taika|zaklecie
 magi di||||magical||magical||||||||||||||taianomainen (maaginen)|magiczny
@@ -2365,7 +2366,7 @@ manera||||behave (act)||comportarse (portarse)||||||||||||||käyttäytyä|zachow
 manete|||eng:magnet, fra:magnétique, spa:magnete, rus:магнит (magnit), tur:mıknatıs, ara:مَغْنَاطِيس‎ (maḡnāṭīs), may:maknit|magnet||imán|||||||||||sumaku|||magneetti|magnes
 manete di||||magnetic||magnético||||||||||||||magneettinen|magnetyczny
 mang|||zho:忙 (máng), yue:忙 (mong4), wuu:忙 (maan), kor:망 (mang)|busy (occupied)|occupé|ocupado (atareado)|ocupado (atarefado)|занятый||忙|忙しい|||व्यस्त||ramai (sibuk)|kushugulika|işlek|okupata|kiireinen|zajęty
-mangan|yum 025|Mn||manganese|manganèse|manganeso|manganésio|марганец|منجنيز|锰|マンガン|망간, 2망가니즈|mangan|मैंगनीज|ম্যাঙ্গানিজ|manggan|manganisi|mangan|mangano|mangaani|mangan
+mangan|yum 025|Mn|eng:manganese, fra:manganèse, spa:manganeso, por:manganésio, rus:марганец, zho:锰 (měng), jpn:マンガン, kor:망가니즈, vie:mangan, hin:मैंगनीज, ben:ম্যাঙ্গানিজ, may:manggan, swa:manganisi|manganese|manganèse|manganeso|manganésio|марганец|منجنيز|锰|マンガン|망간|mangan|मैंगनीज|ম্যাঙ্গানিজ|manggan|manganisi|mangan|mangano|mangaani|mangan
 mango|bio||mal:മാങ്ങ (māṅṅa), eng:spa:tur:mango, por:manga, rus:манго (mango), may:mangga, jpn:マンゴー (mangō), kor:망고 (manggo)|mango||mango||||||||||||||mango|mango
 mangus|bio|Garcinia mangostana||mangosteen||mangostán (jobo de la India)||||||||||||||mangostani|mangostan
 Mani||||prophet Mani||profeta Mani||||||||||||||profeetta Mani|prorok Mani
@@ -2452,7 +2453,7 @@ mega vate|unomete|MW||megawat (MW)||megavatio||||||||||||||megawatti (MW)|megawa
 megi|||hin:मेघ (megh), ben:মেঘ (megh), tam:மேகம் (mēgam), tel:మేఘము (mēghamu), may:mega, tha:เมฆ (mek) + ara: غَيْمَة‎ (ḡayma) + vie:mây|cloud|nuage|nube|nuvem|облако|سَحَابَة|云|雲|구름|mây|मेघ (बादल)|মেঘ|awan (mega)|wingu|bulut|nubo|pilvi|chmura
 Mehiko|desha|MX||Mexico||México|||||||||||||Meksikio|Meksiko|Meksyk
 Mehiko siti|xefsite|||Mexico City||Ciudad de México|||||||||||||||Meksyk
-meitner yum|yum 109|Mt||meitnerium|meitnérium|meitnerio|meitnério|майтнерий|مايتنريوم||マイトネリウム|마이트너륨|meitneri|मेइट्नेरियम|মিটনেরিয়াম|meitnerium|meitneri|meitneriyum|mejtnerio|meitnerium|meitner
+meitner yum|yum 109|Mt|eng:meitnerium, fra:meitnérium, spa:meitnerio, por:meitnério, rus:майтнерий, jpn:マイトネリウム, kor:마이트너륨, vie:meitneri, hin:मेइट्नेरियम, ben:মিটনেরিয়াম, may:meitnerium, swa:meitneri|meitnerium|meitnérium|meitnerio|meitnério|майтнерий|مايتنريوم||マイトネリウム|마이트너륨|meitneri|मेइट्नेरियम|মিটনেরিয়াম|meitnerium|meitneri|meitneriyum|mejtnerio|meitnerium|meitner
 melodi||||melodious (melodic)||melodioso||||||||||||||melodinen (sointuisa)|melodyczny
 melodi|||eng:melody, spa:melodía, por:melodia, rus:мело́дия (melódija), tur:may:melodi, fas:ملودی‎ (melodi), jpn:メロディー (merodī)|melody||melodía|||||||||||||melodio|melodia (sävelmä)|melodia
 melon|bio|Cucumis melo|eng:fra:melon, spa:melón, por:melão, jpn:メロン (meron), kor:멜론 (mellon)|muskmelon||melón|melão|дыня||厚皮甜瓜 (蜜瓜)|マスクメロン||||||||||ogórek melon
@@ -2464,7 +2465,7 @@ memo bina||||monument (memorial)||monumento|||||追悼塔 (碑)||||||||||pomnik 
 memo note||||memorandum (memo)||memorándum (nota)||меморандум||||||||||||muistio (muistiinmerkintä)|notatka, memo
 memo tehni||||mnemotechny||||||||||||||||muistitekniikka|
 men|||zho:们 (men), yue:們 (mun4) + deu:man + eng:one|one (you, they, impersonal pronoun)|on||||||||||||||oni||
-mendelevi yum|yum 101|Md||mendelevium|mendélévium|mendelevio|mendelévio|менделевий|مندلفيوم|钔|メンデレビウム|멘델레븀|menđelevi|मेण्डेलीवियम|মেন্ডেলিভিয়াম|mendelevium|mendelevi|mendelevyum||mendelevium|
+mendelevi yum|yum 101|Md|eng:mendelevium, fra:mendélévium, spa:mendelevio, por:mendelévio, rus:менделевий, zho:钔 (mén), jpn:メンデレビウム, kor:멘델레븀, vie:menđelevi, hin:मेण्डेलीवियम, ben:মেন্ডেলিভিয়াম, may:mendelevium, swa:mendelevi|mendelevium|mendélévium|mendelevio|mendelévio|менделевий|مندلفيوم|钔|メンデレビウム|멘델레븀|menđelevi|मेण्डेलीवियम|মেন্ডেলিভিয়াম|mendelevium|mendelevi|mendelevyum||mendelevium|
 meninge|||eng:meninx, spa:por:meninge, fra:méninge|meninx (meninges)|méninge|meninge|meninge|||脑脊膜||||||||||aivokalvo|opona mózgowa
 meninge flame||||meningitis||meningitis||||||||||||||aivokalvontulehdus|zapalenie opon mózgowych
 mentor|||san:मन्त्रिन् (mantrin), hin:मंत्री (mantrī), tha:มนตรี (mon-tri), may:menteri, eng:deu:fra:por:spa:mentor, jpn:メンター (mentā), kor:멘토 (mento), rus:ментор (mentor)|advisor (counselor, mentor)||consejero (asesor)||||||||||||||neuvontantaja (mentori)|doradca (mentor)
@@ -2569,7 +2570,7 @@ mole|unomete|mol||mole (unit)|mole (unité)|mol|mol|||摩尔 (单位)|モル||||
 molekul|||eng:molecule, spa:por:molécula, fra:molécule|molecule||molécula||||分子|分子||||||||||molekuła (cząsteczka)
 moli|bio|Jasminum|kan:ಮಲ್ಲಿಗೆ  (mallige), tam:(mallikai), tel:మల్లె  (malle), may:melati, tha:มะลิ (má-lí), kor:말리 (malli), tha:มะลิ (mali), zho:茉莉 (mòlì), yue:茉莉 (mut6lei5)|jasmine|jasmin|jazmín|jasmim|жасмин||茉莉|茉莉|말리|mạt lị|चमेली|ইয়াসমিন|melati|asumini|yasemin|jasmeno|jasmiini|jaśmin
 moli hua chai||||jasmine tea||||||茉莉花茶|茉莉花茶||||||||jasmenteo|jasmiinitee|
-moliden yum|yum 042|Mo||molybdenum|molybdène|molibdeno|molibdénio|молибден|مولبيدنيوم|钼|モリブデン|몰리브덴, 2몰리브덴넘|molypđen, molipđen|मोलिब्डेनम|মলিবডেনাম|molibden|molibdeni|molibden|molibdeno|molybdeeni|molibden
+moliden yum|yum 042|Mo|eng:molybdenum, fra:molybdène, spa:molibdeno, por:molibdénio, rus:молибден, zho:钼 (mù), jpn:モリブデン, kor:몰리브덴, vie:molypđen, hin:मोलिब्डेनम, ben:মলিবডেনাম, may:molibden, swa:molibdeni|molybdenum|molybdène|molibdeno|molibdénio|молибден|مولبيدنيوم|钼|モリブデン|몰리브덴|molypđen, molipđen|मोलिब्डेनम|মলিবডেনাম|molibden|molibdeni|molibden|molibdeno|molybdeeni|molibden
 moluske|bio|Mollusca|eng:mollusk, deu:Molluske, fra:mollusque, rus:моллюск (mollyusk), spa:por:molusco, may:moluska, hin:urd:(molask)|mollusk||molusco||моллюск||||||||moluska|||molusko|nilviäinen|mięczak (morski bezkręgowiec)
 Monako|desha|MC||Monaco||Mónaco||||||||||||||Monaco|Monako
 Mongol|desha|MN||Mongolia||Mongolia|||||||||||||Mongolio|Mongolia|Mongolia
@@ -2584,7 +2585,7 @@ mos di||||mossy|moussu|musgoso||мшистый|||苔状|||||berlumut|||||omszał
 mosim|||ara: موسم (mawsim), hin:मौसम (mausam), may:musim, tur:mevsim, swa:msimu + eng:monsoon, fra:mousson, por:monção, rus:муссон (musson)|season|saison|estación (temporada)|estação (sazão)|время года (сезон)|فصل‎ (موسم‎)|季|季節|계절|mùa|मौसम|ঋতু|musim|msimu|mevsim (sezon)|sezono|vuodenaika|pora roku
 moskite||biwe|eng:spa:por:mosquito, fra:moustique, deu:Moskito, rus:моски́т (moskít), ben:মশা (môśa), kor:모기 (mogi)|mosquito||mosquito||||||||||||||hyttynen (sääski)|komar, moskit
 Moskva|xefsite|RU||Moscow||||Москва||||||||||||Moskova|Moskwa
-moskva yum|yum 115|Mc||moscovium|moscovium|moscovio|moscovio|московий|ٲنون بينتيوم||モスコビウム|우눈펜튬|moscovi|||moskovium|moscovi|moscoviyum|moskovio|moscovium|moskovium
+moskva yum|yum 115|Mc|eng:fra:moscovium, spa:moscovio, por:moscovio, rus:московий, jpn:モスコビウム, kor:우눈펜튬, vie:moscovi, may:moskovium, swa:moscovi|moscovium|moscovium|moscovio|moscovio|московий|ٲنون بينتيوم||モスコビウム|우눈펜튬|moscovi|||moskovium|moscovi|moscoviyum|moskovio|moscovium|moskovium
 moto|||eng:spa:por:tur:may:motor, fra;moteur, rus:мотор (motor), ara:(mutūr), zho:摩托 (mótuō), jpn:モーター (mōtā), kor:모터 (moteo), vie:mô-tơ, hin:मोटर (moṭar), ben:মোটর (moṭôr), swa:mota|engine (motor)|moteur|motor|motor|мотор||马达 (发动机)|モーター (エンジン, 機関)|모터 (기관)|động cơ (mô-tơ)|मोटर|ইঞ্জিন (মোটর)|motor|injini (ntambo, mota)|motor|motoro|moottori|silnik
 moto gar|||eng:motorcar, sna:motokari, sot:motokara, swa:motokaa, zul:imoto, hau:mota|motorcar (automobile)||automóvil (coche)||||||||||||||auto (automobiili)|samochód (automobil)
 moto sikle|||eng:motorcycle, spa:motocicleta, fra:motocyclette, rus:мотоцикл (mototsikl), tur:motosiklet, hin:मोटरसाइकिल (moṭarasāikila), may:motosikal, zho:摩托车 (mótuōchē), jpn:モーターサイクル (mōtāsaikuru)|motorcycle||motocicleta||мотоцикл|||オートバイ (モーターサイクル)|||||||||moottoripyörä|motocykl (motor)
@@ -2669,7 +2670,7 @@ nasi sosi sim||||Nazism||nazismo||||||||||||||natsismi|nazizm
 nasi sosi sim||||national socialism||socialismo nacional||||||||||||||kansallissosialismi|narodowy socjalizm
 nasi sosi sim ja||||Nazi||Nazi||||||||||||||natsi|nazista
 natre bilor||||natron||natrón||натрит (натр, натрон, кристаллическая сода)|||||||||||||
-natri|yum 011|Na||sodium|sodium|sodio|sódio|натрий|صوديوم|钠|ナトリウム|나트륨, 2 소듐|natri|सोडियम|সোডিয়াম|natrium|natiri|sodyum|natrio|natrium|sód
+natri|yum 011|Na|eng:sodium, fra:sodium, spa:sodio, por:sódio, rus:натрий, zho:钠 (nà), jpn:ナトリウム, kor:나트륨, vie:natri, hin:सोडियम, ben:সোডিয়াম, may:natrium, swa:natiri|sodium|sodium|sodio|sódio|натрий|صوديوم|钠|ナトリウム|나트륨|natri|सोडियम|সোডিয়াম|natrium|natiri|sodyum|natrio|natrium|sód
 nau|||zho:脑 (nǎo), yue:腦 (nou5), jpn:脳  (nō), kor:뇌 (noe), vie:não|brain|cerveau (cervelle)|cerebro|cérebro|мозг|دِمَاغ‎|脑|脳|뇌|óc (não)|मस्तिष्क (दिमाग़)|মগজ|otak (benak)|ubongo|beyin|cerbo|aivot|mózg
 nau di||||cerebral|cérébral|cerebral|cerebral|мозговой (церебральный)||大脑的||||||||beyinsel|cerba|aivoperäinen (aivo-)|mózgowy
 nau hin||||brainless||descerebrado||безмозглый|||||||মস্তিষ্কহীন||||sencerba|aivoton|bezmózgi
@@ -2697,11 +2698,11 @@ nen|||jpn:年 (nen), zho:年 (nián), yue:年 (nin4), kor:년 (nyeon), vie:năm
 nen festa||||anniversary||aniversario||||||||||||||vuosijuhla|rocznica
 nen mes den|||zho:年月日 (niányuèrì), jpn:年月日 (nengappi), kor:연월일 (yeonworil)|date||fecha||||年月日|年月日|연월일|||||||dato|päivämäärä|data
 nenufar|bio|Nymphaea alba|eng:nenuphar, spa:por:nenúfar, fra:nénufar, rus:ненюфа́р (nenjufár), fas:نیلوفر آبی‎ (nilufar-e âbi)|water lily (nenuphar)||nenúfar (lirio de agua)||||||||||||||lumme|lilia wodna, nenufar
-neodim yum|yum 060|Nd||neodymium|néodyme|neodimio|neodímio|неодим|نيودميوم|钕|ネオジム|네오디뮴|neođim|नियोडाइमियम|নিওডিমিয়াম|neodinium|neodimi|neodim||neodyymi|neodym
-neon|yum 010|Ne||neon|néon|neón|néon|неон|نيون|氖|ネオン|네온|neon, nê-ông|नियोन|নিয়ন|neon|neoni|neon|neono|neon|neon
+neodim yum|yum 060|Nd|eng:neodymium, fra:néodyme, spa:neodimio, por:neodímio, rus:неодим, zho:钕 (nǚ), jpn:ネオジム, kor:네오디뮴, vie:neođim, hin:नियोडाइमियम, ben:নিওডিমিয়াম, may:neodinium, swa:neodimi|neodymium|néodyme|neodimio|neodímio|неодим|نيودميوم|钕|ネオジム|네오디뮴|neođim|नियोडाइमियम|নিওডিমিয়াম|neodinium|neodimi|neodim||neodyymi|neodym
+neon|yum 010|Ne|eng:neon, fra:néon, spa:neón, por:néon, rus:неон, zho:氖 (nǎi), jpn:ネオン, kor:네온, vie:neon, nê-ông, hin:नियोन, ben:নিয়ন, may:neon, swa:neoni|neon|néon|neón|néon|неон|نيون|氖|ネオン|네온|neon, nê-ông|नियोन|নিয়ন|neon|neoni|neon|neono|neon|neon
 Nepal|desha|NP||Nepal||Nepal|||||||||||||Nepalo|Nepal|Nepal
 Neputun|planete 8|||Neptune|Neptune|Neptuno|Netuno|Нептун|نبتون|||||||||Neptün|Neptuno|Neptunus|Neptun
-neputun yum|yum 093|Np||neptunium|neptunium|neptunio|neptúnio|нептуний|نبتونيوم|镎|ネプツニウム|넵투늄|neptuni|नेप्ट्यूनियम|নেপচুনিয়াম|neptunium|neptuni|neptunyum|neptunio|neptunium|neptun
+neputun yum|yum 093|Np|eng:neptunium, fra:neptunium, spa:neptunio, por:neptúnio, rus:нептуний, zho:镎 (ná), jpn:ネプツニウム, kor:넵투늄, vie:neptuni, hin:नेप्ट्यूनियम, ben:নেপচুনিয়াম, may:neptunium, swa:neptuni|neptunium|neptunium|neptunio|neptúnio|нептуний|نبتونيوم|镎|ネプツニウム|넵투늄|neptuni|नेप्ट्यूनियम|নেপচুনিয়াম|neptunium|neptuni|neptunyum|neptunio|neptunium|neptun
 nerve|||eng:spa:por:fra:deu:neuro-, rus:невро- (nevro-)|nerve||nervio|||||||||||||nervo|hermo|nerw
 nerve di||||neural||neural|||||||||||||nerva|hermostollinen|nerwowy (neuronowy)
 nerve pati||||neuropathy||neuropatía||||||||||||||hermosairaus (neuropatia)|neuropatia
@@ -2721,21 +2722,21 @@ niche di||||lower (inferior)||inferior||||||||||||||ala-|poniższy
 nide|||eng:nest, spa:nido, por:ninho, fra:nid, rus:гнездо (gnezdo), hin:नीड़ (nīḍa), ben:নীড় (nīṛa)|nest (hive, den)|nid|nido (avispero, hormiguero, ratonera)|ninho (vespiero)|гнездо (улей)||巢 (穴)|巣|||घोंसला (नीड़, छत्ताधानी)||sarang|tundu (kiota, mzinga)||||gniazdo (ul, nora, jama, barłóg, legowisko)
 Nijer|desha|NE||Niger||Níger|||||||||||||Niĝero|Niger|Niger
 Nikaragua|desha|NI||Nicaragua||Nicaragua|||||||||||||Nikaragvo|Nikaragua|Nikaragua
-nikel|yum 028|Ni||nickel|nickel|níquel|níquel|никель|نيكل|镍|ニッケル|니켈|nikel|निकेल|নিকেল|nikel|nikeli|nikel|nikelo|nikkeli|nikiel
+nikel|yum 028|Ni|eng:nickel, fra:nickel, spa:níquel, por:níquel, rus:никель, zho:镍 (niè), jpn:ニッケル, kor:니켈, vie:nikel, hin:निकेल, ben:নিকেল, may:nikel, swa:nikeli|nickel|nickel|níquel|níquel|никель|نيكل|镍|ニッケル|니켈|nikel|निकेल|নিকেল|nikel|nikeli|nikel|nikelo|nikkeli|nikiel
 nilon|||eng:por:fra:nylon, spa:nilón, rus:нейлон (nejlon), ara:نَايْلُون‎ (nāylūn), fas:نایلون‎ (nâylon), may:nilon, swa:nailoni, zho:尼龙 (nílóng), jpn:ナイロン (nairon)|nylon|nylon|nailon (nilón)||нейлон||尼龙|ナイロン|||||nilon|nailoni||nilono|nailon|nylon
-niobi yum|yum 041|Nb||niobium|niobium|niobio|nióbio|ниобий|نيوبيوم|铌|ニオブ|나이오븀,니오븀, 니오브|niobi|नायोबियम|নাইওবিয়াম|niobium|niobi|niobyum|niobo|niobium|niob
+niobi yum|yum 041|Nb|eng:niobium, fra:niobium, spa:niobio, por:nióbio, rus:ниобий, zho:铌 (ní), jpn:ニオブ, kor:나이오븀, vie:niobi, hin:नायोबियम, ben:নাইওবিয়াম, may:niobium, swa:niobi|niobium|niobium|niobio|nióbio|ниобий|نيوبيوم|铌|ニオブ|나이오븀|niobi|नायोबियम|নাইওবিয়াম|niobium|niobi|niobyum|niobo|niobium|niob
 Nipon|desha|JP||Japan|Japon|Japón|Japão|Япония||日本|日本|일본|Nhật Bản|जापान|জাপান|Jepang|Japani|Japonya|Japanio|Japani|Japonia
 nipon di||||Japanese||japonés|||||日本の (日本語, 日本人)||||||||japana|japanilainen|japoński
-nipon yum|yum 113|Nh||nihonium|nihonium|nihonio|nihonium|нихоний|ٲنون يريوم||ニホニウム|우눈트륨|nihoni|||nihonium|nihoni|nihoniyum|nihonio|nihonium|nihonium
+nipon yum|yum 113|Nh|eng:fra:may:nihonium, spa:nihonio, por:nihonium, rus:нихоний, jpn:ニホニウム, kor:우눈트륨, vie:swa:nihoni|nihonium|nihonium|nihonio|nihonium|нихоний|ٲنون يريوم||ニホニウム|우눈트륨|nihoni|||nihonium|nihoni|nihoniyum|nihonio|nihonium|nihonium
 nish|||fra:eng:niche, por:nicho, rus:ниша (niša)|niche (recess, alcove)|niche|hornacina|nicho|ниша||壁龛|壁龕|반침||||||||alkovi|nisza, alkowa
 Nistre||||Dniester||Dniéster|||||||||||||||
-nitre|yum 007|N||nitrogen|azote|nitrógeno|nitrogénio|азот|نيتروجين|氮|窒素|질소|nitơ|नाइट्रोजन|নাইট্রোজেন|nitrogen|nitrojeni|azot|nitrogeno|typpi|azot
+nitre|yum 007|N|eng:nitrogen, fra:azote, spa:nitrógeno, por:nitrogénio, rus:азот, vie:nitơ, hin:नाइट्रोजन, ben:নাইট্রোজেন, may:nitrogen, swa:nitrojeni|nitrogen|azote|nitrógeno|nitrogénio|азот|نيتروجين|氮|窒素|질소|nitơ|नाइट्रोजन|নাইট্রোজেন|nitrogen|nitrojeni|azot|nitrogeno|typpi|azot
 Niue|desha|NU||Niue||Niue||||||||||||||Niue|Niue
 niuton|unomete|N||newton (N)||newton (N)|||||||||||||newtono (N)|newton (N)|niuton (N)
 no|||eng:spa:no, fra:non, por:não, ben:না (na), rus:не (nye), hin:नहीं (nahī̃), kor:아니 (ani), jpn:-ない (-nai)|not (no)|non (ne...pas)|no|não|нет (не)||不|いいえ|||नहीं|না|tidak|||ne|ei|nie
 no na lin||||offline||||||离线|||||||||||offline (nie na linii, poza siecią)
 no yau di||||unnecessary (extraneous, unneeded)|inutile|innecesario|||||不要|||||||||tarpeeton|niepotrzebny
-nobel yum|yum 102|No||nobelium|nobélium|nobelio|nobélio|нобелий|نوبليوم|锘|ノーベリウム|노벨륨|nobeli|नोबेलियम|নোবেলিয়াম|nobelium|nobeli|nobelyum|nobelio|nobelium|nobel
+nobel yum|yum 102|No|eng:nobelium, fra:nobélium, spa:nobelio, por:nobélio, rus:нобелий, zho:锘 (nuò), jpn:ノーベリウム, kor:노벨륨, vie:nobeli, hin:नोबेलियम, ben:নোবেলিয়াম, may:nobelium, swa:nobeli|nobelium|nobélium|nobelio|nobélio|нобелий|نوبليوم|锘|ノーベリウム|노벨륨|nobeli|नोबेलियम|নোবেলিয়াম|nobelium|nobeli|nobelyum|nobelio|nobelium|nobel
 nobi||||genderqueer (non-binary)|non-binaire|no binario (género)|não-binário||||||||||||neduuma|muunsukupuolinen|genderqueer, niebinarny
 noche|||spa:noche, por:noite, rus:ночь (nočʹ), pol:noc|night|noit|noche|noite|ночь||夜|夜|||रात||malam||gece|nokto|yö|noc
 noche mode||||night mode||modo nocturno||||||||||||||yömoodi|tryb nocny
@@ -2799,7 +2800,7 @@ ofis di||||official||oficial||||||||||||||virallinen|oficjalny
 ofis ja||||officer||funcionario||||||||||||||virkailija (virkamies)|funkcjonariusz, urzędnik
 ofis kan||||office (room)||oficina|||||||||||||||biuro (pokój)
 ofis poze||||office (position)||cargo||||||||||||||virka (virka-asema)|urząd, pozycja, stanowisko, funkcja
-oganeson|yum 118|Og||oganesson|oganesson|oganesón|oganesson|оганесон|||オガネソン|우누녹튬||||oganesson|||oganesono|oganesson|oganesson
+oganeson|yum 118|Og|eng:fra:por:may:oganesson, spa:oganesón, rus:оганесон, jpn:オガネソン, kor:우누녹튬|oganesson|oganesson|oganesón|oganesson|оганесон|||オガネソン|우누녹튬||||oganesson|||oganesono|oganesson|oganesson
 ohtopus|bio|Octopodiformes|eng:octopus, deu:Oktopus, tur:ahtapot, ara:أخطبوط (ʾuḵṭubūṭ), fas:اختاپوس‎ (oxtâpus), hin:ऑक्टोपस (okṭopasa), ben:অক্টোপাস (ôkṭopaś)|octopus|Poulpe (pieuvre)|pulpo|polvo|спрут (осьминог)|أخطبوط|章鱼|タコ|낙지 (문어)|bạch tuộc|||gurita|pweza|ahtapot||mustekala|ośmiornica
 oke|||eng:okay, spa:tur:may:okey, por:OK, rus:окей (okej), ara:أُوكِي‎‎‎ (ʾokey), hin:ओके (oke), zho:OK (ōukèi), jpn:オーケー (ōkē)|okay (acceptable)||bien (aceptable)|||||大丈夫 (ＯＫ)||||||||akceptebla (okej)|kelpo (okei)|okej, spoko, akceptowalny
 oke loga||||okay (acceptance)||||||||||||||||hyväksyntä|
@@ -2808,7 +2809,7 @@ oko di||||ocular|oculaire|ocular|ocular|глазной|عَيْنِيّ|||||||||
 oko kesha||||eyelash||pestaña||||||||||||||silmäripsi|rzęsa
 oko sui|||tam:கண்ணீர் (kaṇṇīr), mal:കണ്ണുനീർ (kaṇṇunīr), tel:(kannīru), kor:눈물 (nunmul), vie:nước mắt, may:air mata, tha:น้ำตา|tear drop||lágrima||||||||||||||kyynel|łza
 oko sui gas||||tear gas|gaz lacrymogène|gas lacrimógeno|gás lacrimogéneo|слезоточи́вый газ||催泪瓦斯|催涙ガス||hơi cay||||||||gaz łzawiący
-oksi|yum 008|O||oxygen|oxygène|oxígeno|oxigénio|кислород|أكسجين|氧|酸素|산소|oxy, oxi|ऑक्सीजन|অক্সিজেন|oksigen|oksijeni|oksijen|oksigeno|happi|tlen
+oksi|yum 008|O|eng:oxygen, fra:oxygène, spa:oxígeno, por:oxigénio, rus:кислород, vie:oxy, oxi, hin:ऑक्सीजन, ben:অক্সিজেন, may:oksigen, swa:oksijeni|oxygen|oxygène|oxígeno|oxigénio|кислород|أكسجين|氧|酸素|산소|oxy, oxi|ऑक्सीजन|অক্সিজেন|oksigen|oksijeni|oksijen|oksigeno|happi|tlen
 okside||||oxide|oxyde|óxide|óxide|окись (оксид)||氧化物|||||||||oksido|oksidi|tlenek
 Olande nesi|desha|AX||Aland Islands||islas Aland||||||||||||||Ahvenanmaa (Oolanti)|Wyspy Alandzkie
 Oman|desha|OM||Oman||Omán||||||||||||||Oman|Oman
@@ -2833,7 +2834,7 @@ oskope|||eng:fra:-scope, spa:por:-scopio, rus:-скоп (skop), jpn:スコープ
 oskur|||eng:obscure, spa:oscuro, por:escuro, fra:obscur|dark (dim)||oscuro||||||||||||||pimeä (hämärä)|ciemny, słabo oświetlony
 osman||||Ottoman||otomana||||||||||||||osmani (ottomaani)|Turek osmański
 Osman Imperi Desha||||Ottoman Empire||Imperio otomano||||||||||||Osmanlı İmparatorluğu||Osmanien valtakunta|Imperium Osmańskie
-osmi yum|yum 076|Os||osmium|osmium|osmio|ósmio|осмий|ازميوم|锇|オスミウム|오스뮴|osimi, osmi|अस्मियम|অসমিয়াম|osmium|osmi|osmiyum|osmio|osmium|osm
+osmi yum|yum 076|Os|eng:osmium, fra:osmium, spa:osmio, por:ósmio, rus:осмий, jpn:オスミウム, kor:오스뮴, vie:osimi, hin:अस्मियम, ben:অসমিয়াম, may:osmium, swa:osmi|osmium|osmium|osmio|ósmio|осмий|ازميوم|锇|オスミウム|오스뮴|osimi, osmi|अस्मियम|অসমিয়াম|osmium|osmi|osmiyum|osmio|osmium|osm
 osmos|||ell:ώσμωση (ósmosi), eng:may:osmosis, spa:ósmosis, por:fra:osmose, rus:осмос (osmos), fas:تَراران (osmoz)|osmosis||ósmosis||осмос|||||||||||osmozo|osmoosi|osmoza
 oste|bode||eng:deu:osteo-, rus:остео- (osteo-), ita:por:osso, fra:os, hin:अस्थि (asthi-)|bone||hueso|||||||||||||osto|luu|kość
 oste jama||||skeleton (frame)|squelette|esqueleto (armazón)|esqueleto|скелет (остов)||骨骼|骨格||||||||||szkielet
@@ -2855,7 +2856,7 @@ pake|||eng:pack, rus:пакет (paket), hin:पैकेट (pækeṭ), deu:tur
 Pakistan|desha|||Pakistan||Pakistán||||||||||||||Pakistan|Pakistan
 paksi|bio|Aves|hin:mar:पक्षी (pakṣī), mal:പക്ഷി (pakṣi), tel:(pakṣi), kh:បក្សី (baksəy), tha:ปักษา (pak-sa), ben:পাখী (pakhī), pnb:ਪੰਖੀ (paṅkhī)|bird|oiseau|pájaro (ave)||||||||पक्षी|পাখী||||birdo|lintu|ptak
 palaba|||eng:palaver, krio:plabah, kon:palaba|conflict (argument, dispute, quarrel)|querelle (dispute, palabre)|||||||||||||||riita (kiista)|
-paladi yum|yum 046|Pd||palladium|palladium|paladio|paládio|палладий|بلاديوم|钯|パラジウム|팔라듐|palađi|पलाडियम|প্যালাডিয়াম|paladium|paladi|palladyum|paladio|palladium|pallad
+paladi yum|yum 046|Pd|eng:palladium, fra:palladium, spa:paladio, por:paládio, rus:палладий, zho:钯 (bǎ), jpn:パラジウム, kor:팔라듐, vie:palađi, hin:पलाडियम, ben:প্যালাডিয়াম, may:paladium, swa:paladi|palladium|palladium|paladio|paládio|палладий|بلاديوم|钯|パラジウム|팔라듐|palađi|पलाडियम|প্যালাডিয়াম|paladium|paladi|palladyum|paladio|palladium|pallad
 Palau|desha|PW||Palau||Palaos||||||||||||||Palau|Palau
 palme|||deu:Palme, eng:palm, por:spa:palma, rus:пальма (palma), tur:palmiye, may:palem, tha:ปาล์ม (pām)|palm tree||palmera|||||||||||||palmo|palmu|palma, drzewo palmowe
 pan|||eng:fra:spa:por:pan-, rus:пан- (pan-) + zho:泛 (fàn), jpn:汎 (han), kor:범 (beom)|every (all)||todo|||||全ての||||||||ĉiu|kaikki|wszyscy, wszystkie, wszystko; każdy
@@ -3018,15 +3019,15 @@ plate geo kaske logi||||plate tectonics|tectonique des plaques|tectónica de pla
 plate geo sim ja||||flat-earther|terreplatiste|terraplanista|terraplanista|плоскоземелец||||||||||||litteän maapallon kannattaja|płaskoziemca
 plate tasa||||plate||plato||||||||||||||lautanen|talerz
 plate topo||||plain (plateau, flat lands)|plaine|llanura||||平原|草原||||||||||równina (plaskowyż, plateau)
-platin|yum 078|Pt||platinum|platine|platino|platina|платина|بلاتين|铂|白金|백금|platin|प्लाटिनम|প্লাটিনাম|platina|platini|platin|plateno|platina|platyna
+platin|yum 078|Pt|eng:platinum, fra:platine, spa:platino, por:platina, rus:платина, zho:铂 (bó), vie:platin, hin:प्लाटिनम, ben:প্লাটিনাম, may:platina, swa:platini|platinum|platine|platino|platina|платина|بلاتين|铂|白金|백금|platin|प्लाटिनम|প্লাটিনাম|platina|platini|platin|plateno|platina|platyna
 Platon||||Plato||Platón||||||||||||||Platon|Platon
 Platon sim||||Platonism||platonismo||||||||||||||platonismi|platonizm
 Platon sim di||||Platonic||platónico||||||||||||||platoninen|platoniczne
 Platon sim ja||||Platonist||platonista||||||||||||||platonisti|platończyk
 plazma|||eng:plasma, spa:plasma, rus:плазма (plazma), ara:بلازما (balazima), hin:प्लाज़्मा (plaazma), jpn:プラズマ (purazuma), may:plasma|plasma (ionized gas)||plasma (gas ionizado)|||||||||||||||plazma (zjonizowany gaz)
-plumbe|yum 082|Pb||lead|plomb|plomo|chumbo|свинец|رصاص|铅|鉛|납|chì|सीसा|লেড|timbal|risasi (plumbi)|kurşun|plumbo|lyijy|ołów
+plumbe|yum 082|Pb|fra:plomb, spa:plomo, por:chumbo, swa:plumbi|lead|plomb|plomo|chumbo|свинец|رصاص|铅|鉛|납|chì|सीसा|লেড|timbal|risasi (plumbi)|kurşun|plumbo|lyijy|ołów
 Pluton||||Pluto (dwarf planet)||Plutón||||||||||||||Pluto (kääpiöplaneetta)|Pluton (planeta karłowata)
-pluton yum|yum 094|Pu||plutonium|plutonium|plutonio|plutónio|плутоний|بلوتونيوم|钚|プルトニウム|플루토늄|plutoni|प्लूटोनियम|প্লুটোনিয়াম|plutonium|plutoni|plutonyum|plutonio|plutonium|pluton
+pluton yum|yum 094|Pu|eng:plutonium, fra:plutonium, spa:plutonio, por:plutónio, rus:плутоний, zho:钚 (bù), jpn:プルトニウム, kor:플루토늄, vie:plutoni, hin:प्लूटोनियम, ben:প্লুটোনিয়াম, may:plutonium, swa:plutoni|plutonium|plutonium|plutonio|plutónio|плутоний|بلوتونيوم|钚|プルトニウム|플루토늄|plutoni|प्लूटोनियम|প্লুটোনিয়াম|plutonium|plutoni|plutonyum|plutonio|plutonium|pluton
 poker|||eng:fra:tur:poker, spa:por:póquer, rus:покер (poker), ara:بُوكَر‎ (būkar), hin:पोकर (pokar), zho:扑克 (pūkè), jpn:ポーカー (pōkā), kor:포커 (pokeo)|poker||póquer|||||||||||||pokero|pokeri|poker
 polau|||fas:(polou), hin:पुलाव (pulav), tur:pilav, rus:плов (plov)|pilaf (pulao)||pilaf (pulaw)||плов||||||पुलाव||||pilav||pilahvi|pilaw
 poli||||poly- (multi-)||poli-||||||||||||||moni- (poly-, multi-)|wielo- (poli-, multi-)
@@ -3053,7 +3054,7 @@ politi lon||||politics (political discourse)||política||||政治|政道||||||||
 politi mode||||regime||régimen|regime|||政体|政体|||||||||hallintomuoto|
 Polska|desha|PL||Poland||Polonia||||||||||||||puola|Polska
 polska basha|basha|||Polish language||idioma polaco||||||||||||||puolalainen|polski
-polska yum|yum 084|Po||polonium|polonium|polonio|polónio|полоний|بولونيوم|钋|ポロニウム|폴로늄|poloni|पोलोनियम|পোলনিয়াম|polonium|poloni|polonyum|polonio|polonium|polon
+polska yum|yum 084|Po|eng:polonium, fra:polonium, spa:polonio, por:polónio, rus:полоний, zho:钋 (pō), jpn:ポロニウム, kor:폴로늄, vie:poloni, hin:पोलोनियम, ben:পোলনিয়াম, may:polonium, swa:poloni|polonium|polonium|polonio|polónio|полоний|بولونيوم|钋|ポロニウム|폴로늄|poloni|पोलोनियम|পোলনিয়াম|polonium|poloni|polonyum|polonio|polonium|polon
 pompe|||eng:pump, spa:por:bombear, fra:pomper, deu:pumpen|pump||bombear||||||||||||||pumppu|pompować
 ponte|||eng:point, por:apontar, spa:apuntar, fra:pointer|point at (indicate)||apuntar (indicar)|||||||||||||montri|osoittaa (näyttää)|wskazać, wskazywać
 ponte fleche||||pointer (indicator)||indicador (cursor)||||||||||||||osoitin (viisari)|wskaźnik
@@ -3074,7 +3075,7 @@ pos di||||back (posterior)|postérieur|posterior|posterior|||||||||||||myöhempi
 pos fikse||||suffix|suffixe|sufijo||||||||||||||loppuliite (jälkiliite)|przyrostek (sufiks)
 pos poza||||put back (postpone)||||||||||||||||siirtää taakse|
 pos zaman||||future time||futuro|||||||||||||estonoteco|tulevaisuus|przyszłość
-pospor|yum 015|P||phosphorus|phosphore|fósforo|fósforo|фосфор|فوسفور|磷|リン|인|photpho|फास्फोरस|ফসফরাস|fosfor|posfori|fosfor|fosforo|fosfori|fosfor
+pospor|yum 015|P|eng:phosphorus, fra:phosphore, spa:fósforo, por:fósforo, rus:фосфор, vie:photpho, hin:फास्फोरस, ben:ফসফরাস, may:fosfor, swa:posfori|phosphorus|phosphore|fósforo|fósforo|фосфор|فوسفور|磷|リン|인|photpho|फास्फोरस|ফসফরাস|fosfor|posfori|fosfor|fosforo|fosfori|fosfor
 posta|||eng:post, por:postagem, fra:poste, rus:почта (pochta), tur:posta, ara:بوسطة‎ (busṭa), swa:posta, may:pos, fas:پست‎ (post)|mail||correo||||||||||pos|posta|||posti (postilähetys)|poczta
 posta chape||||postal stamp||sello postal||||||||||||||postileima|znaczek pocztowy
 posta kan||||post office||oficina de correos|||||||||||||poŝtejo|postitoimisto|poczta, budynek poczty
@@ -3086,7 +3087,7 @@ pote shuta||||pottery|poterie|alfarería|cerâmica|гончарное дело||
 poze|||eng:spa:por:fra:pose, deu:Pose, rus:поза (poza), jpn:ポーズ|pose (position)||pose (postura)||||||||||||||asetelma|poza, pozycja
 prati|||eng:practice, fra:pratique, por:prática, tur:pratik, pol:praktyka, hin:प्रथा (prathā)|practice (actuality)||práctica||||||||||||||käytäntö (pragmatia)|praktyka, aktualność
 prati di||||practical (pragmatic)||práctico||||||||||||||käytännöllinen (pragmaattinen)|practyczny, pragmatyczny
-prazedim yum|yum 059|Pr||praseodymium|praséodyme|praseodimio|praseodímio|празеодим|براسوديميوم|镨|プラセオジム|프라세오디뮴|prazeođim|प्रासियोडाइमियम|প্র্যাসেওডিমিয়াম|praseodinium|praseodimi|praseodim||praseodyymi|prazeodym
+prazedim yum|yum 059|Pr|eng:praseodymium, fra:praséodyme, spa:praseodimio, por:praseodímio, rus:празеодим, jpn:プラセオジム, kor:프라세오디뮴, vie:prazeođim, hin:प्रासियोडाइमियम, ben:প্র্যাসেওডিমিয়াম, may:praseodinium, swa:praseodimi|praseodymium|praséodyme|praseodimio|praseodímio|празеодим|براسوديميوم|镨|プラセオジム|프라세오디뮴|prazeođim|प्रासियोडाइमियम|প্র্যাসেওডিমিয়াম|praseodinium|praseodimi|praseodim||praseodyymi|prazeodym
 presa|||fra:pression, spa:presión, por:pressão, rus:пресс (press), jpn:プレス (puresu)|pressure|pression|presión|pressão|давление (нажим)||压力|圧力|압력|áp lực|दाब|চাপ|tekanan||basınç|premo|puristus (paine)|
 presa gi||||press device|pressoir|prensa|prensa|пресс|||圧搾機||||||||premilo|puristin|
 prezidente|||eng:president, spa:por:presidente, rus:президент (prezident), kat:პრეზიდენტი (ṗrezidenṭi), fas:پرزیدنت‎ (perezident), may:presiden|president||presidente|||||||||||||prezidento|presidentti|prezydent
@@ -3097,9 +3098,9 @@ program|||eng:may:tur:program, fra:programme, por:spa:programa, rus:програ
 program ja||||programmer (coder)||programador||||||||||||||ohjelmoija|programista, koder
 projete|||fra:projet, por:projeto, eng:project, spa:proyecto, rus:проект (proyekt), hin:प्रोजैक्ट (projaikṭ), ben:প্রজেক্ট (prôjekṭ), jpn:プロジェクト (purojekuto), kor:프로젝트 (peurojekteu), tur:proje|project (endeavour)|projet|proyecto|projeto|проект|||プロジェクト|계획 (프로젝트)||परियोजना (प्रोजैक्ट)|প্রজেক্ট|||||hanke (projekti)|projekt, planowane przedsięwzięcie
 Promete|name|||Prometheus|Prométhée|Prometeo|Prometeu|Прометей||||||||||||Prometheus|
-promete yum|yum 061|Pm||promethium|prométhium|prometio|promécio|прометий|بروميثيوم|钷|プロメチウム|프로메튬|prometi|प्रोमेथियम|প্রমিথিয়াম|prometium|promethi|prometyum|prometio|prometium|promet
+promete yum|yum 061|Pm|eng:promethium, fra:prométhium, spa:prometio, por:promécio, rus:прометий, zho:钷 (pǒ), jpn:プロメチウム, kor:프로메튬, vie:prometi, hin:प्रोमेथियम, ben:প্রমিথিয়াম, may:prometium, swa:promethi|promethium|prométhium|prometio|promécio|прометий|بروميثيوم|钷|プロメチウム|프로메튬|prometi|प्रोमेथियम|প্রমিথিয়াম|prometium|promethi|prometyum|prometio|prometium|promet
 proses|||eng:process, spa:proceso, por:processo, rus:процесс (process), fas:پروسه‎ (prose), may:proses, jpn:プロセス (purosesu), kor:프로세스 (peuroseseu)|process (procedure)||proceso (procedimiento)||||||||||||||prosessi (proseduuri)|proces, procedura
-protacini yum|yum 091|Pa||protactinium|protactinium|proactinio|protacnídio|протактиний|بروتكتنيوم|镤|プロトアクチニウム|프로트악티늄 or 프로탁티늄|protactini|प्रोटैक्टीनियम|প্রোটেক্টিনিয়াম|protaktinium|protaktini|protaktinyum|protaktinio|protaktinium|protaktyn
+protacini yum|yum 091|Pa|eng:protactinium, fra:protactinium, spa:proactinio, por:protacnídio, rus:протактиний, zho:镤 (pú), jpn:プロトアクチニウム, kor:프로트악티늄, vie:protactini, hin:प्रोटैक्टीनियम, ben:প্রোটেক্টিনিয়াম, may:protaktinium, swa:protaktini|protactinium|protactinium|proactinio|protacnídio|протактиний|بروتكتنيوم|镤|プロトアクチニウム|프로트악티늄|protactini|प्रोटैक्टीनियम|প্রোটেক্টিনিয়াম|protaktinium|protaktini|protaktinyum|protaktinio|protaktinium|protaktyn
 puding|||eng:pudding, spa:pudín, rus:пудинг (puding), tur:may:puding, swa:pudini, ara:بودنغ (budingh), zho:布丁 (bùdīng), jpn:プディング (pudingu)|pudding||pudín||||布丁|||||||pudini|||vanukas|puding
 puja|||hin:पूजा (pūjā), urd:(pūjā), tha:บูชา (bucha), may:puja|worship (reveration)||adoración (veneración, culto)||||||||पूजा||||||palvonta|cześć, szacunek
 puja kan||||temple (place of worship)|temple|templo|templo|храм (место богослужения)|مَعْبَد‎|寺庙|神殿|절 (사원)|đền|मन्दिर|মন্দির|kuil|hekalu|tapınak (ibadethane)|templo|temppeli|świątynia
@@ -3133,9 +3134,9 @@ radi|||eng:fra:radiation, spa:radiación, por:radiação, may:radiasi, rus:ра�
 radi geter||||radio receiver||receptor de radio|||||||||||||radio|radiovastaanotin|radio
 radi metre gi||||radiometer||radiómetro||||||||||||||säteilymittari|radoiometr
 radi miser||||radiotransmitter||radiotransmisor||||||||||||||radiolähetin|nadajnik radiowy
-radi yum|yum 088|Ra||radium|radium|radio|rádio|радий|راديوم|镭|ラジウム|라듐|rađi|रेडियम|রেডিয়াম|radium|radi|radyum|radiumo|radium|rad
+radi yum|yum 088|Ra|eng:radium, fra:radium, spa:radio, por:rádio, rus:радий, zho:镭 (léi), jpn:ラジウム, kor:라듐, vie:rađi, hin:रेडियम, ben:রেডিয়াম, may:radium, swa:radi|radium|radium|radio|rádio|радий|راديوم|镭|ラジウム|라듐|rađi|रेडियम|রেডিয়াম|radium|radi|radyum|radiumo|radium|rad
 radio|||eng:fra:spa:por:radio, rus:радио (radio), tur:radyo, swa:redio, hin:रेडियो (reḍiyo), ben:রেডিও (reḍio), jpn:ラジオ (rajio), kor:라디오 (radio)|radio|radio|radio|radio|радио||||||रेडियो|রেডিও||redio|radyo|||radio
-radon|yum 086|Rn||radon|radon|radón|rádon|радон|رادون|氡|ラドン|라돈|rađơn|रेडन|রেডন|radon|radoni|radon|radono|radon|radon
+radon|yum 086|Rn|eng:radon, fra:radon, spa:radón, por:rádon, rus:радон, zho:氡 (dōng), jpn:ラドン, kor:라돈, vie:rađơn, hin:रेडन, ben:রেডন, may:radon, swa:radoni|radon|radon|radón|rádon|радон|رادون|氡|ラドン|라돈|rađơn|रेडन|রেডন|radon|radoni|radon|radono|radon|radon
 rai|||ara:(raʾy), swa:rai, hin:राय (rāy), fas:(ra'y), tur:rey|opinion (view)|avis (opinion)|opinión (juicio, consideración)|opinião|мнение|رَأْي‎|意见 (见解)|意見 (見解)|의견 (견해)|ý kiến (kiến giải)|विचार (राय)|অভিমতি (নজর)|opini|wazo (rai)|rey|opinio|mielipide (näkemys)|opinia, pogląd
 raite|||eng:right|right hand side||lado derecho|||||右|||||||||oikea puoli|prawa strona
 raite di||||right hand||derecho|||||||||||||||prawy (prawostronny, z prawej strony)
@@ -3173,8 +3174,8 @@ Rea|planete 6 lun 5|||Rhea|||||||||||||||||
 rebel|||eng:rebel, spa:por:rebelde fra:rebelle|rebellion||rebelión (sublevación)||||||||||||||kapina|rebelia, powstanie
 redi|||eng:ready, deu:bereit, fra:prêt, mao:reri|ready (prepared)||listo (preparado)|||||||||||||preta|valmis|gotowy
 Ren|rivo|||Rhine|Rhin|Rin|Reno|Рейн||莱茵河|ライン川|라인 강||राइन||Rhein||Ren|Rejno|Rein|Ren
-ren yum|yum 075|Re||rhenium|rhénium|renio|rénio|рений|رنيوم|铼|レニウム|레늄|reni|रेनियम|রেনিয়াম|renium|reni|renyum|renio|renium|ren
-rentegen yum|yum 111|Rg||roentgenium|roentgenium|roentgenio|roentgênio|рентгений|رونتجينيوم||レントゲニウム|뢴트게늄|roentgeni|रॉन्टजैनियम|রোয়েন্টজেনিয়াম|roentgenium|roentgeni|röntgenyum|rentgenio|roentgenium|roentgen
+ren yum|yum 075|Re|eng:rhenium, fra:rhénium, spa:renio, por:rénio, rus:рений, zho:铼 (lái), jpn:レニウム, kor:레늄, vie:reni, hin:रेनियम, ben:রেনিয়াম, may:renium, swa:reni|rhenium|rhénium|renio|rénio|рений|رنيوم|铼|レニウム|레늄|reni|रेनियम|রেনিয়াম|renium|reni|renyum|renio|renium|ren
+rentegen yum|yum 111|Rg|eng:roentgenium, fra:roentgenium, spa:roentgenio, por:roentgênio, rus:рентгений, zho: (lún), jpn:レントゲニウム, kor:뢴트게늄, vie:roentgeni, hin:रॉन्टजैनियम, ben:রোয়েন্টজেনিয়াম, may:roentgenium, swa:roentgeni|roentgenium|roentgenium|roentgenio|roentgênio|рентгений|رونتجينيوم||レントゲニウム|뢴트게늄|roentgeni|रॉन्टजैनियम|রোয়েন্টজেনিয়াম|roentgenium|roentgeni|röntgenyum|rentgenio|roentgenium|roentgen
 reporte|||eng:report, spa:reporte, fra:rapport, rus:рапорт (raport), tur:rapor, swa:ripoti, hin:रिपोर्ट (riporṭ), jpn:レポート (repōto)|report||informe (reporte, noticia)||||||||||||||raportti (selostus, selonteko)|raport
 reseta|||ita:ricetta, rus:рецепт (retsept), deu:Rezept, spa:receta, por:receita, fra:recette, may:resep, tur:reçete|instructions (recipe)|recette|instrucciones (receta)|receita|||||||||||tarif||resepti (ohje)|recepta, receptura, przepis
 reside|||fas:(resid), hin:रसीद (rasīd), urd:(rasīd), guj:રસીદ (rasīd), tel:రసీదు (rasīdu), + eng:receipt, swa:resiti, may:resit|receipt (acknowledgement)||reconocimiento (recibo)||||||||||||||kuitti (kuittaus)|paragon, pokwitowanie
@@ -3232,11 +3233,11 @@ rota van gi|||eng:top, fra:toupie|top (spinning top)|toupie|trompo||волчок
 roza|bio|Rosa|fra:eng:rose, spa:por:rosa, rus:роза (roza), fas:(roz, gol-e sorx), tgl:rosas|rose|rose|rosa|rosa|роза||玫瑰|バラ|장미|hoa hồng|गुलाब|গোলাপ|mawar (ros)|waridi|gül|rozo|ruusu|róża
 roza rang|rang|||pink (rosy)||rosa||||||||||||||vaaleanpunainen|różowy, różany
 roza salmon|bio|Oncorhynchus gorbuscha||pink salmon|saumon rose|salmón rosado|salmão-rosa|горбуша||粉紅鮭|カラフトマス||||||||||gorbusza
-roza yum|yum 045|Rh||rhodium|rhodium|rodio|ródio|родий|روديوم|铑|ロジウム|로듐|rođi|रोडियम|রোডিয়াম|rodium|rodi|rodyum|rodio|rodium|rod
+roza yum|yum 045|Rh|eng:rhodium, fra:rhodium, spa:rodio, por:ródio, rus:родий, jpn:ロジウム, kor:로듐, vie:rođi, hin:रोडियम, ben:রোডিয়াম, may:rodium, swa:rodi|rhodium|rhodium|rodio|ródio|родий|روديوم|铑|ロジウム|로듐|rođi|रोडियम|রোডিয়াম|rodium|rodi|rodyum|rodio|rodium|rod
 Ruanda|desha|RW||Rwanda||Ruanda||||||||||||||Ruanda|Rwanda
 rubi|rang||hin:लाल (lāl), ben:লাল (lal), tur:al|red|rouge|rojo|vermelho|красный|أَحْمَر|红|赤い|빨갛다|đỏ|लाल|লাল|merah|nyekundu|kırmızı (al)|ruĝa|punainen|czerwony
 rubi|||eng:ruby, por:rubi, spa:rubí, fra:rubis, deu:Rubin, rus:рубин (rubin), jpn:ルビー (rubī)|ruby|rubis|rubí|rubi|рубин|ياقوت|红宝石|ルビー|루비|hồng ngọc|मानिक (याक़ूत)||delima|yakuti|yakut|rubeno|rubiini|rubin
-rubi yum|yum 037|Rb|eng:fra:may:rubidium, spa:por:rubidio, ara: رُوبِيدْيُوم‎ (rubidyum), zho:銣 (rú), jpn:ルビジウム (rubijiumu), kor:루비듐 (rubidyum), vie:rubiđi, swa:rubidi|rubidium|rubidium|rubidio|rubídio|рубидий|روبيديوم|铷|ルビジウム|루비듐|rubiđi|रुबिडियम|রুবিডিয়াম|rubidium|rubidi|rubidyum|rubidio|rubidium|rubid
+rubi yum|yum 037|Rb|eng:rubidium, fra:rubidium, spa:rubidio, por:rubídio, rus:рубидий, zho:铷 (rú), jpn:ルビジウム, kor:루비듐, vie:rubiđi, hin:रुबिडियम, ben:রুবিডিয়াম, may:rubidium, swa:rubidi|rubidium|rubidium|rubidio|rubídio|рубидий|روبيديوم|铷|ルビジウム|루비듐|rubiđi|रुबिडियम|রুবিডিয়াম|rubidium|rubidi|rubidyum|rubidio|rubidium|rubid
 ruhu|||ara:(rūħ), may:ruh, tur:ruh, hin:रूह (rūh), swa:roho, hau:ruhu, som:ruux, + rus:дух (duh)|soul (mind, psyche)|psyché|psique||душа (дух)|||||||||||animo (psiko)|henki (sielu, mieli, psyyke)|dusza, duch, umysł
 ruhu di||||mental (psychic)||mental (psíquico)||||||||||||||henkinen (psyykkinen)|umysłowy (psychiczny)
 ruhu logi|||tur:ruh bilimi, hin:मनोविज्ञान (manovigyān), ben:মনোবিজ্ঞান (mônobiggan), may:ilmu jiwa, ara:(ʿilm an-nafs), deu:Seelenkunde, eng:psychology, spa:psicológia|psychology|psychologie|psicología|||||||||||saikolojia||psikologio|psykologia|psychologia
@@ -3252,7 +3253,7 @@ Rusia|desha|RU||Russia||Rusia||||||||||||||Venäjä|Rosja
 rusia basha|basha|rus||Russian language||idioma ruso||||||||||||||venäläinen|rosyjski
 rute|||eng:fra:route, spa:ruta, por:rota, deu:Route, jpn:ルート (rūto), rus:маршрут (maršrut)|route (path, trail, course, itinerary)||ruta||||||||||||||polku (reitti, kurssi)|ścieżka (droga, szlak, kurs)
 rute galte di||||stray (deviant)|||||||||||||||||zbłąkany (dewiacyjny, wykolejony)
-ruterfor yum|yum 104|Rf||rutherfordium|rutherfordium|rutherfordio|rutherfórdio|резерфордий, ²курчатовий|رذرفورديوم||ラザホージウム|러더포듐|rutherfordi|रुथरफोर्डियम|রাদারফোর্ডিয়াম|rutherfordium|rutherfordi|rutherfordiyum|ruterfordio|rutherfordium|rutherford
+ruterfor yum|yum 104|Rf|eng:rutherfordium, fra:rutherfordium, spa:rutherfordio, por:rutherfórdio, rus:резерфордий, ²курчатовий, zho: (lú), jpn:ラザホージウム, kor:러더포듐, vie:rutherfordi, hin:रुथरफोर्डियम, ben:রাদারফোর্ডিয়াম, may:rutherfordium, swa:rutherfordi|rutherfordium|rutherfordium|rutherfordio|rutherfórdio|резерфордий, ²курчатовий|رذرفورديوم||ラザホージウム|러더포듐|rutherfordi|रुथरफोर्डियम|রাদারফোর্ডিয়াম|rutherfordium|rutherfordi|rutherfordiyum|ruterfordio|rutherfordium|rutherford
 rutina|||eng:fra:routine, spa:rutina, por:rotina, deu:Routine, fas:روتین‎ (rutin), rus:рутина (rutina)|routine (habit)||rutina (hábito)|||||||||||||rutino (kutimo)|tapa (rutiini)|rutyna, nawyk, zwyczaj
 S||||S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S
 saba|||heb:(sibá), hau:sabo;sababi, kon:sambu, ara:urd:(sabab), tur:sebep, may:sebab, swa:sababu|reason (cause)||razón (causa)|||||||||||||kialo|syy|powód, przyczyna
@@ -3316,7 +3317,7 @@ sama blu||||light blue (sky blue, azure)||celeste (azul celeste)||голубой
 sama di||||celestial (heavenly)||celeste (celestial)|||||||||||||||niebieski, niebiański, podniebny
 sama hal||||weather||clima (tiempo)||погода||天气|天気|날씨|thời tiết|मौसम (ऋतु)|বতৰ|cuaca (hawa)|hali ya hewa|hava|vetero|sää|pogoda
 sama kinar||||horizon||horizonte||горизонт||地平线|地平線 (水平線, 天際)||||||||||horyzont
-samari yum|yum 062|Sm||samarium|samarium|samario|samário|самарий|ساماريوم|钐|サマリウム|사마륨|samari|सैमरियम|সামারিয়াম|samarium|samari|samaryum|samario|samarium|samar
+samari yum|yum 062|Sm|eng:samarium, fra:samarium, spa:samario, por:samário, rus:самарий, zho:钐 (shān), jpn:サマリウム, kor:사마륨, vie:samari, hin:सैमरियम, ben:সামারিয়াম, may:samarium, swa:samari|samarium|samarium|samario|samário|самарий|ساماريوم|钐|サマリウム|사마륨|samari|सैमरियम|সামারিয়াম|samarium|samari|samaryum|samario|samarium|samar
 Samoa|desha|WS||Samoa||Samoa||||||||||||||Samoa|Samoa
 sana||||production||producción||||||||||||||tuotanto|produkcja
 sana basha||||artificial language (conlang)||idioma artificial (lengua construida, conlang)|||||||||||||artefarita lingvo|keinotekoinen kieli (tekokieli, keinokieli)|język sztuczny
@@ -3374,7 +3375,7 @@ sekur kopi||||backup||copia de seguridad|||||バックアップ (控え)||||||||
 sekur nomer||||personal identification number (PIN)||número de identificación personal|||||暗証番号||||||||||osobisty numer identyfikacyjny (pin)
 sela||||should (ought)||deber (se recomienda)|||||||||||||devus|pitäisi|powinien
 sela loga|||ara: صَلَاح‎ (ṣalāḥ), hin:सलाह (salāh), tel:సలహా (salahā), tur:salık + eng:counsel, fra:conseil, spa:consejo, por:conselho + rus:консультант (konsultant)|advice (counsel)|conseil|consejo|conselho|совет||||||||||||neuvo|rada, porada
-selen yum|yum 034|Se||selenium|sélénium|selenio|selénio|селен|سيلينيوم|硒|セレン|셀렌, 2셀레늄|selen|सेलेनियम|সেলেনিয়াম|selenium|seleni|selenyum|seleno|seleeni|selen
+selen yum|yum 034|Se|eng:selenium, fra:sélénium, spa:selenio, por:selénio, rus:селен, zho:硒 (xī), jpn:セレン, kor:셀렌, vie:selen, hin:सेलेनियम, ben:সেলেনিয়াম, may:selenium, swa:seleni|selenium|sélénium|selenio|selénio|селен|سيلينيوم|硒|セレン|셀렌|selen|सेलेनियम|সেলেনিয়াম|selenium|seleni|selenyum|seleno|seleeni|selen
 selge|bio|Beta vulgaris subsp. vulgaris, Cicla|ara:سلق (silqa), spa:por:acelga|chard|blettes (bettes)|acelga||мангольд|||フダンソウ (スイスチャード)||||||||||boćwina (botwina)
 selu|||may:sel, fas:sellul, tha:เซลล์ (seel), swa:seli, tgl:selula, eng:cell, fra:cellule, spa:célula|cell (biology)||célula|||||||||||||ĉelo|solu|komórka (biologia)
 selu logi||||cytology|cytologie|citología|citologia|цитология||细胞学|||||||||citologio|soluoppi (sytologia)|cytologia
@@ -3496,7 +3497,7 @@ si ja||||being (entity)||ser||||||||||||||olento (olio)|
 si membre||||belong (be a member)||pertenecer (ser miembro de)||||||||||||||kuulua (olla jäsenenä)|należeć (być członkiem)
 sian|rang||eng:cyan, spa:cian, rus:циан (tsian), ara:سيان (sayan), hin:क्यान (kyāna), jpn:シアン (shian), may:sian|cyan||cian||циан|||シアン|||||||||syaani|niebieskozielony (cyjan)
 Sibiria||||Siberia||Siberia||||||||||||||Siperia|Syberia
-siborge yum|yum 106|Sg||seaborgium|seaborgium|seaborgio|seabórgio|сиборгий|سيبورجيوم||シーボーギウム|새보쥼|seaborgi|सीबोर्गियम|সিওবোর্গিয়াম|seaborgium|seaborgi|siborgiyum|seborgio|seaborgium|seaborg
+siborge yum|yum 106|Sg|eng:seaborgium, fra:seaborgium, spa:seaborgio, por:seabórgio, rus:сиборгий, zho: (xǐ), jpn:シーボーギウム, kor:새보쥼, vie:seaborgi, hin:सीबोर्गियम, ben:সিওবোর্গিয়াম, may:seaborgium, swa:seaborgi|seaborgium|seaborgium|seaborgio|seabórgio|сиборгий|سيبورجيوم||シーボーギウム|새보쥼|seaborgi|सीबोर्गियम|সিওবোর্গিয়াম|seaborgium|seaborgi|siborgiyum|seborgio|seaborgium|seaborg
 side|||rus:сидеть (sidet'), eng:sit, deu:sitzen, ita:sedere|sit down||sentarse|||||座る||||||||||usiąść
 side loka||||seat (saddle)||silla (montura)||сиденье (седло)||座部 (马鞍)|座席 (鞍)||||||||||siedzenie (siodło)
 sifa|||ara:صفة (ṣifa), fas:صفت (sefat), hin:सिफ़त (sifat), swa:sifa, tur:sıfat, may:sifat|attribute (charasteristic, quality, feature, description, property)||cualidad (atributo, descripción)||||||||||||||laatu (ominaisuus, ominaispiirre, määrite)|cecha, właściwość, parametr
@@ -3511,7 +3512,7 @@ sili|||hin:सिलसिला (silsilā), ara:(silsila), tur:silsile, swa:sil
 sili nete||||chain mail||cota de malla||кольчуга||||||||||||silmukkapanssari (rengashaarniska)|kolczuga
 sili sili||||chain||cadena|||||||||||||ĉeno|ketju|łańcuch
 sili tika||||link|maillon (chaînon)|eslabón|elo|звено||连结|連結|연결|liên kết||||||ĉenero|ketjun lenkki|
-silis|yum 014|Si||silicon|silicium|silicio|silício|кремний|سيلكون|硅|ヶィ素|규소|silic|सिलिकॉन|সিলিকন|silikon|silikoni|silisyum|silicio|pii|krzem
+silis|yum 014|Si|eng:silicon, fra:silicium, spa:silicio, por:silício, rus:кремний, vie:silic, hin:सिलिकॉन, ben:সিলিকন, may:silikon, swa:silikoni|silicon|silicium|silicio|silício|кремний|سيلكون|硅|ヶィ素|규소|silic|सिलिकॉन|সিলিকন|silikon|silikoni|silisyum|silicio|pii|krzem
 silko|||zho:丝 (sī), yue:絲 (si1), wuu:絲 (sr1), eng:silk, spa:por:sérico, rus:шёлк (sholk)|silk|soie|seda|seda|шёлк||丝绸|絹|||||||||silkki|jedwab
 sim|||tha:เสริม (soem) + eng:-ism, fra:-isme, spa:por:-ismo, rus:-изм (-izm), may:-isme|advocacy (promotion, -ism)||ideología (doctrina, -ismo)||идеология|||主义|主義|||||||ismo|aate (aatteen kannatus, ismi)|
 sim ja||||advocate (promoter, supporter, adherent)||||||||||||||||kannattaja (tukija, -isti)|
@@ -3619,7 +3620,7 @@ sukar bete|bio|Beta vulgaris subsp. vulgaris, Altissima||sugar beet|betterave à
 sukar di||||sugary (sweet)||azucarado||||||||||||||sokerinen (makea)|słodki
 sukar gana|bio|||sugarcane|canne à sucre|caña de azúcar|cana-de-açúcar|сахарный тростник||甘蔗|サトウキビ|||गन्ना||tebu|muwa|||sokeriruoko|trzcina cukrowa
 sukar oranje|bio|Citrus × sinensis||sweet orange|orange douce|||апельсин|||オレンジ (アマダイダイ)||||||||||pomarańcza słodka (pomarańcza chińska)
-sulfu|yum 016|S||sulfur (brimstone)|soufre|azufre|enxofre|сера|كبريت|硫|硫黄|황|lưu huỳnh|गन्धक|সালফার|belerang|kibiriti (sulfuri)|kükürt|sulfuro|rikki|siarka
+sulfu|yum 016|S|eng:sulfur, fra:soufre, spa:azufre, por:enxofre|sulfur (brimstone)|soufre|azufre|enxofre|сера|كبريت|硫|硫黄|황|lưu huỳnh|गन्धक|সালফার|belerang|kibiriti (sulfuri)|kükürt|sulfuro|rikki|siarka
 sultan||||power (authority, rule)||poder (autoridad, competencia)|||||||||||||||siła, autorytet, władza
 sultan desha||||sultanate||sultanato|||||||||||||||
 sultan ja|||ara:سلطة (sulṭa), eng:tur:may:sultan, spa:sultán, rus: султан (sultan), fas:سلطان‎ (soltân), hin:सुल्तान (sultān), ben:সুলতান (śultan), swa:sultani|ruler||gobernante (soberano)|||||||||||||||władca
@@ -3671,14 +3672,14 @@ tal darja||||level down|||||||||||||||||
 tal di|||fas:ته (tah), hin:तह (tah) + zho:低 (dī), yue:低 (dai1), wuu:低 (ti1), jpn:低 (tei) + cze:dole|low (short)|bas|bajo|||||||||||||||niski
 tal moku||||bush (shrub)|buisson|arbusto (mata)|arbusto (mata)|куст||灌木|灌木 (藪)|||झाड़ी||alas gandar|||||krzak (krzew)
 tal tela||||carpet (rug)||alfombra (tapete)||ковёр|||絨毯 (カーペット)||||||||||dywan
-tali yum|yum 081|Tl||thallium|thallium|talio|tálio|таллий|ثاليوم|铊|タリウム|탈륨|tali|थैलियम|থ্যালিয়াম|tallium|tali|talyum|talio|tallium|tal
+tali yum|yum 081|Tl|eng:thallium, fra:thallium, spa:talio, por:tálio, rus:таллий, zho:铊 (tā), jpn:タリウム, kor:탈륨, vie:tali, hin:थैलियम, ben:থ্যালিয়াম, may:tallium, swa:tali|thallium|thallium|talio|tálio|таллий|ثاليوم|铊|タリウム|탈륨|tali|थैलियम|থ্যালিয়াম|tallium|tali|talyum|talio|tallium|tal
 tam|||ara: طَمَّاع‎ (ṭammāʿ), zho:贪 (tān), yue:貪 (taam1), kor:탐욕 (tamyok), vie:tham|greedy||codicioso (avaro)||||贪婪的|||||||||avida|ahne|chciwy (żądny)
 tamar|bio||por:tamara, ara:(tamar)|date fruit||dátil|||||||||||mtende|||taateli|daktyl
 Tamil|nas|||Tamil||tamil||||||||||||||tamil (eräs intialainen kieli)|tamilski
 tana|||fas: تنه‎ (tane), hin:तना (tanā), tam:தண்டு (taṇṭu), vie:thân, tha:ต้น (ton), may:tangkai|stem (torso, trunk, stalk)|tige|tallo|haste (talo, caule)|стебель||茎 (梗)|茎 (胴)|||तना (डाली)||tangkai|shina||||łodyga (tors, pień, trzon)
 tanah||||Tanakh (Jewish Bible)||Tanaj (Biblia hebrea)||||||||||||||tanakh|Tanach, Biblia hebrajska
 tanke|||eng:tank, hin:टंकी (ṭaṅkī), swa:tangi, spa:tanque, jpn:タンク (tanku), tgl:tangke|tank (reservoir)||tanque (cisterna)||||||||||||||tankki (säiliö)|zbiornik (cysterna, pojemnik, rezerwuar)
-tantal yum|yum 073|Ta||tantalum|tantale|tántalo|tântalo|тантал|تنتالم|钽|タンタル|탄탈, 2탄탈럼|tantali, tantan|टाण्टलम|ট্যান্টালাম|tantalum|tantali|tantal|tantalo|tantaali|tantal
+tantal yum|yum 073|Ta|eng:tantalum, fra:tantale, spa:tántalo, por:tântalo, rus:тантал, zho:钽 (tǎn), jpn:タンタル, kor:탄탈, vie:tantali, hin:टाण्टलम, ben:ট্যান্টালাম, may:tantalum, swa:tantali|tantalum|tantale|tántalo|tântalo|тантал|تنتالم|钽|タンタル|탄탈|tantali, tantan|टाण्टलम|ট্যান্টালাম|tantalum|tantali|tantal|tantalo|tantaali|tantal
 tanur|||fas:heb:tanur, ara:(tannūr), eng:tandoor, athanor, tur:tandır, hin:तनूर (tanūr), urd:(tanūr), pnb:ਤੰਦੂਰ (tandūr), swa:tanuri|oven (furnace)||horno|||||||||||tanuri||forno|uuni|piec (piekarnik)
 Tanzania|desha|TZ||Tanzania||Tanzania|||||||||||||Tanzanio|Tansania|Tanzania
 tapa|||spa:tur:tapa, por:tampa, ell:τάπα (tapa), bul:тапа (tapa), eng:tap|stopper (cap, peg, tap)||tapón (tapa)||||||||||||||tulppa (tappi, korkki)|korek, zatyczka, szpunt
@@ -3694,7 +3695,7 @@ taza|||tur:taze, hin:ताज़ा (tāzā), ben:তাজা (taja), fas:(tâ
 tehni|||ell:τεχνική (tehniki), rus:техника (tehnika), fra:eng:technique, spa:por:técnica, hin:तकनीक (taknīk), may:teknik|technique (technology)|technique|técnica|técnica|техника||技术|技術|기술|kỹ thuật|||teknik||teknik|tekniko|tekniikka (keino, menetelmä)|technika, technologia
 tehni krati||||technocracy||tecnocracia||||||||||||||teknokratia|technokracja
 tehni logi||||technology (study of techniques)|technologie|tecnología||технология||工艺学|||||||||teknologio|tekniikka (teknologia)|technologia, nauka o technikach
-tehni yum|yum 043|Tc||technetium|technétium|tecnetio|tecnécio|технеций|تكنيتيوم|锝|テクネチウム|테크네튬|tecnexi|टेक्निशियम|টেকনিসিয়াম|teknetium|tekineti|teknesyum|teknecio|teknetium|technet
+tehni yum|yum 043|Tc|eng:technetium, fra:technétium, spa:tecnetio, por:tecnécio, rus:технеций, zho:锝 (dé), jpn:テクネチウム, kor:테크네튬, vie:tecnexi, hin:टेक्निशियम, ben:টেকনিসিয়াম, may:teknetium, swa:tekineti|technetium|technétium|tecnetio|tecnécio|технеций|تكنيتيوم|锝|テクネチウム|테크네튬|tecnexi|टेक्निशियम|টেকনিসিয়াম|teknetium|tekineti|teknesyum|teknecio|teknetium|technet
 tela|||spa:por:tgl:tela, fra:toile + eng:towel, hin:तौलिया (tauliyā), swa:taulo, jpn:タオル (taoru), may:tuala|cloth (fabric, textile)|tissu|tela (paño, tejido)|fazenda (tecido)|ткань||布料|布|||||||||kangas|tkanina (materiał, sukno)
 tela gi|||rus:ткать (tkat’) + may:duk + tur:doku|loom|métier à tisser|telar|tear|ткацкий станок||织机|織機|직기|khung cửi|||||dokuma tezgahı||kutomakone (kangaspuut)|krosno
 tele|||eng:spa:por:may:tele-, fra:télé-, rus:теле- (tele-)|distance (far away)||lo lejos|||||||||||||malproksimeco|etäisyys (kaukaisuus)|dystans
@@ -3706,7 +3707,7 @@ tele fon shuta||||telephony (telephone communication)||telefonía|telefonia|те
 tele ta||||distance (length)||distancia||||||||||||||etäisyys|dystans
 tele vide gi||||television|téléviseur|televisión||телевизор||电视机|||||||||televidilo|televisio|telewizja
 teleskope||||telescope|télescope (lunette)|telescopio|telescópio|телескоп||望远镜|望遠鏡 (テレスコープ)|망원경|kính thiên văn|दूरबीन|দূরবীন|teleskop|darubini|teleskop|teleskopo|kaukoputki (teleskooppi)|teleskop
-telu yum|yum 052|Te||tellurium|tellure|telurio|telúrio|теллур|تيلوريوم|碲|テルル|텔루르, 2텔루륨|telua, telu|टेलुरियम|টেলুরিয়াম|telurium|teluri|tellur|teluro|telluuri|tellur
+telu yum|yum 052|Te|eng:tellurium, fra:tellure, spa:telurio, por:telúrio, rus:теллур, zho:碲 (dì), jpn:テルル, kor:텔루르, vie:telu, hin:टेलुरियम, ben:টেলুরিয়াম, may:telurium, swa:teluri|tellurium|tellure|telurio|telúrio|теллур|تيلوريوم|碲|テルル|텔루르|telua, telu|टेलुरियम|টেলুরিয়াম|telurium|teluri|tellur|teluro|telluuri|tellur
 Telugu|nas|||Telugu||télugu||||||||||||||telugu (eräs intialainen kieli)|telugu
 tema|||fra: thème, spa: tema, rus: тема (tema), deu:Thema + zho:题目 (tímù)|topic (subject, theme)|sujet (thème)|tema||тема||主题目|||||||||temo|aihe (teema)|temat, motyw
 tema||||be about (discuss as a subject)||tratar de|||||||||||||esti pri; pridiskuti|aiheesta (-sta)|być o; dyskutować o
@@ -3715,7 +3716,7 @@ ten|||fra:tener, spa:tenir, por:ter, eng:-tain|hold (grasp, detain)|tenir|tener 
 ten bil||||accessible (within reach)|accessible (atteignable, à portée)|accesible||доступный|||とっつきやすい (アクセス可能)|||सुगम्य (सुगम, सुलभ)||dapat dicapai (dapat diakses)||||ulottuvilla|
 ten fasil ta||||accessibility (ease of access)||fácil acceso (accesibilidad)||доступность||無障礙環境|アクセシビリティ|||सुगमता (सुलभता, सुगम्यता, पहुंच)||ketercapaian|||||
 Tenesi||||Tennessee||Tennessee||||||||||||||Tennessee|
-tenesi yum|yum 117|Ts||tennessine|tennessine|teneso|tennessine|теннессин|ٲنون سيبتيوم||テネシン|우눈셉튬||||tennessine|||teneso|tennessine|tenesyn, tennessine
+tenesi yum|yum 117|Ts|eng:fra:por:may:tennessine, spa:teneso, rus:теннессин, jpn:テネシン, kor:우눈셉튬|tennessine|tennessine|teneso|tennessine|теннессин|ٲنون سيبتيوم||テネシン|우눈셉튬||||tennessine|||teneso|tennessine|tenesyn, tennessine
 tenis||||tennis||tennis|||||||||||||teniso|tennis|tenis
 tense|||eng:tense, fra:tendu, spa:por:tenso|tight (tense)|tendu|tenso|tenso|тугой||||||||||||kireä (tiukka, jännittynyt)|
 tense ta||||tension||||||||||||||||jännitys (jännite)|
@@ -3723,7 +3724,7 @@ tenta|||eng:tempt, spa:por:tentar, fra:tenter|tempt (entice)||tentar (seducir)||
 teori|||eng:theory, spa:teoría, por:teoria, fra:téorie, rus:теория (teoriya), fas:تئوری‎ (teori), may:teori|theory||teoría|||||||||||||teorio|teoria|teoria
 tepe|||eng:tape, swa:tepe, jpn:テープ (tēpu), kor:테이프 (teipeu), tur:teyp, hin:टेप (tep)|tape|ruban (bande)|cinta adhesiva||лента|||||||||||bendo|teippi (nauha)|taśma
 tera|nomer||eng:fra:spa:por:may:tur:tera-, rus:тера- (tera-), jpn:テラ (tera), kor:테라- (tera-)|tera-||tera-||||||||||||||biljoona (tera-)|tera-
-terbi yum|yum 065|Tb||terbium|terbium|terbio|térbio|тербий|تربيوم|铽|テルビウム|테르븀, 2터븀|tecbi|टर्बियम|টার্বিয়াম|terbium|taribi|terbiyum|terbio|terbium|terb
+terbi yum|yum 065|Tb|eng:terbium, fra:terbium, spa:terbio, por:térbio, rus:тербий, zho:铽 (tè), jpn:テルビウム, kor:테르븀, 2터븀, vie:tecbi, hin:टर्बियम, ben:টার্বিয়াম, may:terbium, swa:taribi|terbium|terbium|terbio|térbio|тербий|تربيوم|铽|テルビウム|테르븀|tecbi|टर्बियम|টার্বিয়াম|terbium|taribi|terbiyum|terbio|terbium|terb
 tercha|||spa:torcido, por:torto, hin:तिरछा (tirachha), ben:তেরছা (tērachā), pan:तिरकस (tirakasa)|oblique (askew, tilted)|oblique (de travers)|oblicuo (torcido)|oblíquo (torto)|косой||斜的|斜め|||||||||vino|skośny (ukośny, pochyły)
 termo|||deu:eng:fra:thermo-, spa:por:termo-, rus:термо- (termo-)|temperature||temperatura||||||||||||||lämpötila|temperatura
 termo metre gi||||thermometer||termómetro|||||||||||||termometro|lämpömittari|termometr
@@ -3750,7 +3751,7 @@ tire yo milke||||milk (draw milk)|tirer|ordeñar||тянуть||拉|||||||||melk
 tire yo pil||||strip (peel)|écorce|quitar (pelar)||ободрать||削 (刮去)|はがす (剥ぐ)|||||||||kuoria|obrać (obierać)
 tisa|nomer|9|ara: تِسْعَة‎ (tisʿa), swa:tisa|nine (9)|neuf (9)|nueve (9)|nove (9)|девять (9)||九 (9)|九 (9)|||नौ|নয়|||||yhdeksän|dziewięć (9)
 Titan|planete 6 lun 6|||Titan||||||||||||||||Titan|
-titan yum|yum 022|Ti||titanium|titane|titanio|titânio|титан|تيتانيوم|钛|チタン|타이타늄, 타타늄, 타탄|titan|टाइटानियम|টাইটেনিয়াম|titanium|titani|titan|titanio|titaani|tytan
+titan yum|yum 022|Ti|eng:titanium, fra:titane, spa:titanio, por:titânio, rus:титан, zho:钛 (tài), jpn:チタン, kor:타이타늄, vie:titan, hin:टाइटानियम, ben:টাইটেনিয়াম, may:titanium, swa:titani|titanium|titane|titanio|titânio|титан|تيتانيوم|钛|チタン|타이타늄|titan|टाइटानियम|টাইটেনিয়াম|titanium|titani|titan|titanio|titaani|tytan
 Titania|planete 7 lun 4|||Titania||||||||||||||||Titania|
 titi|||eng:tit, fra:tété, spa:teta, rus:титьки (tit’ki), ara:ثَدْي‎ (ṯady), swa:titi, may:tetek, jpn:乳 (chichi)|breast (boob, tit)|sein|seno (teta)|seio (mama)|||||||||payudara|titi|meme|mamo|nisä (tissi)|
 tochu|||eng:touch, spa: tocar, + hin: छूना (chūnā), zho: 触 (chù)|touch|toucher|tocar (rozar)||касаться||接触|||||||||tuŝi|koskea (koskettaa)|dotyczyć
@@ -3768,7 +3769,7 @@ Tonga|desha|TO||Tonga||Tonga||||||||||||||Tonga|Tonga
 topo|||eng:fra:spa:por:tur:mal:topo-, rus:топо- (topo-)|region (tract, land, ground)||región (zona)|||||||||||||regiono|seutu (maa, alue)|region
 topo grafi||||topography|topographie|topografía|topografia|топография||地形|地勢|||||topografi||topografi||topografia|
 topo metre grafi||||map (chart, geographic map)|carte (plan)|mapa|carta geográfica|карта (план)||地图||||||||harita||kartta|
-tor yum|yum 090|Th||thorium|thorium|torio|tório|торий|ثوريوم|钍|トリウム|토륨|thori|थोरियम|থোরিয়াম|torium|thori|toryum|torio|torium|tor
+tor yum|yum 090|Th|eng:thorium, fra:thorium, spa:torio, por:tório, rus:торий, zho:钍 (tǔ), jpn:トリウム, kor:토륨, vie:thori, hin:थोरियम, ben:থোরিয়াম, may:torium, swa:thori|thorium|thorium|torio|tório|торий|ثوريوم|钍|トリウム|토륨|thori|थोरियम|থোরিয়াম|torium|thori|toryum|torio|torium|tor
 torso|||fra:torse, rus:торс (tors), deu:eng:spa:may:torso|trunk (torso)||torso|||||||||||||torso|vartalo (varsi, torso)|tułów
 tortuga|bio|Testudines|eng:tortoise, spa:tortuga, por:tartaruga, fra:tortue|turtle (tortoise)||tortuga||||||||||||||kilpikonna|żółw
 transe|||eng:fra:spa:por:deu:may:trans-, rus:транс- (trans-)|transit (transport, passage)||tránsito (transporte)||||||||||||||läpikulku (kuljetus)|przejazd, przewóz, tranzyt, transport
@@ -3795,7 +3796,7 @@ tubo|||spa:por:tubo, eng:fra:tube, jpn:チューブ (chūbu), zul:ithumbu, xho:�
 tuh|||hin: थूकना (thūknā), zho: 吐 (tǔ), tur:tükürmek|spit||escupir (bufar)|||||||||||||sputi|sylkeä|pluć
 tul|||eng: tool, kor: 툴 (tul), jpn: ツール (tsūru), Zulu: ithuluzi|tool||herramienta|||||||||||||ilo|työkalu|narzędzie
 Tule||||Thule|Thulé|||Туле|||||||||||Tuleo|Thule|
-tule yum|yum 069|Tm||thulium|thulium|tulio|túlio|тулий|ثليوم|铥|ツリウム|툴륨|tuli|थुलियम|থুলিয়াম|tulium|thuri|tulyum|tulio|tulium|tul
+tule yum|yum 069|Tm|eng:thulium, fra:thulium, spa:tulio, por:túlio, rus:тулий, zho:铥 (diū), jpn:ツリウム, kor:툴륨, vie:tuli, hin:थुलियम, ben:থুলিয়াম, may:tulium, swa:thuri|thulium|thulium|tulio|túlio|тулий|ثليوم|铥|ツリウム|툴륨|tuli|थुलियम|থুলিয়াম|tulium|thuri|tulyum|tulio|tulium|tul
 tulpan|bio|Tulipa|eng:tulip, spa:tulipá, por:túlipa, nld:tulp, rus:тюльпан (t’ul’pan), ara:توليب (tūlīb), hin:ट्यूलिप (ṭyūlip), may:tulip, jpn:チューリップ (chūrippu)|tulip||tulipán||||||||||||||tulppaani|tulipan
 tumen|pron.|||you all||ustedes||||你们|あなたたち||||||||vi ĉiu|te|wy, was
 tumen su||||your|votre|vuestro|vosso|ваш||你们的|||||||||via|teidän|
@@ -3842,7 +3843,7 @@ unta di||||united||unido||||||||||||||yhtenäinen|zjednoczony
 unta liga||||union|union|unión|união|союз||合并|連合 (接合)|||संयोग (सम्मिलन)||serikat (gabungan, ikatan)|jumuia (muungano)|birlik (kavuşma)|uniono|liitto (unioni)|unia
 ura|||rus:ура (ura), ita:urrà, deu:spa:hurra, fra:hourra, eng:hurrah, may:hore, fas:(hurâ)|cheer (hurrah, hooray)|hourra|hurra|urra|ура||好哇||||जय हो||||||hurraa (hurrata)|wiwatować; hura
 Uran|planete 7|||Uranus|Uranus|Urano|Urano|Уран|أورانوس|||||||||Uranüs||Uranus|Uran
-uran yum|yum 092|U||uranium|uranium|uranio|urânio|уран|يورانيوم|铀|ウラン|우라늄|urani (uran)|युरेनियम|ইউরেনিয়াম|uranium|urani|uranyum|uranio|uraani|uran
+uran yum|yum 092|U|eng:uranium, fra:uranium, spa:uranio, por:urânio, rus:уран, jpn:ウラン, kor:우라늄, vie:urani (uran), hin:युरेनियम, ben:ইউরেনিয়াম, may:uranium, swa:urani|uranium|uranium|uranio|urânio|уран|يورانيوم|铀|ウラン|우라늄|urani (uran)|युरेनियम|ইউরেনিয়াম|uranium|urani|uranyum|uranio|uraani|uran
 urdu|nas|||Urdu||urdu||||||||||||||urdu|urdu
 Urdun|desha|JO||Jordan||Jordania||||||||||||||Jordania|Jordan
 urso|bio|Ursidae|fra:ours, por:urso, spa:oso, fas:(xers)|bear|ours|oso|urso||||||||||||urso|karhu|niedźwiedź
@@ -3869,7 +3870,7 @@ vampir ohtopus|bio|Vampyroteuthis infernalis||vampire squid|vampire des abysses|
 van|||zho:玩 (wán), yue:玩 (waan4), cjy:玩 (van1), kor:완 (wan)|fun (amusement)||diversión||||娱乐|楽しみ (娯楽)||||||||amuzo|huvi (hauskuus)|zabawa, rozrywka
 van di||||funny (amusing)||divertido|||||楽しい||||||||amuza|hauska (huvittava)|zabawny
 van gi||||toy (plaything)||jugete||игрушка|||おもちゃ|||||||||leikkikalu (lelu)|
-vanadi yum|yum 023|V||vanadium|vanadium|vanadio|vanádio|ванадий|فناديوم|钒|バナジウム|바나듐|vanađi|वनेडियम|ভ্যানাডিয়াম|vanadium|vanadi|vanadyum||vanadiini|wanad
+vanadi yum|yum 023|V|eng:vanadium, fra:vanadium, spa:vanadio, por:vanádio, rus:ванадий, zho:钒 (fán), jpn:バナジウム, kor:바나듐, vie:vanađi, hin:वनेडियम, ben:ভ্যানাডিয়াম, may:vanadium, swa:vanadi|vanadium|vanadium|vanadio|vanádio|ванадий|فناديوم|钒|バナジウム|바나듐|vanađi|वनेडियम|ভ্যানাডিয়াম|vanadium|vanadi|vanadyum||vanadiini|wanad
 vanila|||eng:vanilla, spa:vainilla, por:baunilha, fra:vanille, rus:ваниль (vanil’)|vanilla||vainilla||||||||||||||vanilja|wanilia
 Vanuatu|desha|VU||Vanuatu||Vanuatu||||||||||||||Vanuatu|Vanuatu
 var|||hin:वार (vār), ben:বার (bar) + por:feira|day of the week||día de semana|||||||||||||semajntago|viikonpäivä|
@@ -3958,7 +3959,7 @@ vodun|||ewe:vodun, hat:vodou, bra:vodum, eng:voodoo, fra:vaudou, spa:vudú|voodo
 vol|||fra:voiloir, ita:volere, deu:wollen, eng:volition, spa:voluntad, rus:воля (volya), pol:wola|want (desire, wish)|vouloir|querer (desear)|querer (desejar)|хотеть|أَرَادَ|想要 (愿意)|欲しい|싶다 (원하다)|muốn|चाहना|চাওয়া|mau (mahu)||istemek|voli|haluta|chcieć, pragnąć
 vol she||||want (desire, wish)||deseo|vontade|||||소원|||||||volo|halu (toive)|wola (chęć, pragnienie)
 volfe|||deu:ned:eng:wolf, rus:волк (volk)|wolf|loup|lobo|||||||||||||lupo|susi (hukka)|wilk
-volfram|yum 074|W||tungsten (wolfram)|tungstène|tungsteno (wolframio)|tungsténio|вольфрам|تنجستين|钨|タングステン|텅스텐|vonfam|टंग्स्टन|টাংস্টেন|wolfram|wolframi|volfram||volframi|wolfram
+volfram|yum 074|W|eng:wolfram, spa:wolframio, rus:вольфрам, zho:钨 (wū), vie:vonfam, may:wolfram, swa:wolframi|tungsten (wolfram)|tungstène|tungsteno (wolframio)|tungsténio|вольфрам|تنجستين|钨|タングステン|텅스텐|vonfam|टंग्स्टन|টাংস্টেন|wolfram|wolframi|volfram||volframi|wolfram
 Volof||||Wolof (language and people)|wolof||||||||||||kiwolofu|||wolofin kansa ja kieli|wolof
 volte|unomete|V||volt (V)||voltio (V)||||||||||||||voltti (V)|wolt (V)
 vote|||eng:vote, spa:por:voto, hin:वोट (voṭ), rus:вотум (votum)|vote (ballot)||voto|voto|||||||||||||ääni (äänestyksessä)|głos
@@ -3966,7 +3967,7 @@ vote haki||||franchise (right to vote)||sufragio (derecho al voto)||||||||||||||
 vulva|||fra:vulve, eng:por:spa:tur:vulva, rus:вульва (vul’va)|vulva|vulve|vulva|vulva|вульва||外阴 (陰门)|陰門|음문|âm hộ|||||vulva|vulvo|häpy (ulkosynnyttimet)|srom
 vutu|||zho:物 (wù), wuu:物 (veq5), jpn:物 (butsu), vie:vật + hin:mar:वस्तु (vastu), ben:বস্তু (bôstu), pan:ਵਸਤੁ (vastu), tha:วัสดุ (wạttu)|object (item, thing)|objet (article)|objeto (artículo)|item|статья (предмет)||物体 (物品)|物 (品)|||||||||esine (tavara)|przedmiot (obiekt)
 X||||X|X|X|X|X|X|X|X|X|X|X|X|X|X|X|X|X|X
-xenon|yum 054|Xe||xenon|xénon|xenón|xénon|ксенон|إكسينون|氙|キセノン|크세논, 2제논|xenon|ज़ेनान|জেনন|xenon|zenoni|ksenon|ksenono|ksenon|ksenon
+xenon|yum 054|Xe|eng:xenon, fra:xénon, spa:xenón, por:xénon, rus:ксенон, zho:氙 (xiān), jpn:キセノン, kor:크세논, vie:xenon, hin:ज़ेनान, ben:জেনন, may:xenon, swa:zenoni|xenon|xénon|xenón|xénon|ксенон|إكسينون|氙|キセノン|크세논|xenon|ज़ेनान|জেনন|xenon|zenoni|ksenon|ksenono|ksenon|ksenon
 Y||||Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y
 ya|pron.||may:ia + hin:यह (yah) + swa:yeye, zul:yena, lin:ye, ktu:ya, ibo:ya + rus:е- (ye-) + zho:伊 (yī), vie:y|he or she or it||él o ella||||他，她，它|||||||||li aŭ ŝi aŭ ĝi|hän (se)|on, ona, ono
 ya|||spa:por:eng:-ia, rus:-ия (-iya), ara: ية (-iya), jpn:屋 (-ya)|area of thinking or being||sufijo para regiónes y sustantivos abstractos|||||||||||||ejo (ujo, io)|ajattelun, olemisen tai ihmisten ala tai alue|przyrostek dla miejsca
@@ -4016,12 +4017,11 @@ yong petra||||lava|lave|lava||||熔岩|溶岩|||||||||laava|lawa
 yong safa||||smelt|fondu|||||熔炼|||||||||||topić (upłynnić, upłynniać)
 Yoruba|nas|||Yoruba (language and people)|||||||||||||kiyoruba|||joruban kansa ja kieli|Joruba
 yota|nomer||eng:fra:spa:por:yotta, may:yota-, zho:尧它- (yáotā-), jpn:ヨタ- (yota-), kor:요타- (yota-)|yotta-||||||||||||||||kvadriljoona (jotta-)|
-yum||||chemical element|élément chimique|elemento químico|elemento químico|химический элемент||元素|元素|원소|nguyên tố|रासायनिक तत्व||unsur kimia||kimyasal element|kemia elemento|alkuaine|
 yumor|||rus:юмор (yumor), spa:eng:humor, fra:humour, jpn:ユーモア (yūmoa), kor:유머 (yumeo), zho:幽默 (yōumò)|humor||humor (gracia)||юмор|||||||||||humuro|huumori|humor
 yumor di||||humorous (comical, funny)||humorístico (gracioso, cómico)|||||||||||||humura|koominen (hauska)|humorystyczny, śmieszny, zabawny, komiczny
 yumor ja||||humorist||humorista|||||||||||||humuristo|humoristi|komik
-yuter yum|yum 039|Y||yttrium|yttrium|itrio|itrio|иттрий|يتريوم|钇|イットリウム|이트륨|ytri|इत्रियम|ইটরিয়াম|itrium|yitri|i̇triyum|itrio|yttrium|itr
-yuterbi yum|yum 070|Yb||ytterbium|ytterbium|iterbio|itérbio|иттербий|يتربيوم|镱|イッテルビウム|이테르븀, 2이터븀|ytecbi|यिट्टरबियम|ইটারবিয়াম|iterbium|yitebi|i̇tterbiyum|iterbio|ytterbium|iterb
+yuter yum|yum 039|Y|eng:yttrium, fra:yttrium, spa:itrio, por:itrio, rus:иттрий, zho:钇 (yǐ), jpn:イットリウム, kor:이트륨, vie:ytri, hin:इत्रियम, ben:ইটরিয়াম, may:itrium, swa:yitri|yttrium|yttrium|itrio|itrio|иттрий|يتريوم|钇|イットリウム|이트륨|ytri|इत्रियम|ইটরিয়াম|itrium|yitri|i̇triyum|itrio|yttrium|itr
+yuterbi yum|yum 070|Yb|eng:ytterbium, fra:ytterbium, spa:iterbio, por:itérbio, rus:иттербий, zho:镱 (yì), jpn:イッテルビウム, kor:이테르븀, vie:ytecbi, hin:यिट्टरबियम, ben:ইটারবিয়াম, may:iterbium, swa:yitebi|ytterbium|ytterbium|iterbio|itérbio|иттербий|يتربيوم|镱|イッテルビウム|이테르븀|ytecbi|यिट्टरबियम|ইটারবিয়াম|iterbium|yitebi|i̇tterbiyum|iterbio|ytterbium|iterb
 Z||||Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z
 zai|||zho:在 (zài), jpn:在 (zai), vie:tại|exist (presently, currently)||existir (actualmente)|||||ある (いる)|||||||||olla olemassa|istnieć
 zai den||||today||hoy|||||今日||||||||hodiaŭ|tänään|dziś, dzisiaj
@@ -4056,11 +4056,11 @@ zikura|||ara:(ziqqūra), deu:Zikkurat, rus:зиккурат (zikkurat)|ziggurat|
 Zimbabue|desha|ZW||Zimbabwe||Zimbabue||Зимбабве||||||||||||Zimbabwe|Zimbabwe
 zina|||ara:(zināʾ), may:tur:zina, swa:zinaa, urd:(zinā), fas:(zenā)|adultery (infidelity)||adulterio|||||||||||||malfideleco|haureus (uskottomuus)|zdrada małżeńska, cudzołóstwo
 zinji|||tam:இஞ்சி (inji), eng:ginger, ara:(zanjabīl), tur:zencefil, fra:gingembre|ginger|gingembre|gengibre|jengibre|имбирь||姜||||अदरक||jahe||zencefil|zingibro|inkivääri|imbir
-zinke|yum 030|Zn||zinc|zinc|cinc|zinco|цинк|خارصين|锌|亜鉛|아연|kẽm|जस्ता|জিঙ্ক|seng|zinki (bati)|çinko|zinko|sinkki|cynk
+zinke|yum 030|Zn|eng:zinc, fra:zinc, spa:cinc, por:zinco, rus:цинк, zho:锌 (xīn), ben:জিঙ্ক, may:seng, swa:zinki|zinc|zinc|cinc|zinco|цинк|خارصين|锌|亜鉛|아연|kẽm|जस्ता|জিঙ্ক|seng|zinki (bati)|çinko|zinko|sinkki|cynk
 zipa|||eng:zipper, ben:জিপার (jipar), hin:ज़िपर (zipar), jpn:ジッパー (jippā), kor:지퍼 (jipeo), tha:ซิป (síp), fas:urd:(zip)|zipper (zip)||cremallera||||||||||||||vetoketju|zamek błyskawiczny
 zira|||ben:জিরা (zīra), hin:ज़ीरा (zīrā), tam:சீரகம் (sīrakam), swa:mjira, fas:(zire), zho:孜然 (zīrán)|cumin (jeera)||comino||тмин||孜然||||ज़ीरा|জিরা||mjira||kumino|juustokumina (jeera)|kumin, kmin
 zirkon||||zircon||circón||циркон||||||||||||zirkoni|
-zirkon yum|yum 040|Zr||zirconium|zirconium|circonio|zircónio|цирконий|زيركونيوم|锆|ジルコニウム|지르코늄|ziriconi|जर्कोनियम|জিরকোনিয়াম|zirkonium|zirikoni|zirkonyum|zirkonio|zirkonium|cyrkon
+zirkon yum|yum 040|Zr|eng:zirconium, fra:zirconium, spa:circonio, por:zircónio, rus:цирконий, jpn:ジルコニウム, kor:지르코늄, vie:ziriconi, hin:जर्कोनियम, ben:জিরকোনিয়াম, may:zirkonium, swa:zirikoni|zirconium|zirconium|circonio|zircónio|цирконий|زيركونيوم|锆|ジルコニウム|지르코늄|ziriconi|जर्कोनियम|জিরকোনিয়াম|zirkonium|zirikoni|zirkonyum|zirkonio|zirkonium|cyrkon
 zizi|||zho:zizi eng:sizzle|sizzle||chisporrotear||||||||||||||sihistä|skwierczeć
 zoku|||wuu:续 (zoq), yue:續 (zuk6), jpn:続 (zoku), kor:속 (sok), vie:kế tục|continue (go on, keep on, carry on, proceed, still, yet)|continuer (poursuivre, encore)|todavía (aún)|ainda|ещё||还 (依然)|まだ|||||||devam etmek|ankoraŭ|vielä (yhä, jatkua)|wciąż, nadal; kontynuować, wznawiać, ponawiać
 zoku di||||continuous (analog)|continu (analogique)|continuo (analógico)|analógico|||指针式的|アナログ|||||||||jatkuva (analoginen)|ciągły (analogowy)

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -8,7 +8,7 @@ achar|||fas:آچار (âčâr), hin:अचार (acār), ara:اچار‎ (əča
 achar di||||pickled|décapé (mariné)|encurtido||марино́ванный||||||||||||säilötty|kiszony (marynowany)
 achar hiyar||||gherkin (pickle)|concombre confit (cornichon)|pepinillo||||||||||||||suolakurkku (etikkakurkku)|korniszon
 achi|||spa:achís, zho: 阿嚏 (ātì), kor:에취 (echwi), rus:апчхи, vie:hắt xì, eng:achoo, fra:atchoum|sneeze (achoo)|éternuer (atchoum)|estornudar (achís)|espirrar|чихать||打喷嚏 (阿嚏)|||hắt xì||||||terni|aivastaa (atsii!)|kichać (apsik!)
-acinium|mate|Ac||actinium|actinium|actinio|||||||||||||aktinio|aktinium|aktyn
+acini yum|yum 089|Ac||actinium|actinium|actinio|actínio|актиний|اكتنيوم|锕|アクチニウム|악티늄|actini|एक्टिनियम|অ্যাক্টিনিয়াম|aktinium|aktini|aktinyum|aktinio|aktinium|aktyn
 ada|||ara: عادة (ʿāda), hin:आदत (ādat), may:adat, tur:adet, swa:ada|habit (custom)|coutume|costumbre (hábito)|costume (hábito)|обычай (привычка)|عادة|习惯 (风俗)|習慣 (風俗)|습관 (풍속)|tập quán (phong tục)|आदत||adat|ada|adet|kutimo|tapa|nawyk (przyzwyczajenie)
 ada di||||ordinary (customary, habitual, normal)|ordinaire (habituel, normal)|ordinario (habitual)||||||||||beradat||||tavallinen|zwyczajny (rutynowy, normalny)
 adil|||ara: عدل (’adl), may:tur:adil, swa:adili + hin:अदालत (adālat)|just (fair, righteous)|juste|justo|justo|справедливый|عدل|公正地||||उचित||adil|adili|adil|justa|oikeudenmukainen|sprawiedliwy
@@ -23,7 +23,6 @@ agresi|||eng:deu:fra:agression, pol:agresja, rus:агрессия (agressiya), s
 agresi ja||||aggressor|agresseur|agresor|agressor|агрессор||侵略者||||||||||hyökkääjä|
 agresi tabi||||aggressive|agressif|agresivo|||||||||||||agresema|hyökkäävä (aggressiivinen)|agresywny
 aha|||rus:ага (aha), kor: 아하 (aha), eng: uh-huh, pol:aha|understand (realize)|comprendre (réaliser)|entender (comprender)|||||||||||||kompreni|oivaltaa (tajuta)|rozumieć, pojmować
-ainstainium|mate|Es||einsteinium|Einsteinium|einsteinium|||||||||||||ejnŝtejnio|einsteinium|einstein
 air|||eng:fra:spa:air, por:ar, rus:аэро- (aero-)|air|air|aire|ar|воздух|هوا‎|空气|空気|공기|không khí|हवा (वायु)|বায়ু|udara (hawa)|hewa|hava|aero|ilma|powietrze
 air bio di||||aerobic|aérobique|aeróbico|aeróbico|аэробный|||好気性|||||||||aerobinen|
 air gun||||airforce|armée de l'ai|fuerza aérea|força aérea|военно-воздушные силы||空军|空軍|공군|không quân|वायु सेना||angkatan udara||hava kuvetleri|aerarmeo|ilmavoimat|siły powietrzne
@@ -61,7 +60,7 @@ alo romanse di||||heteroromantic|hétéroromantique (hétéromantique)|heterorro
 alo sekse di||||heterosexual|hétérosexuel|heterosexual|||||||||||||samseksema|heteroseksuaali|heteroseksualny
 alo sifa||||difference|différence|diferencia||||||||||||||erilaisuus (ero)|różnica
 alo sifa di||||different|différent|diferente||||||||||||||erilainen|różny (inny)
-alumin|mate|Al||aluminium|aluminium|aluminio|||||||||||||aluminio|alumiini|glin (aluminium)
+alumin|yum 013|Al||aluminium|aluminium|aluminio|alumínio|алюминий|الومينيوم|铝|アルミニウム|알루미늄|nhốm|एल्युमिनियम|অ্যালুমিনিয়াম|aluminium|alumini|alüminyum|aluminio|alumiini|glin (aluminium)
 alumin mate||||alum|alun|alumbre||||||||||||||aluna|
 alumin okside||||alumina (aluminum oxide)|alumine (oxyde d'aluminium)|alúmina||||||||||||||alumiinioksidi|
 ama|||spa:por:amar, fra:aimer|love (liking, affection)|amour (affection)|amor|amor|любовь||爱|愛|||मुहब्बत (अनुराग, पसंद)||cinta (kasih, asmara)|penzi (ashiki, upendo)|sevda (aşk)|amo|rakkaus (tykkääminen)|miłość (afekt)
@@ -77,7 +76,7 @@ amen shin di||||trusted|fiable (de confiance, fidèle, sûr, crédible)|||||||||
 Amerika|||eng:America, spa:por:América, rus:Америка (Amerika), tur:swa:may:Amerika, ara:أمريكا‎ (ʾamrīkā), hin:अमेरिका (amerikā), ben:আমেরিকা (amerika), jpn:アメリカ (amerika)|America (continent)|Amérique|América|||||||||||||Ameriko|Amerikka|Ameryka (kontynent)
 Amerika di||||American|américain|americano|||||||||||||amerika|amerikkalainen|amerykański
 Amerika Samoa|desha|AS||American Samoa|Samoa américaines|Samoa Americana||||||||||||||Amerikan Samoa|Amerykańska Samoa
-amerikium|mate|Am||americium|américium|americio|||||||||||||americio|amerikium|ameryk
+amerika yum|yum 095|Am||americium|américium|americio|amerício|америций|أمريكيوم|镅|アメリシウム|아메리슘|amerixi|अमेरिशियम|অ্যামেরিসিয়াম|amerisium|ameriki|amerikyum|americio|amerikium|ameryk
 amir|||ara: أَمْر‎ (ʾamr), fas: امر‎ (amr), tur:emir, swa:amiri, hau:umarni + eng:admiral, fra:amiral, spa:por:emir rus:эмир (emir)|order (command)||orden (mando, comando)|||||||||||amri|emir|ordono|käsky (komento)|rozkaz, komenda
 amir desha||||emirate|émirat|emirato||||||||||||||emiirikunta|emirat
 amir haki||||authority (power to give orders)||||||||||||||||käskyvalta|
@@ -150,9 +149,9 @@ arena|||spa:ita:arena, por:areia + eng:tur:arena, fra:arène, rus:арена (ar
 arena estade||||arena (stadium with a sand floor)|arène|||арена||||||||arena||||areena|
 arena petra||||sandstone|grès||||||砂岩|||||||||hiekkakivi|piaskowiec
 arena topo||||desert||desierto|||||||||||||dezerto|aavikko (hiekkaerämaa)|pustynia
-argente|mate|Ag|por:ita:argento, fra:argent, may:argentum|silver|argent|plata|prata|||银|銀|||||perak (argentum)|||arĝento|hopea|srebro
+argente|yum 048|Ag|por:ita:argento, fra:argent, may:argentum|silver|argent|plata|prata|серебро|فضة|银|銀|은|bạc|चाँदी|রূপা|perak|agenti|gümüş|arĝento|hopea|srebro
 Argentina|desha|AR||Argentina|Argentine|Argentina|||||||||||||Argentino|Argentiina|Argentyna
-argon|mate|Ar||argon|argon|argón|||||||||||||argono|argon|argon
+argon|yum 018|Ar||argon|argon|argón|argon|аргон|أرجون|氩|アルゴン|아르곤|agon|ऑर्गन|আর্গন|argon|arigoni|argon|argono|argon|argon
 argu||||argument (rationale, grounds)|argument|argumento|argumento|аргумент (обосновани)|||||lí lẽ|||||||perustelu (argumentti)|argument
 Ariel|planete 7 lun 2|||Ariel||||||||||||||||Ariel|
 arka|||eng:arch, spa:por:arco, fra:arc, rus:арка (arka), may:arka|bow (arch, arc)|arc|arco|arco|лук (арка)||弓 (琴弓, 拱)|弓 (弓なり)|||||||||kaari|łuk
@@ -164,7 +163,7 @@ aroma||||smell (sniff)|sentir qqch|oler (olfatear)||понюхать||闻到|嗅
 aroma|||eng:spa:por:may:aroma, fra:arôme, deu:Aroma, rus:аромат (aromat), jpn:アロマ (aroma)|scent (odor, fragrance, aroma)|odeur|olor (aroma)|cheiro|запах (аромат)||气味|香り (匂い, 臭い)|||||||||haju|zapach (aromat, smród, odór)
 aroma||||smell (reek)|sentir qqch (avoir l'odeur de qqch)|oler (apestar)|cheirar|пахнуть||发臭|香る (匂う, 臭う)|||||||||haista|pachnieć
 aroma melon|bio|Cucumis melo, Makuwa||Korean melon||melón coreano|melão coreano|||香瓜|マクワウリ||||||||||melon koreański
-arsene|mate|As||arsenic|arsenic|arsénico|||||||||||||arseno|arseeni|arsen
+arsen yum|yum 033|As||arsenic|arsenic|arsénico|arsénic|мышьяк|زرنيخ|砷|ヒ素|비소|asen|आर्सेनिक|আর্সেনিক|arsen|aseniki|arsenik|arseno|arseeni|arsen
 arte ja||||artist|artiste|artista|artista|художник (артист)||美术家||||कलाकार||seniman|mwanasanaa|sanatçı|artisto|taiteilija|artysta
 Artika|desha|||Arctic|arctique|Ártico||||||||||||||Arktis|Arktyka
 Artika Hai||||Arctic Ocean|océan Arctique|océano Ártico||||||||||||||Jäämeri|Ocean Arktyczny
@@ -184,7 +183,7 @@ Asia|||eng:spa:Asia, rus:Азия (Aziya), tur:Asya, ara:آسيا (ʾāsiyā), f
 askete|||eng:ascetic, spa:por:asceta, fra:ascéte, rus:аскет (asket)|ascetic|ascète|asceta|||||||||||||ascetiko|askeett|asceta
 asma|||fra:asthme, eng:asthma, spa:por:may:asma, pol:astma|asthma|asthme|asma|asma|астма||气喘||||श्वासरोग||bengek||astım|astmo|astma|astma
 aspirin|||eng:aspirin, spa:por:aspirina, fra:aspirine, rus:аспирин (aspirin), ara:أسبرين‎ (ʾasbirīn), hin:एस्पिरिन (espirin), zho:阿司匹林 (āsīpǐlín),  jpn:アスピリン (asupirin), swa:aspirini|aspirin|aspirine|aspirina|aspirina|аспирин||阿司匹林||||||aspirin|aspirini|aspirin|aspirino|aspiriini|aspiryna
-astate|mate|As||astatine|astate|ástato||||||||||||||astatiini|astat
+astatin|yum 085|As||astatine|astate|ástato|astato|астат(ин)|استاتين|砹|アスタチン|아스타틴|astatin|एस्टाटिन|অ্যাস্টাটিন|astatin|astatini|asatatin||astatiini|astat
 astro||fra:astre, por:astro, eng:astro-||celestial body|astre (corps céleste)|cuerpo celeste|astro (corpo celeste)|небесное тело||天体|天体 ||||||||astro|taivaankappale|
 astro nave||||starship|astronef|astronave (nave estelar)|astronave|звездолёт||||||||||||tähtialus|
 astro nave ja||||astronaut|astronaute|astronauta|astronauta|астронавт||宇航员||||||||astronot|astronaŭto|astronautti (tähtimatkaaja)|astronauta
@@ -197,7 +196,7 @@ Atlanti Hai|||eng:Atlantic, spa:Atlántico, por:Atlântico, rus:Атлантич
 atlanti salmon|bio|Salmo salar||Atlantic salmon|saumon altentique|salmón del Atlántico||Атлантический лосось (сёмга)||大西洋鮭|タイセイヨウサケ|||||salmon Atlantik|||||łosoś atlantycki
 atom|||eng:tur:may:atom, spa:por:átomo, rus:атом (atom), swa:atomi, jpn:アトム (atomu)|atom|atome|átomo|||||||||||||atomo|atomi|atom
 audi|||eng:spa:fra:audio, por:áudio|hear (listen)||oír (escuchar)|||||||||||||aŭdi (aŭskulti)|kuulla (kuunnella)|usłyszeć, słyszeć; słuchać
-auro|mate|Au|ltn:aurum, por:ouro, spa:oro, fra:or, rus:аурум (aurum), may:aurum|gold|or|oro|ouro|золото (аурум)||金|金|금|vàng|सोना|সোনা|emas (mas, aurum)|dhahabu|altın|oro|kulta|złoto
+auro|yum 079|Au|ltn:aurum, por:ouro, spa:oro, fra:or, rus:аурум (aurum), may:aurum|gold|or|oro|ouro|золото|ذهب|金|金|금|vàng|सोना|গোল্ড|emas|dhahabu (auri)|altın|oro|kulta|złoto
 Australia|desha|AU||Australia|Australie|Australia|||||||||||||Aŭstralio|Australia|Australia
 Austronesi||||Austronesia|Austronésie|Austronesia|Austronésia|Австронезия||南岛|オーストロネシア|오스트로네시아|||||||Aŭstronezio|Austronesia|
 auto|||ell:αὐτός (aftós), eng:fra:spa:por:auto-, rus:авто- (avto-)|self (identity)||mismo (yo)|||||自己|||||||||itseys|jaźń (tożsamość)
@@ -276,11 +275,11 @@ barde|||fra:barbe, spa:por:barba, deu:Bart, eng:beard, rus:борода (boroda)
 bari|||hin:भारी (bhārī), ben:ভারী (bharī), may:berat, tel:బరువు (baruvu), fas: بار‎ (bâr), ell: βαρύς (barýs) + kor:바리 (bari)|heavy (requiring much effort, hard, difficult, serious, important, etc.)||||||||||||||||raskas (kova, vaativa, vaikea, jne.)|
 bari fon||||accent (stress)|accent|acento|acento|ударение||重音符号||||स्वर का चढ़ाव उतार||aksen|||akcento|painotus (aksentti)|akcent, nacisk
 bari metal||||heavy metal|métaux lourds|metal pesado|||||||||||||pezmetalo|raskasmetalli|metal ciężki
-barium|mate|Ba||barium|baryum|bario|||||||||||||bario|barium|bar
+bari yum|yum 056|Ba||barium|baryum|bario|bário|барий|باريوم|钡|バリウム|바륨|bari|बेरियम|বেরিয়াম|barium|bari|baryum|bario|barium|bar
 barka|||hau:barka, may:berkah, tur:tebrik, fas:(tabrik), ara:urd:(mubārak), swa:baraka, yor:alubarika|congratulate (bless)|féliciter|felicitar|||||||||||||gratuli|onnitella (siunata)|gratulować; błogosławić
 barka||||congratulations! (blessing, benediction)|Félicitations !|¡Felicitaciones!|||||||||||baraka|||onneksi olkoon!|gratulacje!
-barti|||hin:भारतीय (bhārtīy), urd:(bhārtīy), mar:(bhārtīya), tel:(bhāratīya)|Indian|indien|indio (hindú)|||||||||||||Barata|intialainen|Indyjski
 Barti|desha|IN||India|Inde|India|||||||||||||Baratio|Intia|Indie
+barti|||hin:भारतीय (bhārtīy), urd:(bhārtīy), mar:(bhārtīya), tel:(bhāratīya)|Indian|indien|indio (hindú)|||||||||||||Barata|intialainen|Indyjski
 Barti Hai||||Indian Ocean|océan Indien|océano Índico||||||||||||||Intian valtameri|Ocean Indyjski
 barude|||ara:fas:urd:(bārūd), hin:बारूद (bārūd), swa:baruti, tur:barut|gunpowder|poudre à canon|pólvora|||||||||||baruti|barut|pulvo|ruuti|proch strzelniczy
 basa|||fas:urd:س (bas), ara:(bass), hin:(bas), swa:basi, spa:por:ita:basta|enough (sufficient)|assez|bastante|bastante (suficiente)|достаточно (довольно)||够|十分|||काफ़ी (बस)||cukup|basi||sufiĉa|tarpeeksi (riittävästi)|wystarczający
@@ -401,8 +400,8 @@ Benin|desha|BJ||Benin||Benín||||||||||||||Benin|Benin
 benzin|||deu:Benzin, spa:bencina, rus:бензин (benzin), tur:benzin, ara:بنزين (banzīn), hin:बेंज़ीन (benzīn), may:bensin, jpn:ベンジン (benjin), swa:benzini|gasoline (petrol)||gasolina (bencina)|||||||||||benzini|benzin|benzino|bensiini (bensa)|benzyna
 bere|||fra:béret, tur:bere, eng:beret, jpn:ベレー帽 (berē bō), zho:贝雷帽 (zh) (bèiléimào), rus:берет (beret)|beret||boina|||||||||||||bereto|baskeri (baretti)|beret
 beri|||deu:Beere, eng:berry, may:beri, hin:बेरी (berī), ben:বেরি (beri), jpn: ベリー (berī)|berry|baie|baya|baga|ягода|توت|浆果 (莓)|漿果 (ベリー )|||बेरी||beri||||marja|jagoda
-berilium|mate|Be||beryllium||berilio|||||||||||||berilio|berylli|beryl
-berkelium|mate|Bk||berkelium||berkelio|||||||||||||berkelio|berkelium|berkel
+beril yum|yum 004|Be||beryllium|béryllium|berilio|berílio|бериллий|بيريليوم|铍|ベリリウム|베릴륨|berili|बेरिलियम|বেরিলিয়াম|berilium|berili|berilyum|berilio|beryllium|beryl
+berkli yum|yum 097|Bk||berkelium|berkélium|berkelio|berqueélio|берклий|بركليوم|锫|バークリウム|버클륨|beckeli|बर्केलियम|বার্কেলিয়াম|berkelium|berkeli|berkelyum|berkelio|berkelium|berkel
 Berlin|xefsite|DE||Berlin|||||||||||||||Berlino|Berlin|
 Bermuda|desha|BM||Bermuda||Bermuda||||||||||||||Bermuda|Bermudy
 bete|bio|Beta vulgaris subsp. vulgaris, Conditiva|eng:beet, spa:betabel, por:beterraba, fra:betterave, deu:Bete, jpn:ビート (bīto)|beetroot|betterave|remolacha||свёкла||甜菜頭|テーブルビート|||||||||juurikas|burak
@@ -432,7 +431,7 @@ bir|||eng:beer, tur:bira, fra:bière, ara: بيرة (bīra), may:bir, hin:बि
 bir kan|||eng:bar, hin:बार (bār), spa:bar, zho:酒吧 (jiǔbā), rus:бар (bar)|bar (pub, beer house)||bar (pub)|||||||||||||drinkejo|baari (kapakka)|bar, knajpa
 Bisau Ginia|desha|GW||Guinea-Bissau||Guinea-Bisáu||||||||||||||Guinea-Bissau|Guinea Bissau
 biskute|||eng:fra:biscuit, por:biscoito, rus:бисквит (biskvit), tur:bisküvi, swa:biskuti, ara: بسكويت‎ (baskawīt), hin:बिस्कुट (biskuṭ), ben:বিস্কুট (biśkuṭ), may:biskut, jpn:ビスケット (bisuketto), kor:비스켓 (biseuket)|biscuit (cookie)|biscuit|galleta|biscoito|печенье (бисквит)||饼干 (曲奇饼)|ビスケット (クッキー)|비스켓 (쿠키)||बिस्कुट|মিষ্ট রূটি (বিস্কুট)|beskit (kue, kuih)|biskuti|bisküvi|biskvito (kuketo)|keksi (pikkuleipä)|biszkopt, ciastko
-bismute|mate|Bi||bismuth||bismuto|||||||||||||bismuto|vismutti|bizmut
+bismute|yum 083|Bi||bismuth|bismuth|bismuto|bismuto|висмут|بزموث|铋|ビスマス|비스무트|bitmut, bismut|बिस्मथ|বিসমাথ|bismut|bismuthi|bizmut|bismuto|vismutti|bizmut
 bizar|||eng:fra:bizarre, por:bizarro, deu:bizarr|odd (strange, weird)||raro (extraño)|||||||||||||stranga|outo (kummallinen)|dziwny
 biznes|||eng:business, rus:бизнес (biznes), may:bisnes, jpn:ビジネス (bijinesu)|business (commercial activity)||negocios (comercio)||предприятие (бизнес)|||業務 (営業, ビジネス)|||व्यवसाय|||||negoco|liiketoiminta (bisnes)|biznes, interes (aktywność komercyjna)
 biznes ja||||businessperson (businessman)||empresario|||||||||||||komercisto|liikemies|osoba biznesu, biznesman
@@ -467,10 +466,10 @@ bon sifa ta||||excellence (quality, virtue)||calidad (excelencia, mérito, virtu
 bon sin di||||auspicious (promising)|propice|auspicioso (propicio)||благоприятный||吉利的||||||||||lupaava (hyvältä vaikuttava)|obiecujący (dobrze wróżący)
 bon vide di||||beautiful (handsome, good-looking)||guapo (bien parecido)||||好看|||||||||bonaspekta|hyvännäköinen (kaunis, komea)|przystojny, atrakcyjny, ładny
 bon zar||||good luck||buena suerte||||||||||||||hyvä onni (tuuri, säkä, lykky)|dobry los, szczęście
+bor yum|yum 107|Bh||bohrium|bohrium|bohrio|bóhrio|борий|بوريوم||ボーリウム|보륨|bohri|बोरियम|বোহরিয়াম|bohrium|bohri|bohriyum|borio|bohrium|bohr
 bori||27 emotions||boredom||aburrimiento||||||||बोरियत|||||enuo|tylsyys (pitkästys)|nuda (znudzenie)
 bori di|||eng:bored, spa:aburrido, hin:(bhorī)|bored||aburrido|||||||||||||enui|pitkästynyt|znudzony
-borium|mate|Bh||bohrium||bohrio|||||||||||||borio|bohrium|bohr
-boron|mate|B||boron||boro|||||||||||||boro|boori|bor
+boron|yum 005|B||boron|boron|boro|boro|бор|بورون|硼|ホウ素|붕소|bo|बोरॉन्|বোরন|boron|boroni|bor|boro|boori|bor
 Bosna e Hercegovina|desha|BA||Bosnia and Herzegovina||Bosnia y Herzegovina||||||||||||||Bosnia ja Hertsegovina|Bośnia i Harcegowina
 Bote|desha||tib:བོད (bod, phø)|Tibet||Tíbet|||||||||||||Tibeto|Tiibet|Tybet
 botel|||eng:bottle, fra:bouteille, spa:botella, por:botelha, rus:бутылка (butylka), hin:बोतल (botal), ben:বোতল (botôl), may:botol|bottle|bouteille|botella|garrafa (botelha)|бутылка||瓶|瓶|병|chai|शीशी (बोतल)|বোতল|botol|chupa|şişe|botelo|pullo|butelka
@@ -484,7 +483,7 @@ Brazavil Kongo|desha|CG||Congo (Brazzaville)||República del Congo||||||||||||||
 Brazil|desha|BR||Brazil||Brasil|||||||||||||Brazilo|Brasilia|Brazyla
 briko|pal||ara:(barqūq), pa:albaricoque, fra:abricot, rus:абрикос (abrikos), tgl:albarikoke, swa:aprikoti|apricot (plum, peach)|abricot (prune)|albaricoque (ciruela)|damasco (abricó, ameixa)|абрикос (слива)||杏子 (李子)|アンズ (梅, モモ, プラム)|자두|mận|ख़ूबानी (आलूचा)|খুবানি||aprikoti|kayısı (zerdali, erik)|abrikoto (pruno)|aprikoosi (luumu)|morela (śliwka)
 Britan|desha|GB||United Kingdom||Reino Unido||||||||||||||Iso-Britannia (Yhdistyneet Kuningaskunnat)|Zjednoczone Królestwo
-brom|mate|Br||bromine||bromo|||||||||||||bromo|bromi|brom
+brom|yum 035|Br||bromine|brome|bromo|bromo|бром|بروم|溴|臭素|브롬, 2브로민|brom|ब्रोमिन|ব্রোমিন|brom|bromi|brom|bromo|bromi|brom
 brosha|||eng:brush, fra:brosse, spa:por:brocha, jpn:ブラシ (burashi), kor:브러시 (beureosi), hin:ब्रश (braś), ben:ব্রাশ (braś), hau:swa:burashi, fas:(boros), may:berus, ara: فُرْشَاة‎ (furšāh), tur:fırça|brush|brosse|cepillo (brocha)|brocha (pincel)|щётка|فُرْشَاة‎|笔||||ब्रश|ব্রাশ||burashi|fırça|broso|harja|szczotka
 brosha kalam||||inkbrush (calligraphy brush)||||||毛笔|筆 (毛筆)|||||||||mustesivellin|
 Brunei|desha|BN||Brunei Darussalam||Brunei||||||||||||||Brunei|Brunei Darussalam
@@ -518,8 +517,8 @@ buyu|bio||swa:mbuyu, wol:buy, sna:muuyu, zul:isimuhu|baobab||baobab|||||||||||||
 C||||C|C|C|C|C|C|C|C|C|C|C|C|C|C|C|C|C|C
 celsius darje|unomete|°C||degree Celsius||grado Celsius||||||||||||||celsiusaste|stopień Celsjusza
 Ceres||||Ceres (dwarf planet)||Ceres (planeta enano)|||||||||||||Cereso|Ceres|Ceres (planeta karłowata)
-cerium|mate|Ce||cerium||cerio|||||||||||||cerio|cerium|cer
-cesium|mate|Cs||caesium||cesio|||||||||||||cezio|cesium|cez
+ceres yum|yum 058|Ce||cerium|cérium|cerio|cério|церий|سيريوم|铈|セリウム|세륨|xeri|सेरियम|সেরিয়াম|serium|seri|seryum|cerio|cerium|cer
+cesi yum|yum 055|Cs||caesium|césium|cesio|césio|цезий|سيزيوم|铯|セシウム|세슘|xezi, xêzi|सीज़ियम|সিজিয়াম|sesium|sizi|sezyum|cezio|cesium|cez
 chabi|||por:chave, spa:llave, hin:चाबी (cābī), ben:চাবি (cabi), kon:nsapi|key|clef|llave|chave|ключ|مِفْتَاح‎|钥匙|鍵|열쇠|chìa khoá|चाबी|চাবি|kunci|ufunguo|anahtar|ŝlosilo|avain|klucz
 Chade|desha|TD||Chad||Chad||||||||||||||Tšad|Czad
 chai|||zho: 茶 (chá), jpn: (cha), kor:차 (cha), vie:trà, tur:çay, swa:chai, rus:чай (čay), hin:चाय (cāy), ara:(šāy), por:chá|tea|thé|té|chá|чай|شَاي|茶|茶|다 (차)|chè(trà)|चाय||teh|chai|çay|teo|tee|herbata
@@ -643,7 +642,7 @@ darja|||ara:(daraja), hin:दर्जा (darjā), swa:daraja, tur:derece, fas:
 darja di||||gradual||||||||||||||||asteittainen (porrastettu)|stopniowy
 darja medan||||gradient (gradation, incline)||||||||||||||||kaltevuus|gradient (gradacja, stopniowanie)
 darja mute||||development|développement|desarrollo|desenvolvimento|развитие||发展 (开发)|発展 (開発)|발전 (개발)|sự phát triển|विकास|||||disvolvi|kehitys|rozwój
-darmesitadium|mate|Ds||darmstadtium||darmstatio||||||||||||||darmstadtium|darmsztadt
+darmestadi yum|yum 110|Ds||darmstadtium|darmstadtium|darmstatio|darmstádio|дармштадтий|دارمشتاتيوم||ダームスタチウム|다름슈타튬|darmstadti|डार्म्स्टेडशियम|ডারমস্টাডটিয়াম|darmstadtium|darmstadti|darmstadtiyum||darmstadtium|darmsztadt
 darte|||eng:dirt, hin:धरती (dhartī), urd:(dhartī), vie:đất, may:darat|soil (dirt)||tierra (barro)|||||土|||||||||maa (multa)|grunt (ziemia, próchnica)
 darte bon ja||||fertilizer||||||||||||||||lannoite|nawóz
 darte di||||soily (dirty)||sucio||||||||||||||likainen (mutainen)|ziemny (glebowy, gruntowy)
@@ -720,7 +719,7 @@ diorite|||eng:fra:diorite, spa:diorita, rus:диорит (diorit), tur:diyorit, 
 disha|||hin:mar:दिशा (diśā), urd:(diśā), mal:ദിശ (diśa), khm:ទិស (tɨh), tha:ทิศทาง (tit-taang)|direction||dirección||||||||||||||suunta|kierunek
 disha di||||directly||directamente||||||||||||||suoraan|wprost (bezpośrednio)
 diske|||eng:tur:disk, fra:disque, spa:por:disco, rus:диск (disk), hin:डिस्क (ḍisk), ben:ডিস্ক (ḑisk), jpn:ディスク (disuku), kor:디스크 (diseukeu)|disc (disk)|disque|disco|disco|диск|قُرْص|圆盘|ディスク (円盤)|디스크 (원반)|đĩa|डिस्क|ডিস্ক|cakram||disk|disko|kiekko (levy)|dysk
-disprosium|mate|Dy||dysprosium||disprosio|||||||||||||disprozio|dysprosium|dysproz
+disprosi yum|yum 066|Dy||dysprosium|dysprosium|disprosio|disprósio|диспрозий|ديسبروسيوم|镝|ジスプロシウム|디스프로슘|đysprosi, đisprozi|डिस्प्रोसियम|ডিসপ্রোসিয়াম|disprosium|disprosi|disprosyum|disprozio|dysprosium|dysproz
 Divehi|desha|MV||Maldives||Maldivas||||||||||||||Malediivit|Malediwy (Republika Malediwów)
 do|prep.||rus:до (do) pol:do + zho:到 (dào), yue:到 (dou3)|to (toward, till, until, for)||a (hacia)||||到|||||||||al (ĝis, por)|luokse (tykö, kohti, asti)|do, dopóki, dla
 do ekso||||outward (external)||||||||||||||||ulkoinen|
@@ -777,7 +776,7 @@ du she sim||||dualism||dualismo||||||||||||||dualismi|dualizm
 du soni di||||stereophonic||||||||||||||||stereofoninen|
 dua||||pray (beg, entreat, implore)||rezar (orar)|||||||cầu nguyện||||||preĝi|rukoilla (anoa)|pomodlić się, modlić się
 dua|||ara: دُعَاء‏  (duʿāʾ), hin:दुआ (duā), swa:tur:dua, may:doa + zho:祈祷 (dǎo), jpn:禱 (tō), kor:도 (do)|prayer||rezo (oración)||||祈祷|祈祷|기도|||||||preĝo|rukous|modlitwa
-dubnium|mate|Db||dubnium||dubnio|||||||||||||dubnio|dubnium|dubn
+dubna yum|yum 105|Db||dubnium|dubnium|dubnio|dúbnio|дубний, ²нильсборий|دبنيوم||ドブニウム|더브늄|dubni|डब्नियम|ডুবনিয়াম|dubnium|dubni|dubniyum|dubnio|dubnium|dubn
 dudu|bio|Insecta|swa:mdudu, ara: دُود (dūd)|insect|insecte|insecto|inseto|насекомое||昆虫|昆虫|곤충|sâu bọ (côn trùng)|कीड़ा||serangga|mdudu|böcek|insekto|hyönteinen (ötökkä)|owad
 duka|||hin:दुःख (duḥkh), ben:দুঃখ (dukhô), tha:ทุกข์ (tuk), may:duka, eng:dukkha|grief (sorrow)||pena (tristeza)|||||||||||||malĝojo|suru (murhe)|żal, smutek
 duka di||||sad||triste|||||||||||||malĝoja|surullinen|smutny
@@ -813,6 +812,7 @@ E||||E|E|E|E|E|E|E|E|E|E|E|E|E|E|E|E|E|E
 e|funsi||fra:et, por:e, spa:y;e, zho:和 (hé)|and|et|y|e|||和|||||||||kaj|ja (sekä)|i, oraz
 e mas||||also (too)||además|||||||||||||ankaŭ|lisäksi (myös)|
 eglisa|||eng:ecclesia-, fra:église, spa:iglesia, por:igreja, hin:गिरजा (girjā), may:gereja, ara:(kanisā), swa:kanisa, tur:kilise|church||iglesia|||||||||||||preĝejo|kirkko|kościół
+einstein yum|yum 099|Es||einsteinium|einsteinium|einsteinium|einstânio|эйнштейний|انيشتنيوم|锿|アインスタイニウム|아인시타이늄 or 아인슈타이늄|ensteni|आइन्स्टाइनियम|আইনস্টাইনিয়াম|einsteinium|einsteni|eınsteınyum|ejnŝtejnio|einsteinium|einstein
 eko|||eng:spa:por:eco-, fra:éco-, deu:öko-, rus:эко-, tur:may:eko-|environment (nature)||medioambiente (naturaleza)|||||||||||||naturo|luonto|natura, środowisko
 eko di||||environmental (natural)||ambiental (ecológico, natural)||||||||||||||ympäristö- (luonto-)|środowiskowy, naturalny
 eko jene di||||wild (savage)|sauvage|salvaje||дикий|||野生|||||||||villi (villinä syntynyt)|dziki
@@ -859,15 +859,15 @@ english margarita|bio|Bellis perennis||English daisy|pâquerette|margarita comú
 eni|||eng:any|any (no matter which)||qualquier|||||||||||||iu ajn|mikä tahansa|jakikolwiek, którykolwiek
 enjener|||eng:engineer, spa:ingeniero, por:engenheiro, rus:инженер (inzhener), hin:mar:इंजीनियर (iñjīniyar), jpn:エンジニア (enjinia)|engineer||ingeniero||||||||||||||insinööri|inżynier
 enzim|||eng:fra:enzyme, spa:por:enzima, rus:энзим (enzim), tur:may:enzim, ara:انزيم‎, fas:آنزیم‎ (ânzim)|enzyme||enzima||||||||||||||entsyymi|enzym
-erbium|mate|Er||erbium||erbio|||||||||||||erbio|erbium|erb
+erbi yum|yum 068|Er||erbium|erbium|erbio|érbio|эрбий|إربيوم|铒|エルビウム|에르븀, 2어븀|eribi|अर्बियम|ইরবিয়াম|erbium|erbi|erbiyum|erbio|erbium|erb
 Eris||||Eris (dwarf planet)||Eris (planeta enano)|||||||||||||Eris (planedeto)|Eris (kääpiöplaneetta)|Eris (planeta karłowata)
 Eritra|desha|ER||Eritrea||Eritrea|||||||||||||Eritreo|Eritrea|Erytrea
 esai|||eng:essay, spa:ensayo, por:ensaio, fra:essai, deu:Essay, rus:эссе (esse), jpn:エッセイ (essei)|essay||ensayo (redacción)||||||||||||||essee|esej
 eskale||||climb (get on)||escalar||подниматься|||上る (乗る, よじ登る)|||||||||kiivetä|wspinać się (wspiąć się)
 eskale|||fra:escalier, spa:escalera, por:escada, + eng:scale, deu:Skale, rus:шкала (škala)|stairs (ladder)||escalera|||||||||||||ŝtuparo|portaat (rappuset, tikkaat)|schody (drabina)
 eskale tana||||vine|vigne|enredadera|||||蔓草|||||||||köynnös|pnącz
+eskandi yum|yum 021|Sc||scandium|scandium|escandio|escândio|скандий|سكانديوم|钪|スカンジウム|스칸듐|scandi|स्काण्डियम|স্ক্যান্ডিয়াম|skandium|skandi|skandiyum|skandio|skandium|skand
 Eskandinavia||||Scandinavia|Scandinavie|Escandinavia||||||||||||||Skandinavia|Skandynawia
-eskandium|mate|Sc||scandium||escandio|||||||||||||skandio|skandium|skand
 Eskote|desha|||Scotland||Escocia||||||||||||||Skotlanti|Szkocja
 eskulte||||sculpture (statue)||escultura (estatua)|||||||||||||statuo (skultaĵo)|veistos (patsas)|rzeźba
 eskulte ja|||spa:por:escultor, fra:sculpteur, eng:sculptor, rus:скульптор (skulptor)|sculptor|sculpteur|escultor|escultor|скульптор|||||||||||skultisto|kuvanveistäjä|rzeźbiarz
@@ -879,12 +879,12 @@ esponje|bio||eng:sponge, spa:por:esponja, ara:إسفنج (ʾisfanj), fas:اسف�
 esporte|||eng:deu:fra:sport, spa:deporte, por:esporte, rus:спорт (sport), jpn:スポーツ (supōtsu), kor:스포츠 (seupocheu), hin:स्पोर्ट (sporṭ), swa:spoti, tur:spor|sport (athletics)|sport|deporte|esporte|спорт||||||स्पोर्ट|||spoti|spor|sporto|urheilu|sport, lekkoatletyka
 esporte ja||||athlete (sportsman)||deportista||||||||||||||urheilija|hałas
 estadi|||fra:stade, por:estádio, spa:estadio, rus:стадион (stadion), eng:stadium, tur:stadyum, ara:(ʾistād), hin:स्टेडियम (sṭeḍiyam)|stadium (arena)||estadio (arena)|||||||||||||stadiono (areno)|stadioni (areena)|stadion, arena
-estan|mate|Sn|spa:estaño, por:estanho, fra:étain, ita:stagno, eng:tin|tin|étain|estaño|estanho|||锡|珍|||||||||tina|cynk
+estan|yum 050|Sn|spa:estaño, por:estanho, fra:étain, ita:stagno, eng:tin|tin|étain|estaño|estanho|олово|قصدير|锡|スズ|주석|thiếc|त्रपु|টিন|timah|stani (bati)|kalay||tina|cynk
 estasi|||tur:istasyon, por:estação, spa:estación, tgl:estasyon, urd:(isṭeśan), eng:fra:station, hin:स्टेशन (sṭeśan), rus:станция (stantsiya)|station||estación|||||||||||||stacio|asema|stacja
 estasi di||||static (stationary)||estático (estacionario)||||||||||||||seisova (staattinen)|statyczny, stacjonarny, nieruchomy
 Esti|desha|EE||Estonia||Estonia|||||||||||||Estonio|Viro (Eesti)|Estonia
-estibium|mate|Sb||antimony|antimoine|antimonio|antimônio|сурьма (стибиум)||锑|アンチモン|||अंजन||||||antimoni|antymon
-estrontium|mate|Sr||strontium||strontium|||||||||||||stroncio|strontium|stront
+estibi yum|yum 051|Sb||antimony|antimoine|antimonio|antimónio|сурьма|انتيمون|锑|アンチモン アンチモカ|안티몬, 2안티모니|antimon|एन्टिमोनी|অ্যান্টিমনি|antimon|stibi|antimon||antimoni|antymon
+estronti yum|yum 038|Sr||strontium|strontium|strontium|estrôncio|стронций|سترانشيوم|锶|ストロンチウム|스트논듐 or 스트론튬|stronti|स्ट्रोन्सियम|স্ট্রনসিয়াম|strontium|stronti|stronsiyum|stroncio|strontium|stront
 estude||||study (work made in order to practise or demonstrate)|étude|||этюд||||||||||||tutkielma|
 estude ja||||student|étudiant|estudiante|estudante|студент||||||विद्यार्थी (स्टूडेंट)|ছাত্র (তালিব)|pelajar (murid)|mwanafunzi|öğrenci|studento|opiskelija|student
 estude kan||||studio||estudio||||||||||||||ateljee (studio)|studio (pracownia)
@@ -898,12 +898,12 @@ eu topo||||utopia||||||||||||||||utopia|
 Eurasia|||eng:spa:may:Eurasia, por:Eurásia, fra:Eurasie, rus:Евразия (Evraziya), tur:Avrasya, ევრაზია (evrazia), hye:Եվրասիա (Evrasia), ara:يُورَاسِيَا‎ (yūrāsiyā), hin:यूरेशिया (yūreśiyā), ben:ইউরেশিয়া (iureśiẏa), zho:歐亞大陸 (Ōuyà dàlù), jpn:ユーラシア (yūrashiya)|Eurasia||Eurasia|||||||||||||Eŭrazio|Euraasia|Eurazja
 eureka|||ell:ευρίσκω (evrísko), eng:spa:eureka, por:eureca, fra:eurêka, rus:эврика (evrika), tur:efreka, jpn:ユーレカ (yūreka)|find (discover)||econtrar (hallar)|||||||||||||trovi|löytää (keksiä)|znaleźć, znajdywać, odkryć, odkrywać
 euro||||euro (€)||euro|||||||||||||eŭro|euro (€)|euro (€)
-Europa|planete 5 lun 2|||Europa||||||||||||||||Europa-kuu|
-Europe|||eng:fra:Europe, spa:por:deu:pol:Europa, ell:Ευρώπη (Evrópi) rus:Европа (Evropa), tur:Avrupa, swa:Uropa, hin:यूरोप (yūrop), may:Eropah, zho:歐洲 (Ōuzhōu), jpn:ヨーロッパ (yōroppa)|Europe|Europe|Europa|||||||||||||Eŭropo|Eurooppa|Europa
-europe baluta|bio|Quercus robur||English oak|chêne pédonculé|roble común|carvalho-roble|дуб черешчатый||夏櫟|ヨーロッパナラ|||||||||tammi|dąb szypułkowy
-europe di||||European|européen|europeo|||||||||||||Eŭropa|eurooppalainen|europejski
-Europe Unta||||European Union (EU)||Unión Europea|||||||||||||Eŭropa Unio (EU)|Euroopan unioni|Unia Europejska (EU)
-europium|mate|Eu||europium||europio|||||||||||||eŭropio|europium|europ
+Europa|||eng:fra:Europe, spa:por:deu:pol:Europa, ell:Ευρώπη (Evrópi) rus:Европа (Evropa), tur:Avrupa, swa:Uropa, hin:यूरोप (yūrop), may:Eropah, zho:歐洲 (Ōuzhōu), jpn:ヨーロッパ (yōroppa)|Europe|Europe|Europa|||||||||||||Eŭropo|Eurooppa|Europa
+europa baluta|bio|Quercus robur||English oak|chêne pédonculé|roble común|carvalho-roble|дуб черешчатый||夏櫟|ヨーロッパナラ|||||||||tammi|dąb szypułkowy
+europa di||||European|européen|europeo|||||||||||||Eŭropa|eurooppalainen|europejski
+Europa luna|planete 5 lun 2|||Europa||||||||||||||||Europa-kuu|
+Europa Unta||||European Union (EU)||Unión Europea|||||||||||||Eŭropa Unio (EU)|Euroopan unioni|Unia Europejska (EU)
+europa yum|yum 063|Eu||europium|europium|europio|európio|европий|يروبيوم|铕|ユウロピウム|유로퓸|europi|युरोपियम|ইউরোপিয়াম|europium|europi|europyum|eŭropio|europium|europ
 F||||F|F|F|F|F|F|F|F|F|F|F|F|F|F|F|F|F|F
 fa|||fra:faire, por:fazer, ita:fare + ara: فَعَلَ‎ (faʿala) + swa:fanya|do|faire|hacer|fazer|делать|فَعَلَ|作|する|하다|làm|करना|করা|buat|kufanya|yapmak|fari|tehdä (toimia)|zrobić (stworzyć, wykreować)
 fa achar||||pickle (preserve in vinegar or brine)||encurtir|||||酢漬けある|||||mengasamkan||||säilöä|kisić (marynować)
@@ -1191,8 +1191,8 @@ fen|||zho:分 (fèn), wuu:分 (fén), yue:分 (fan), vie:phần, tha:ปัน (
 fen di||||partial||parcial|||||部分的|||||||||osittainen|
 fen gata||||analysis (dissection)|analyse|análisis (disección)|análise|анализ||分析|分析 (解析)|||विश्लेषण||||analiz|analizo|analyysi|analiza
 fendona||||contribute||contribuir||||||||||||||osallistua (tehdä osansa)|wnieć wkład (przyczynić się)
-fermium|mate|Fm||fermium||fermio|||||||||||||fermio|fermium|ferm
-feru|mate|Fe|spa:hierro, por:ferro, fra:fer, may:ferum|iron||hierro|||||||||||||fero|rauta|żelazo
+fermi yum|yum 100|Fm||fermium|fermium|fermio|férmio|фермий|فرميوم|镄|フェルミウム|페르뮴|fecmi|फर्मियम|ফার্মিয়াম|fermium|fermi|fermiyum|fermio|fermium|ferm
+feru|yum 026|Fe|spa:hierro, por:ferro, fra:fer, may:ferum|iron|fer|hierro|ferro|железо|حديد|铁|鉄|철|sắt|लोहा|আয়রন|besi|feri (chuma)|demir|fero|rauta|żelazo
 festa|||por:festa, spa:fiesta, fra:fête, deu:Fest, eng:festival, rus:фестиваль (festival'), may:pesta|party (celebration, festival)||celebración (fiesta)||||||||||pesta|||festo|juhlat|przyjęcie, święto, festiwal
 festa den||||holiday||día festivo (feriado)||||||||||||||juhlapäivä|święto
 figur|||eng:fra:figure, spa:por:figura|figure (representation)||representación (figura)|||||||||||||figuro|hahmo (figuuri)|figura, reprezentacja
@@ -1226,8 +1226,8 @@ fizika shuta|||eng:physics, spa:por:física, rus:физика (fizika), tur:may:
 flame|||eng:fra:inflammation + zho:炎 (yán), yue:炎 (jim4), kor:염 (yeom), vie:viêm|inflammation (-itis)|inflammation|inflamación|inflamaçao|воспаление||炎症||||||||||tulehdus|zapalenie
 fleche|||spa:por:flecha, fra:flèche, eng:fletch|arrow (bolt)|flèche|flecha|flecha (seta)|стрела (стрелка)||箭|矢 (矢印)|||||||||nuoli|strzała (bełt)
 fleche ja||||fletcher||||||||||||||||nuolentekijä|wytwórca łuków i strzał
-flerovium|mate|Fl||flerovium||flerovio||||||||||||||flerovium|flerow
-flur|mate|F||fluorine||flúor|||||||||||||fluoro|fluori|fluor
+flerof yum|yum 114|Fl||flerovium|flérovium|flerovio|fleróvio|флеровий|ٲنون كواديوم||フレロビウム|플레로븀|flerovi|||flerovium|flerovi|fleroviyum||flerovium|flerow
+flur|yum 009|F||fluorine|fluor|flúor|flúor|фтор|فلور|氟|フッ素|플루오르|flo|फ्लोरीन|ফ্লুরিন|fluor|florini|fluor|fluoro|fluori|fluor
 fobi|||eng:-phobia, spa:por:may:-fobia, fra:deu:-phobie, rus:-фобия (-fobiya), tur:-fobi|fear (phobia)||miedo (-fobia)|||||||||||||timo (fobio)|kammo (fobia)|strach, fobia
 fobi di||||afraid (scared)||||||||||||||||pelokas|
 fobi ja||||scary (frightening)|effrayant|asustador|assustador|||||||||||korkutucu|timiga|pelottava|
@@ -1268,9 +1268,9 @@ France|desha|FR||France||Francia|||||||||||||Francio|Ranska|Francja
 france fon di||||Francophone (French speaking)|francophone|||||||||||||||ranskaa puhuva (frankofoni)|
 France fon dunia||||Francophonie|francophonie|||||||||||||||ranskankielinen maailma|
 France Guyana|desha|GF||French Guiana||Guyana Francesa||||||||||||||Ranskan Guiana|Gujana Francuska
-France krepe|yam|||crepe|crêpe|crepa (crep, tortilla de trigo)|crepe||||||||||||franca krepo|kreppi|francuski naleśnik (crêpe)
+france krepe|yam|||crepe|crêpe|crepa (crep, tortilla de trigo)|crepe||||||||||||franca krepo|kreppi|francuski naleśnik (crêpe)
 France Polinesi|desha|PF||French Polynesia|Polynésie française|Polinesia Francesa||||||||||||||Ranskan Polynesia|Polinezja Francuska
-francium|mate|Fr||francium||francio|||||||||||||franciumo|fransium|frans
+france yum|yum 087|Fr||francium|francium|francio|frâncio|франций|فرنسيوم|钫|フランシウム|프랑슘|franxi|फ्रान्सियम|ফ্রান্সিয়াম|fransium|fransi|fransiyum|franciumo|frankium|frans
 frem|||eng:frame, ben:ফ্রেম (phrēma), pan:ਫਰੇਮ (pharēma), mar:फ्रेम (phrēma), swa:fremu|frame|cadre|marco|moldura|рама||框|額||||||fremu|frame|kadro|kehys (raamit)|rama
 frike|||eng:friction, spa:por:friccionar, fra:frictionner + ara:فرك (farak)|rub (scrape, scrub)||raspar (arañar)||царапать||擦伤|擦る (擦り傷する)|||||||||hangata|trzeć (pocierać, obetrzeć, pucować)
 frute|||eng:fra:fruit, spa:por:fruta, rus:фрукт (frukt), jpn:フルーツ (furūtsu)|fruit|fruit|fruta|fruta|плод (фрукт)||果|果実 (フルーツ)|과일|quả|फल|ফল|buah|tunda|meyve|frukto|hedelmä|owoc
@@ -1305,12 +1305,12 @@ Gabon|desha|GA||Gabon||Gabón||||||||||||||Gabon|Gabon
 gabur|||ara:(qabr), hin:क़ब्र (qabra), ben:কবর (kôbôr), may:kubur, swa:kaburi, tur:kabir + deu:Grab, pol:grób, rus:гроб (grob)|grave (tomb, bury)|tombe (enterrer)|tumba (sepultura, enterrar)|sepultura (túmulo, enterrar)|могила (гроб, хоронить)||坟墓 (埋葬)|墓 (埋葬, 葬る)|무덤|mộ (phần mộ)|क़ब्र|কবর|kubur|kaburi|mezar (kabir)|tombo (enterigi)|hauta|grób (mogiła, grobowiec, zakopać, pochować)
 gabur bagi||||graveyard (cemetery, burial ground)|cimetière|cementerio|cemitério|кладбище|مقبرة‎|公墓 (墓地)|墓 (墓地)|묘지|nghĩa trang|क़ब्रिस्तान|কারবালা|pekuburan|makaburi|mezarlık (kabristan, mezaristan)|tombejo|hautausmaa|cmentarz
 gabur sheku||||tombstone (gravestone)|pierre tombale|lápida|lápide|надгробие||墓石 (墓碑)|墓石 (墓碑)|묘석|bia mộ|कब्र का पत्थर||batu nisan||mezartaşı|tomboŝtono|hautakivi|nagrobek
-gadolinium|mate|Gd||gadolinium||gadolinio|||||||||||||gadolinio|gadolinium|gadolin
+gadolin yum|yum 064|Gd||gadolinium|gadolinium|gadolinio|gadolínio|гадолиний|جدولينيوم|钆|ガドリニウム|가돌리늄|gađolini|ग्याडोलिनियम|গ্যাডোলিনিয়াম|gadolinium|gadolini|gadolinyum|gadolinio|gadolinium|gadolin
 gaja|||hin:गज (gaj), tel:గజము (gajamu), kan:ಗಜ (gaja), may:gajah, tgl:gadya|elephant||elefante|||||||||||||elefanto|norsu (elefantti)|słoń
 galaksi|||eng:galaxy, spa:galaxia, por:galáxia, fra:galaxie, rus:галактика (galaktika), tur:may:galaksi, hin:गैलेक्सी (gaileksī)|galaxy|galaxie|galaxia|galáxia|галактика||恆星系|銀河|은하|thiên hà|गैलेक्सी|ছায়াপথ|galaksi||galaksi|galaksio|galaksi|galaktyka
 galeri|||eng:gallery, spa:galería, por:galeria, fra:galerie, rus:галерея (galereya), tur:galeri, hin:गैलरी (gailrī), jpn:ギャラリー (gyararī)|gallery (exhibition hall)||galería|||||||||||||galerio (ekspozicio)|galleria|galeria, sala wystawowa
+gali yum|yum 031|Ga||gallium|gallium|galio|gálio|галлий|جاليوم|镓|ガリウム|갈륨|gali|गैलियम|গ্যালিয়াম|galium|gali|galyum|galiumo|gallium|gal
 Galia||||Gaul|Gaule|Galia|Gália|Галлия||高卢|ガリア||||||||Gaŭlio|Gallia|Galia
-galium|mate|Ga||gallium||galio|||||||||||||galiumo|gallium|gal
 galope|||eng:gallop, fra:galop, spa:por:galope, rus:галоп (galop)|canter and gallop|galop|galope|galope|кентер и галоп||||||||||||laukka|cwał (galop)
 galte|||ara:(ğalṭa), hin:ग़लती (ġaltī), swa:ghalati, tur:galat, fas:(ğalat),|mistake (error, fault, blunder, bug)|faute (erreur)|error|erro (falta)|||错误|間違い (誤り, バグ)|||ग़लती (भूल)||||yanlışlık (galat, erör)|eraro (miso)|virhe (erhe)|błąd (pomyłka)
 galte budi||||misunderstand||malinterpretar||||||||ग़लत समझना||||||ymmärtää väärin|źle zrozumieć
@@ -1395,8 +1395,8 @@ geo politi||||geopolitics|géopolitique|geopolítica|geopolítica|геополи
 geo sismo||||earthquake||terremoto|||||||||||||tertremo|maanjäristys|trzęsienie Ziemi
 geo termo||||geothermal|géothermique|geotérmico||геотерма́льный||地热的||||||||||geoterminen (maalämpö-)|
 geo tika||||lot (plot of land)||terreno (solar)||||||||||||||tontti (maakaistale)|działka (teren)
+german yum|yum 032|Ge||germanium|germanium|germanio|germânio|германий|جرمانيوم|锗|ゲルマニウム|게르마늄, 2저마늄|gecmani|जर्मेनियम|জার্মেনিয়াম|germanium|gerimani|germanyum|germaniumo|germanium|german
 Germania||||Germania|Germanie|Germania|Germânia|||||||||||||Germania|
-germanium|mate|Ge||germanium||germanio|||||||||||||germaniumo|germanium|german
 Gernezi|desha|GG||Guernsey||Guernesey||||||||||||||Guernsey|Guernsey
 gi|||zho:機 (jī), wuu:機 (ji1), yue:機 (gei1), jpn:機 (ki), kor:기 (gi), tha:กี่ (gìi) + jpn:器 (ki)|machine (device, aparatus)||máquina (dispositivo, aparato)|||||装置 (機, 器)||||||||maŝino|kone|maszyna
 giau||||teach (educate, instruct, doctrine)|enseigner|enseñar (instruir, doctrina)|ensinar (lecionar)|учить (преподавать)|دَرَّسَ|教学|教える (教義, -教)|||सिखाना (पढ़ाना)|শেখান|mengajar|kufundisha|öğretmek (ders vermek)|instrui (lernigi)|opettaa|
@@ -1488,9 +1488,9 @@ habar|||ara:(xabar), tur:haber, may:kabar, swa:habari, hin:ख़बर (xabar),
 habar gazeta||||newspaper (gazette)||periódico (diario)|||||||||||||gazeto|sanomalehti|gazeta
 habasha||||Abyssinian||abisinio||||||||||||||abyssinialainen|abisyński
 Habasha||||Abyssinia|Abyssinie|Abisinia|Abissínia|Абиссиния|الْحَبَشَة‎|阿比西尼亚|アビシニア|아비시니아||हबश||||Habeşistan||abyssinia|Abisynia
+hafen yum|yum 072|Hf||hafnium|hafnium|hafnio|háfnio|гафний|هفنيوم|铪|ハフニウム|하프늄|hafini|हाफ्नियम|হাফনিয়াম|hafnium|hafni|hafniyum|hafnio|hafnium|hafn
 hafiza|||ara:(ḥafiẓa), fas:urd:(hāfiz), tur:muhafaza, hin:हाफ़िज़ (hāfīz), swa:hifadhi|keep (preserve, conserve, retain, spare)||conservar (preservar, mantener)||||||||||||||säilyttää (varjella, säästää)|zachować, zakonserwować, zachować, utrzymać
 hafiza ja||||keeper (preserver)||guarda (preservador, conservador)||||||||||||||säilyttäjä|przechowawca, kustosz, opiekun
-hafnium|mate|Hf||hafnium||hafnio|||||||||||||hafnio|hafnium|hafn
 haha|||eng:fra:por:tur:haha, spa:jaja, rus:ха-ха (ha-ha), zho:哈哈 (hāhā), jpn:わはは (wa-ha-ha), ara:(hahah)|laugh|rire|reír|rir|смеяться||笑|笑う|웃다|cười|हँसना|হাসা|tawa|kuseka|gülmek|ridi|nauraa|śmiać się
 hai|||zho:海 (hǎi), yue:海 (hoi2), jpn:海 (kai), kor:해양 (haeyang), vie:hải|sea|mer|mar|mar|море||海|海|바다 (해양)|biển (hải)|समन्दर (समुद्र)|সাগর (সমুদ্র)|laut (samudera)|bahari|deniz|maro|meri|może
 hai alga|bio|||seaweed (macroalgae)|algues|macroalga|macroalga|морские водоросли||海藻|海藻|||||rumpai laut||||merilevä|wodorosty
@@ -1542,7 +1542,6 @@ Hartum|xefsite|SD||Khartoum|Khartoum|Jartum|Cartum|Хартум|الخرطوم|�
 has|||ara:(xāṣṣ), fas:urd:(xās), hin:ख़ास (xās), may:khas, swa:hususa|special (distinct)||especial (diferenciado, distinto)|||||||||||||speciala|erikoinen (erityinen)|specjalny, wyraźny, wyrazisty
 has ta||||distinction (specialty)||especialización (distinción)||||||||||||||erikoisuus|różnica (specjalność)
 hashish||||hashish||hachís||||||||||||||hasis|haszysz
-hasium|mate|Hs||hassium||hasio|||||||||||||hasio|hasium|has
 hata|prep.||por:até, ara:(ḥatta), spa:hasta, swa:hata + fas: تا‎ (tâ), hin:तक (-tak)|until (til, up to)|jusque (jusqu’à)|hasta|até|до||直到|||||||mpaka||ĝis|asti (saakka)|aż do
 hata||||even (implying extreme example)|voire (même)|hasta (también)||||连||||और भी|||||eĉ|jopa|nawet
 hatar|||ara: خطر‎ (xaṭar), fas: خطر‎ (xatar), urd: خطرہ‎ (xatrā), hin:ख़तरा (xatrā), swa:hatari, tur:muhatara|danger (peril)|danger|peligro|perigo|опасность|خطر‎|危险|危険|위험|nguy hiểm|जोखिम (ख़तरा)|বিপদ|bahaya|hatari|tehlike (muhatara)|danĝero|vaara|zagrożenie, niebezpieczeństwo
@@ -1555,10 +1554,10 @@ Hayaki|desha|AM||Armenia||Armenia||||||||||||||Armenia|Armenia
 he|||eng:huh, fra:hein, por:hã, vie:hả, deu:hä|huh? (eh?, pardon?)|hein?|cómo? (eh?)|||||||||||||ĉu?|häh (-ko, -kö)|hę?, co?, pardon?
 Helen|desha|GR||Greece||Grecia|||||||||||||Grekio|Kreikka|Grecja
 Helen||||Greek (Hellenic)||griego (helénico)|||||||||||||greka|kreikkalainen|gracki, helleński; Grek
+heli yum|yum 002|He||helium|hélium|helio|hélio|гелий|هيليوم|氦|ヘリウム|헬륨|heli|हिलियम|হিলিয়াম|helium|heli|helyum|helio|helium|hel
 helis|||ell: ἕλιξ (helix), eng:helix, fra:por:spa:hélice, pol:helisa, ara:(ḥalazūn), tur:helezon|spiral (helix, corkscrew, twist)||espiral (hélice)||||螺旋||||||||||kierre (spiraali)|helisa
 helis babul|bio|Vachellia tortilis||umbrella thorn acacia tree|acacia faux-gommier|acacia de copa plana||акация кручёная|||||||||||||
 helis fei gi||||helicopter|hélicoptère|helicóptero|hélicoptero|вертолёт||直升机|ヘリコプター|헬리콥터 (헬기)||हेलिकॉप्टर|হেলিকোপটার||||helikoptero|helikopteri|helikopter
-helium|mate|He||helium||helio|||||||||||||helio|helium|hel
 Helsinki|xefsite|FI||Helsinki||||||||||||||||Helsinki|
 hem||||ponder (think, contemplate, consider, regard)|considérer|considerar (reflexionar, pensar en)|considerar|думать||深思 (考虑)|考える|||विचार करना||menung (mengirakan)|||pripensi (rigardi ia)|miettiä (pohtia, pitää jonakin)|dumać, rozmyślać, zastanawiać się, rozważać, brać pod uwagę
 hem…|||eng:hmm, rus:хм (hm), эм (em), kor:음 (eum)|hmm…|hum…|hm…|hmm…|хм…|||||hmm… (hừmm…)||||||hm…|hmm…|hmm…
@@ -1570,15 +1569,17 @@ hero di||||heroic||valiente (heroico)|||||||||||||heroa|urhea (sankarillinen)|bo
 hero kata||||saga (heroic tale)||||||||||||||||sankaritaru (legenda)|
 herze|unomete|Hz||hertz (Hz)||hercio (Hz)||||||||||||||hertsi (Hz)|herc
 Hese||||Hesse|Hesse|Hesse (Hessia)|Hesse (Héssia)|Гессен||黑森|ヘッセン|||||||||Hessen|
+hese yum|yum 108|Hs||hassium|hassium|hasio|hássio|хассий|هاسيوم||ハッシウム|하슘|hassi|हसियम|হ্যাসিয়াম|hassium|hassi|hassiyum|hasio|hassium|has
 hibride|||eng:hybrid, spa:por:híbrido, fra:hybride, rus:гибрид (gibrid)|hybrid (mongrel)||híbrido (mestizo)|||||||||||||miksulo|risteytys (hybridi)|hybryda; kundel
-hidrargente|mate|Hg||mercury (quicksilver)||mercurio||||||||||||||elohopea|rtęć
-hidro|mate|H||hydrogen||hidrógeno|||||||||||||hidrogeno|vety|wodór
+hidrargente|yum 080|Hg||mercury (quicksilver)|mercure|mercurio|mercúrio|ртуть|زئبق|汞|水銀|수은|thuỷ ngân|पारा|পারদ (মৌল)|raksa|zaibaki (hidrajiri)|civa||elohopea|rtęć
+hidro|yum 001|H||hydrogen|hydrogène|hidrógeno|hidrogéno|водород|هيدروجين|氢|水素|수소|hyđrô, hiđro|हाइड्रोजन|হাইড্রোজেন|hidrogen|hidrojeni|hidrojen|hidrogeno|vety|wodór
 hijabu|||ara:(ḥijāb), fas:(hejâb), swa:hijabu, hau:hijabi, hin:हिजाब (hijāb), ben:হিজাব (hijab), eng:por:hijab, fra:hidjab, spa:hiyab, rus:хиджаб (xidžab)|veil (cover, screen)|voile|velo|véu|вуаль|حِجَاب|面纱||||||||hijabu (veli, shela)||verho (huntu, peite)|welon (woalka)
 hima|||hin:हिमपात (himpāt), tha:หิมะ (hima), tel:(himamu)|snow|neige|nieve|neve||||||||||||neĝo|lumi|śnieg
 hima rose||||frost||escarcha|||||||||||||frosto|kuura|szron
 Himalaya||||Himalayas||Himalaya|||||||||||||Himalajo|Himalaja|Himalaje
 hin|||hin:-हीन (hīn), ben:-হীন (-hin), guj:-હીન (-hīn)|lack (miss, be without)||faltar (sin)|sem|без|||||||||||sen (manki)|puuttua (ilman, vailla)|bez
 hin di||||lacking (-less)|||||||||||||||ne havanta (sen~a)|ilman oleva (-ton)|
+hindi yum|yum 049|In||indium|indium|indium|índio|индий|انديوم|铟|インジウム|인듐|indi|इण्डियम|ইন্ডিয়াম|indium|indi|i̇ndiyum|indio|indium|ind
 Hindu||||Hindu||hindú|||||||||||||hinduo|hindu|hinduistyczny
 Hindu basha||||Hindi (Hindustani)||||||||||हिंदी (हिंदुस्तानी)|হিন্দি|||||hindin kieli|
 Hindu desh||||Hindustan|Hindustan|Indostán||Индостан||印度斯坦||||हिंदुस्तान|হিন্দুস্তান|||||Hindustan|
@@ -1608,7 +1609,7 @@ hogo sheku||||flint|silex|pedernal (sílex)|pederneira|кремень||燧石|�
 hogo tehni||||fireworks (pyrotechnics)|feu d’artifice|dispositivo pirotécnico|fogos de artifício|фейерверк||烟火|花火|||||||||pyrotekniikka|pirotechnika
 hoki|||eng:fra:spa:hockey, por:hóquei, rus:хоккей (hokkey),  jpn:ホッケー (hokkē), hin:हाकी (hākī), ben:হকি (hôki), ara:(hūkī), swa:hoki|hockey|hockey|hockey|hóquei|хоккей||曲棍球|ホッケー|khúc côn cầu||हाकी|হকি|hoki||hokey|hokeo|hockey (jääkiekko)|hokej
 holera|||eng:cholera, spa:por:cólera, fra:choléra, rus:холера (holera), tur:kolera, ara:كُولِيرَا‎ (kōlīrā), hin:कॉलरा (kŏlrā), zho:虎列拉 (hǔlièlā), jpn:コレラ (korera)|cholera||cólera||||||||||||||kolera|cholera
-holmium|mate|Ho||holmium||holmio|||||||||||||holmio|holmium|holm
+holme yum|yum 067|Ho||holmium|holmium|holmio|hólmio|гольмий|هلميوم|钬|ホルミウム|홀뮴|holmi, honmi|होल्मियम|হলমিয়াম|holmium|homi|holmiyum|holmio|holmium|holm
 holo|||eng:whole, spa:por:fra:tur:may:holo-, rus:голо- (golo-), jpn:ホロ (horo-)|whole (entire)||entero (todo)||||||||||||||koko (kokonainen)|cały
 holo grafi||||hologram||holograma||||||||||||||hologrammi|hologram
 holo ta||||wholeness (integrity)||totalidad (integridad)||||||||||||||kokonaisuus|całość (integralność)
@@ -1675,7 +1676,6 @@ in pushe||||squeeze (squish)||||||||||||||||pusertaa|ścisnąć (sciskać, wycis
 in she||||content||contenido||||||||||||||sisältö|treść (zawartość)
 in verse jan||||introvert|introverti|introvertido||интроверт||内向的|内向的な人|||||||||sisäänpäinsuuntautunut (introvertti)|
 in vide||||introspection||||||||||||||||introspektio|
-indium|mate|In||indium||indium|||||||||||||indio|indium|ind
 Indonesi|desha|ID||Indonesia||Indonesia|||||||||||||Indonezio|Indonesia|Indonezja
 insan|bio|Homo Sapiens|ara:(ʔinsan), hin:इंसान (insān), tur:insan, urd:(insān), fas:(ensān)|human being|être humain|ser humano|ser humano|человек|إِنْسَان|人类|人間|인류||मनुष्य (इंसान)|মানুষ|manusia|binadamu|insan|homo|ihminen|człowiek, istota ludzka
 insan di||||humane|humain|humano|humano|человечный|||||||||||humana|inhimillinen|ludzki
@@ -1688,13 +1688,13 @@ insulte|||eng:insult, fra:insulte, spa:por:insulto, rus:инсульт (insul’
 insulte di||||rude (offensive)||grosero (maleducado)||||||||||||||törkeä|obraźliwy, niemiły, obelżywy
 internete||||internet||Internet||||||||||||||internet|internet
 Io|planete 5 lun 1|||Io||||||||||||||||Io|
-iode|mate|I||iodine||yodo (iodo)||йод|||||||||||jodo|jodi|jod; jodyna
+iode|yum 053|I||iodine|iode|yodo (iodo)|iodo|йод|يود|碘|ヨウ素|요오드, 2아이오딘|iot, iođ|आयोडिन|আয়োডিন|yodium|iodini (aidini)|i̇yod|jodo|jodi|jod; jodyna
 ion|||eng:fra:spa:ion, rus:ион (ion), tur:iyon|ion||ion|||||||||||||iono|ioni|jon
 ion radi||||radioactivity (ionizing radiation)||radiación ionizante||||||||||||||radioaktiivisuus|radioaktywność
 ion radi di||||radioactive||radiactivo||||||||||||||radioaktiivinen|radioaktywny
 Iraki|desha|IQ||Iraq||Iraq|||||||||||||Irakio|Irak|Irak
 Iran|desha|IR||Iran||Irán|||||||||||||Iranio|Iran|Iran
-iridium|mate|Ir||iridium||iridio|||||||||||||iridio|iridium|iryd
+iris yum|yum 077|Ir||iridium|iridium|iridio|irídio|иридий|إريديوم|铱|イリジウム|이리듐|iriđi|इरिडियम|ইরিডিয়াম|iridium|iridi|i̇ridyum|iridio|iridium|iryd
 ironi|||eng:irony, spa:ironía, por:ironia, fra:ironie, rus:иро́ния (ironija), jpn:アイロニー (aironī)|irony|ironie|ironía|ironia|ирония|||反語 (皮肉)|||||||||ironia|ironia
 ironi di||||ironic||irónico|||||反語的|||||||||ironinen|ironiczny
 islam|||ara:(ʾislām), fas:(taslim), tur:teslim|submission (surrender)|soumission|sumisión (rendición)||||||||||||||alistuminen (antautuminen)|poddanie się, uległość, pokora, posłuszeństwo
@@ -1804,14 +1804,14 @@ jusha||||inject||inyectar||||||||||||||ruiskuttaa|wstrzyknąć, wstrzykiwać
 juste|||eng:just, fra:juste, spa:justo, ita:giusto, jpn:ジャスト (jasto)|just (precise, exact, accurate)|justo (exact, précis)|exacto (preciso)|exato (preciso)|точный|||||||||halisi|dakik|ĝuste (precize, ekzakte)|juuri (tarkka, täsmällinen)|tylko (precyzyjny, dokładny)
 juste pau ja||||sniper (sharpshooter)||francotirador||снайпер|||狙撃兵||||||||||snajper (strzelec wyborowy)
 K||||K|K|K|K|K|K|K|K|K|K|K|K|K|K|K|K|K|K
-ka|||jpn:家 (-ka), kor:가 (-ga), yue:家 (-gaa1) + eng:-ic, fra:-ique, spa:por:-ico, hin:-इक (-ika)|person engaged in a profession or practice (-ic, -er)||||||家|家|||||||||henkilö jota asia määrittelee|
 ka|prep.||spa:por:fra:que, swa:kumliko, suo:kuin, lao:ກວ່າ (kuā), tgl:kaysa|than (as, compared to, relative to)|que (comme)|que (como, en comparación con)|que (como)|чем||比|より (に比べ)||hơn|||daripada|kuliko|göre|ol (kiel)|kuin (verrattuna)|jak, niż, od
+ka|||jpn:家 (-ka), kor:가 (-ga), yue:家 (-gaa1) + eng:-ic, fra:-ique, spa:por:-ico, hin:-इक (-ika)|person engaged in a profession or practice (-ic, -er)||||||家|家|||||||||henkilö jota asia määrittelee|
 kababu|||ara:fas:urd: كباب (kabāb), tur:may:eng:spa:kebab, rus:кебаб (kebab), hin:कबाब (kabāb), ben:কাবাব (kabab), swa:kababu|barbecue (grill)||asar||||||||||||||grillata (kärventää)|grillować
 kababu nama||||grilled meat (kebab)||||кебаб|كباب|||||कबाब|কাবাব|||kebap||kebab (grilliliha)|kebab
 kabin|||eng:cabin, spa:cabaña, por:cabana, fra:cabane, ben:কেবিন (kebin)|cabin (booth)||cabaña||||||||||||||koppi (maja)|kabina, budka
 kaboga|bio|Cucurbita|tur:kabak, swa:boga, jpn:カボチャ (kabocha)|squash (pumpkin, gourd)|citrouille|calabaza|abóbora (jerimun)|тыква||南瓜|カボチャ||||||||||kabaczek (dynia, tykwa)
 Kabu Verde|desha|CV||Cabo Verde (Cape Verde)||Cabo Verde||||||||||||||Cabo Verde|Wyspy Zielonego Przylądka (Republika Zielonego Przylądka)
-kadmium|mate|Cd||cadmium||cadmio|||||||||||||kadmio|kadmium|kadm
+kadim yum|yum 048|Cd||cadmium|cadmium|cadmio|cádmio|кадмий|كادميوم|镉|カドミウム|카드뮴|catmi, cađimi|काडमियम|ক্যাডমিয়াম|kadmium|kadimi|kadmiyum|kadmio|kadmium|kadm
 kafe|||deu:Kaffee, fra:spa:por:café, rus:кофе, zho: 咖啡 (kāfēi), yue:咖啡 (gaa3 fe1), eng:coffee, hin:काफ़ी (kāfī), ben:কফি (kôphi), tur:kahve, tgl:kape, tha:กาแฟ (kafæ)|coffee|café|café|café|кофе|قَهْوَة|咖啡|コーヒー|||काफ़ी (क़हवा)||kopi|kahawa|kahve|kafo|kahvi|kawa
 kafe alga|bio|Phaeophyceae||brown algae|algues brunes|algas pardas||бурые водоросли|||褐藻||||||||||brunatnica
 kafe kan||||cafe (coffee shop)|café|café (cafetería)|café|кафе (кофейня)||咖啡馆|カフェ (コーヒー店)|카페 (커피점)|quán cà phê|कॉफ़ीख़ाना (कैफ़े)|হোটেল (ক্যাফে)|kedai kopi|mkahawa|kahvehane|kafejo|kahvila|kawiarnia
@@ -1837,16 +1837,16 @@ kali||||alkaline|basique|alcalino|alcalino||||||||||||alkaleca|emäksinen (alkal
 kali guste||||bitter|amer|amargo|amargo|горький||苦的|苦い||||||||amara|kitkerä (karvas)|gorzki
 kali melon|bio|Momordica charantia||bitter melon||melón amargo||горький огурец (китайская горькая тыква)||苦瓜|ツルレイシ (ニガウリ)||||||||||przepękla ogórkowata (balsamka ogórkowata)
 kali oranje|bio|Citrus × aurantium||bitter orange|orange amère|naranjo amargo||померанец|||ダイダイ||||||||||gorzka pomarańcza
-kalifornium|mate|Cf||californium||californio|||||||||||||kaliforniumo|kalifornium|kaliforn
+kali yum|yum 019|K||potassium|potassium|potasio|potássio|калий|بوتاسيوم|钾|カリウム|칼륨, 2포타슘|kali|पोटैशियम|পটাসিয়াম|kalium|kali|potasyum|kalio|kalium|potas
+kaliforni yum|yum 098|Cf||californium|californium|californio|califórnio|калифорний|كاليفورنيوم|锎|カリホルニウム|칼리포르늄 or 칼리포늄|califoni|कैलीफोर्नियम|ক্যালিফোর্নিয়াম|kalifornium|kalifoni|kaliforniyum|kaliforniumo|kalifornium|kaliforn
 Kalisto|planete 5 lun 4|||Callisto|||||||||||||||||
-kalium|mate|K||potassium||potasio|||||||||||||kalio|kalium|potas
 kalkul|||fra:calcul, spa:cálculo, eng:calculus, hin:कलन (kalan)|calculus (manipulation of symbolic expressions)||cálculo||||||||||||||kalkyyli|rachunek (formalny system obliczeń)
 kalmar|bio|Decapodiformes|ell:καλαμάρι (kalamári), spa:por:calamar, fra:calmar, ita:eng:calamari, rus:кальмар (kal’mar), tur:kalamar, ara:كلاماري‎ (klamāri)|squid (cuttlefish)|calmar (encornet, calamar)|calamar|lula (calamar)|кальмар||鱿鱼|イカ||||||fuu||||kałamarnica (mątwa)
 kalse bilor||||marble|marbre|marmól|mármore|мрамор|رُخَّام|大理石|大理石|대리석|đá hoa|संगमरमर||marmer||mermer|marmoro|marmori|marmur
 kalse mate||||lime|chaux|cal|cal|известь||石灰|石灰|석회||||||kireç|kalko|kalkki|wapno
 kalse petra||||limestone|calcaire|caliza|calcário|известняк||石灰岩||||||batu kapur||kireç taşı|kalkoŝtono|kalkkikivi|wapień
+kalsi yum|yum 020|Ca||calcium (Ca)|calcium|calcio|cálcio|кальций|كلسيوم|钙|カルシウム|칼슘|canxi|कैल्शियम|ক্যালসিয়াম|kalsium|kalisi|kalsiyum|kalcio|kalsium|wapń
 kalsite||CaCO3||calcite|calcite|calcita|calcita|кальцит||方解石||||||||kalsit|kalcito|kalsiitti (kalkkisälpä)|kalcyt
-kalsium|mate|Ca||calcium (Ca)||calcio|||||||||||||kalcio|kalsium|wapń
 kama||27 emotions|hin:काम (kām), ben:কাম (kam), tha:กาม (gaam)|lust (desire, libido, sexual passion)|luxure (libido)|lujuria (deseo)|luxúria||شَهْوَة‎|情欲|色欲|성욕 (정욕)||काम (कामना, वासना)|কাম|||||himo (seksuaalinen halu)|pożądanie, żadza
 kama deu||||god of love (Eros, Kamadeva)|||||||カーマ|||||||||rakkaudenjumala|
 kama kanon||||Kama Sutra|Kâmasûtra||Kama Sutra|Камасутра||欲经||||कामसूत्र|কামসূত্র||||deziro||
@@ -1900,7 +1900,7 @@ karate||||karate|karaté|karate|caratê|каратэ||空手道|空手|가라데
 karate ka||||karateka (practitioner of karate)|karatéka|||каратист (каратэка)|||空手家|||||||||karateka (karaten harrastaja)|
 karavi|bio|Carum carvi|ara:(karāwiya), eng:caraway, fra:carvi, spa:alcaravea, por:alcaravia|caraway||carvis (alcaravea)|alcaravia (cariz)||||||||||||karvio|kumina|kminek
 karbau|bio|Bubalus bubalis|spa:carabao, may:kerbau, jav:kebo, khm:ក្របី (krɑbəy)|water buffalo||búbalo (arni)||||||||||||||vesipuhveli|bawół domowy
-karbon|mate|C||carbon (coal)||carbón|||||||||||||karbono|hiili|węgiel
+karbon|yum 006|C||carbon (coal)|carbone|carbón|carbono|углерод|كربون|碳|炭素|탄소|cacbon|कार्बन|কার্বন|karbon|kaboni|karbon|karbono|hiili|węgiel
 karbon duokside||||carbon dioxide|dioxyde de carbone|dióxido de carbono|dióxido de carbono|двуокись углерода||二氧化碳||||प्रांगार द्विजारेय|||||karbona dioksido|hiilidioksidi|dwutlenek węgla
 karbon kalam||||pencil|crayon|lápiz|lápis|карандаш||铅笔|鉛筆|연필|bút chì|अंकनी (पेंसिल)|অঙ্কনী (পেনসিল)|pensil|penseli|kurşun kalem|krajono|lyijykynä|
 karbon sui||||carbohydrate (saccharide)||carbohidrato||углевод|||炭水化物||||||||||
@@ -1979,7 +1979,6 @@ kilomitre|unomete|km||kilometer (km)||kilometre|||||||||||||kilometro|kilometri|
 kimi|||eng:chemistry, fra:chimie, spa:por:química, rus:химия (himiya), ara:(kīmiyāʾ), may:kimia, swa:kemia, tur:kimya|substance (physical material from which something is made)|substance|sustancia|substância|вещество||物质|物質|물질|vật chất|पदार्थ|পদার্থ|||||aine (aines, materia)|
 kimi di||||chemical||químico||||||||||||||kemikaali|chemiczny
 kimi logi||||chemistry|chimie|química|química|химия|كِيمِيَاء‎|化学|化学|화학|hóa học|रसायन शास्त्र|রসায়ন|kimia|kemia|kimya|ĥemio (kemio)|kemia|chemia
-kimi so||||chemical element|élément chimique|elemento químico|elemento químico|химический элемент||元素|元素|원소|nguyên tố|रासायनिक तत्व||unsur kimia||kimyasal element|kemia elemento|alkuaine|
 kimono||||kimono|kimono|quimono|quimono|кимоно||和服|着物|기모노|kimono||||||kimono|kimono|kimono
 kinar|||hin:किनारा (kinārā), ben:কিনারা (kinara), tur:kenar, fas: کنار‎ (kenâr)|border (edge, fringe, margin, rim, side, shore, periphery)|bord|frontera (límite, borde, periferia)|margem (borda)|край (грань)||边|際 (端)||rìa|किनारा|কিনারা|||kenar|rando (orlo)|reuna (raja, ääri)|granica, skraj, brzeg, krawędź
 kinar baryer||||fence||valla (cerca)|cerca|забор (ограда)||篱笆|柵 (垣)||||||||||płot
@@ -2021,11 +2020,11 @@ klima logi||||climatology||climatología|||||||||||||klimatscienco|ilmastotiede 
 klima mute||||climate change|changement climatique|cambio climático|mudança climática|изменение климата||气候变化|気候変動|기후 변화|biến đổi khí hậu|||||iklim değişikliği||ilmastonmuutos|zmiana klimatu
 klin|||eng:-cline, fra:-cliner, por:spa:-clinar, rus:склонить (sklonit’)|slope (tilt, slant, bias, inclination, tendency)|tendance|cuesta (inclinación, pendiente, predisposición, tender)|tendência|тенденция (склонить)||趋势|斜め (傾向)|경향||||cenderung (condonkan)|mwelekeo|eğilim (meyletmek)|emo (inklino, tendenco)|taipumus|tendencja (być skłonnym)
 klon|||en:por:fra:clone, spa:clon rus:клон (klon), may:klon, jpn:クローン (kurōn)|clone (replica)||clonar|||||||||||||klono|klooni (identtinen kopio)|klon, replika
-klor|mate|Cl||chlorine||cloro|||||||||||||kloro|kloori|chlor
+klor|yum 017|Cl||chlorine|chlore|cloro|cloro|хлор|كلور|氯|塩素|염소|clo|क्लोरीन|ক্লোরিন|klor|klorini|klor|kloro|kloori|chlor
 klube|||eng:spa:fra:club, por:clube, rus:клуб, tur:kulüp, swa:klabu, hin:क्लब (klab), may:kelab, zho:俱乐部 (jùlèbù), jpn:クラブ (kurabu)|club||club|||||||||||||klubo|kerho (klubi)|klub
 klus||||closed||||||||||||||||suljettu|zamknięty
 klus|||eng:fra:spa:por:-clus-, rus:ключить (-klyučítʹ)|close (shut)||||||||||||||||sulkea|
-kobalte|mate|Co||cobalt||cobalto|||||||||||||kobalto|kobaltti|kobalt
+kobalte|yum 027|Co||cobalt|cobalt|cobalto|cobalto|кобальт|كوبلت|钴|コバルト|코발트|coban|कोबाल्ट|কোবাল্ট|kobalt|kobalti|kobalt|kobalto|koboltti|kobalt
 koda|||eng:coda, spa:coda,cola, por:cauda, fra:côté, jpn:コーダ (kōda)|tail (coda)|queue (côté )|cola (rabo, coda)||хвост||尾巴 (尾部)|尾 (尾翼)|||पूंछ (दुम)|লেজ|ekor (kotek, basian)|mkia|kuyruk|vosto|häntä|ogon
 kode||||encode (encrypt)||codificar (cifrar)||||||||||||||koodata|kodować
 kode|||eng:code, spa:por:código, ru:код, fas:کد‎ (kod), hin:कोड (koḍ), jpn:コード (kōdo)|code (cipher)||código (cifra)|||||||||||||kodo|koodi|kod, szyfr
@@ -2071,7 +2070,7 @@ kong fuzi sim||||Confucianism||confucianismo||||||||||||||Kungfutselaisuus|konfu
 Konkani|nas|||Konkani||konkani||||||||||||||konkani (eräs intialainen kieli)|konkani
 konserte|||eng:fra:concert, spa:concierto, por:concerto, deu:Konzert, rus:концерт (koncert), may:tur:konser, jpn:コンサート (konsāto), kor:콘서트 (konseoteu), hin:कॉन्सर्ट (kŏnsarṭ)|concert|concert|concierto|concerto|концерт||音乐会|コンサート (音楽会)|콘서트 (음악회)||कॉन्सर्ट|সঙ্গীতানুষ্ঠান|konser||konser|koncerto|konsertti|koncert
 kontra|coverb|||go against||estar en contra|||||||||||||kontraŭi|mennä vasten|być przeciw
-kopernikium|mate|Cn||copernicium||copérnico|||||||||||||kopernicio|kopernikium|kopernik
+koperni yum|yum 112|Cn||copernicium|copernicium|copérnico|copernício|коперниций|ٲنون بيوم||コペルニシウム|코페르니슘|copernici|||copernicium|kopernici|koperniciyum|kopernicio|copernicium|kopernik
 kopi|||eng:copy, fra:copie, spa:por:copia, rus:копия (kopiya), hin:कापी (kāpī), tur:kopya, may:kopi, zho:拷貝 (kǎobèi), jpn:コピー (kopī)|copy (duplicate, replica)|copie|copia (réplica)|cópia|копия||摹本 (拷貝)|コピー|||कापी (प्रति)||salinan (turunan, kopi)|nakala|kopya (suret, nüsha)|kopio|kopio (jäljennös)|kopia, replika
 kopi haki||||copyright||derechos de autor (copyright)||||||||||||||kopiointioikeus (tekijänoikeus)|prawa autorskie
 koral|bio||eng:spa:por:coral, fra:corail, deu:Koralle, rus:коралл|coral|corail|coral|coral|коралл||珊瑚|サンゴ|||मूंगा||karang|matumbawe (marijani)||||koral
@@ -2111,12 +2110,12 @@ krevete|||eng:fra:crevette, ita:gamberetto, rus:креветка (krevetka)|shri
 krim|||eng:fra:por:crime, spa:crimen, tgl:krimen|crime||crimen (delito)|||||||||||||krimo|rikos|przestępstwo
 krim di||||criminal||criminal|||||||||||||krima|rikos- (rikollinen)|kryminalny, przestępczy
 krita|||eng:cry, spa:por:gritar, fra:crier, rus:крича́ть (kričátʹ)|cry (shout)||gritar||||||||||||||huutaa|krzyknąć, krzyczeć
-kriton|mate|Kr||krypton||criptón (kriptón)|||||||||||||kriptono|kryptoni|krypton
+kriton|yum 036|Kr||krypton|krypton|criptón (kriptón)|krípton|криптон|كربتون|氪|クリプトン|크립톤|kripton|क्रिप्टन|ক্রিপ্টন|kripton|kriptoni|kripton|kriptono|krypton|krypton
 krizi|||eng:crisis, fra:por:crise, deu:Krise, rus:кризис (krizis), spa:crisis|crisis||crisis|||||||||||||krizo|kriisi (käännekohta)|kryzys
 krizi||||critical (pertaining to crisis)||crítico (fundamental)||||||||||||||kriittinen (kriisi-)|kryzysowy
 krokodil|bio|Crocodilia|ell:κροκόδειλος, eng:crocodilian, fra:crocodilien, spa:crocodilio, por:crocodiliano, rus:крокодил (krokodil), jpn:クロコダイル, kor:크로커다일 (keulokeodail)|crocodillian|crocodilien|crocodilio|crocodiliano|крокодил||鳄|ワニ||||||||||krokodyl
 krokroke|bio||eng:croak, deu:gribbit, spa:croac croac, fin:kurr kurr, jpn:ケロケロ (kero kero), tur:vrak vrak, may:krok krok, tgl:kokak kokak|frog|grenouille|rana|rã|лягушка||蛙|蛙||||||||||żaba
-kromium|mate|Cr||chromium||cromo|||||||||||||kromo|kromi|chrom
+krom yum|yum 024|Cr||chromium|chrome|cromo|crómo|хром|كروم|铬|クロム|크롬, 2크로뮴|crom|क्रोमियम|ক্রোমিয়াম|krom|kromi|krom|kromo|kromi|chrom
 krote|bio|Talpinae|rus:крот (krot), pol:kret|mole (burrowing animal)|taupe|topo|toupeira|крот||鼹鼠|田鼠|||छछूंदर||tikus mondok|fuko|छछूंदर||kontiainen (maamyyrä)|kret
 kruasan|yam||fra:eng:croissant, por:croassã, spa:cruasán, rus:круассан, jpn:クロワッサン (kurowassan), kor:크루아상 (keruasang), hin:क्रोइसैन (kroisain)|croissant|croissant|cruasán|croassã|круассан||牛角包|クロワッサン|크루아상|bánh sừng bò|क्रोइसैन||||kruvasan|korna bulko|voisarvi (kroissantti)|croissant
 krus|||eng:cross, por:spa:cruz, deu:Kreuz, fra:croix, jpn:クロス (kurosu), rus:крест (krest), kon:kuluzi, hin:क्रूश (krūś)|cross|croix|cruz|cruz|крест||||||||||çarpı (haç)|kruco|risti|krzyż
@@ -2144,10 +2143,10 @@ kultur|||eng:fra:culture, spa:por:cultura, rus:культу́ра (kulʹtúra), 
 kupa|||eng:cup, fra:coupe, spa:copa, por:copo, ara: كُوب‎ (kūb), tur:kupa, hin:कप (kap), jpn:コップ (koppu), kor:컵 (keop) + fas:(koppe), ara:قبة (qubba), may:kubah, rus:купол (kupol), deu:Kuppel|drinking vessel (cup, glass, mug, goblet, chalice)|coupe (tasse, verre)|vaso (taza, copa)|copo (taça)|чаша (чашка, стакан)|كُوب‎|杯子|コップ|컵|ly (chén)|प्याला|পেয়ালা|cangkir (cawan, gelas)|kikombe (glas)|kase (fincan, bardak, kupa)|taso|malja (kuppi, muki, lasi)|kubek
 kupa chati||||dome||cúpula||||||||||||||kupoli (holvikatto)|kopuła
 kupon|||eng:fra:coupon, spa:cupón, por:cupom, rus:купо́н (kupón), may:kupon, jpn:クーポン (kūpon), kor:쿠폰 (kupon), swa:kuponi|coupon||cupón (vale)|||||||||||kuponi|||kuponki|kupon
-kupre|mate|Cu||copper||cobre|||||||||||||kupro|kupari|miedź
+kupre|yum 029|Cu||copper|cuivre|cobre|cobre|медь|نحاس|铜|銅|구리|đồng|ताम्र|কপার|tembaga|nahasi (kupri)|bakır|kupro|kupari|miedź
 kuran||||Quran (Koran)||Corán||||||||||||||koraani|Koran
 kurban|||ara: قُرْبَان‎ m (qurbān), hin:कुरबानी (kurbānī), ben:কোরবানি (korbani), may:tur:kurban|sacrifice (offer)|sacrifice|sacrificio|sacrifício|жертва|قُرْبَان‎|牺牲|犠牲|희생|lễ vật|निसार (क़ुर्बानी)|কোরবানি (ত্যাগ)|kurban|dhabihu|kurban (feda)|ofero|uhri (uhraus)|ofiara
-kurium|mate|Cm||curium||curio|||||||||||||kuriumo|curium|kiur
+kuri yum|yum 096|Cm||curium|curium|curio|cúrio|кюрий|كوريوم|锔|キュリウム|퀴륨|curi|क्यूरियम|কুরিয়াম|kurium|kuri|curiyum|kuriumo|curium|kiur
 kursi|||ara:(kursiy), hin:कुरसी (kursī), urd:(kursī), pnb:ਕੁਰਸੀ (kursī), tel:(kurcī), may:som:kursi, fas:(korsi)|chair||silla|||||||||||||seĝo|tuoli|kszesło, fotel
 kurva|||eng:curve, fra:courbe, spa:por:curva, swa:kuruba + rus:кривая (krivaya)|curve (bend)|courbe|curva|curva|кривая|||||||||kuruba||kurbo|mutka (kurvi)|wygiąć, wyginać, zgiąć, zginać, zakrzywić, zakrzywiać
 kurva di||||curvy (curved)||curvo||||||||||||||mutkikas|zakrzywiony
@@ -2167,7 +2166,6 @@ laji|||zho:垃圾 (lājī)|garbage (rubbish, trash, waste)|ordures|basura (desec
 laji bagi||||dump (junk yard)|décharge|basural|aterro (lixão)|свалка||垃圾场|ゴミ捨て場||||||||rubejo|kaatopaikka|
 laji tong||||garbage can (trash bin)|poubelle|basurero|lixeira|мусорный бак||垃圾桶|ごみ箱|쓰레기통|thùng rác|कचरा पात्र||tong sampah|pipa|çöp kutusu|rubujo|jäteastia (roskakori, roskis)|śmietnik
 laka|||eng:lacquer, spa:por:laca, fra:laque, rus:лак (lak), jpn:ラッカー|lacquer (varnish)||laca||||||||||||||lakka|lakier
-lal|rang||hin:लाल (lāl), ben:লাল (lal), tur:al|red|rouge|rojo|vermelho|красный|أَحْمَر|红|赤い|빨갛다|đỏ|लाल|লাল|merah|nyekundu|kırmızı (al)|ruĝa|punainen|czerwony
 lal linse|bio|Lynx rufus||bobcat||lince rojo (gato montés)||рыжая рысь||短尾貓|ボブキャット||||||||||ryś rudy
 lal oranje|bio|Citrus reticulata||mandarin orange (tangerine)|mandarine|mandarina (tangerina)|tangerina (mandarim)|мандарин||柑橘 (红橘)|ポンカン (マンダリン)|||नारंगी (nārangī)||limau mandarin (oren mandarin, tangerin)|chenza||mandarino|mandariini|mandarynka
 lal salmon|bio|Oncorhynchus nerka||sockeye salmon|saumon sockeye|salmón rojo|salmão-vermelho|нерка (красница)||紅鮭|ベニザケ||||||||||nerka (łosoś czerwony)
@@ -2183,7 +2181,7 @@ lanse|||eng:launch, ita:lanciare, por:lançar, fra:lancer, spa:lanzar, deu:lanci
 lanse grafi||||projection (image)|projection|proyección|projeção|||投影|投影|||||||||projektio (diakuva)|rzut (projekcja)
 lanse grafi||||project (cast)|projeter (donner)|proyectar||||投射|映す (投影する)|||||||||heijastaa kuvia (projisoida)|wyświetlać
 lanse she||||projectile (missile)|projectile|proyectil (misil)|projétil|снаряд||投掷物|飛翔体 (矢玉)||||||||||pocisk
-lantanium|mate|La||lanthanum||lantano||||鑭|ランタン|||||||||lantaani|lantan
+lantan yum|yum 057|La||lanthanum|lanthane|lantano|lantâno|лантан|لنثانوم|镧|ランタン|란탄, 2란타넘|lantan|लाञ्थनम|ল্যান্থানাম|lantanium|lanthani|lantan||lantaani|lantan
 larva|||deu:fra:larve, eng:tur:larva, hin:लार्वा (lārvā), urd:(lārvā), pol:larwa|larva (maggot, caterpillar)||larva||||||||||||||toukka|larwa, czerw, gąsienica
 lashe|||fra:laisser,lâcher, ita:lasciare, deu:lassen|leave behind (abandon, let go)|laisser|dejar|deixar|||落 (留下)|残す|||||||||jättää (hylätä)|pozostawiać (pozostawić)
 lashe she||||leftover (residue, vestige)||vestigio (sobrante, residuo)||||||||||||||jäte (hylkytavara)|pozostałość (szczątek)
@@ -2198,7 +2196,7 @@ Lau|desha|LA||Laos||Laos||||||||||||||Laos|Laos
 lau|||zho:老 (lǎo), yue:老 (lau2), wuu:老 (lau3), jpn:老 (rō), vie:lão|old (aged, elderly)|vieux (âgé, ancien)|viejo (anciano)|idoso|пожилой||老 (老年, 年歲大)|年配||già (lão)||||||||stary (sędziwy, wiekowy)
 lau di||||Lao (Laotian)||laosiano||||||||||||||laoslainen|laotański
 lau jan||||elder||viejo (anciano)|||||||||||||||starzec
-laurencium|mate|Lr||lawrencium||laurencio|||||||||||||laŭrencio|lawrensium|lorens
+laurence yum|yum 103|Lr||lawrencium|lawrencium|laurencio|lawrêncio|лоуренсий|لورنسيوم|铹|ローレンシウム|로렌슘|lorenxi, lawrenci|लॉरेंशियम|লরেনসিয়াম|lawrensium|lawirensi|lawrenciyum, ²lorentiyum|laŭrencio|lawrencium|lorens
 lazanya|||fra:lasagne, eng:lasagna, spa:lasaña, por:lasanha, rus:лазанья (lazanya), ara:(lazanyā), jpn:ラザニア (razania), kor:라자냐 (lajanya), hin:लज़ैन्या (lazenyā)|lasagna|lasagne|lasaña|lasanha|лазанья|لَازَانْيَا|千层面|ラザニア|라자냐||लज़ैन्या||||lazanya||lasagne|lazania
 lazur|rang|||azure|azur|azur (blao)|azur (blau)|лазурь|||||||||||||
 lazur petra|||fas:لاجورد (lājevard), eng:lazuli, spa:lapislázuli, rus:лазурит (lazurit), ara:لازورد (lāzaward), hin:लाजवर्द (lājavarda), jpn:ラピスラズリ (rapisurazuri), may:lazuardi, tur:lazur taşı|lapis lazuli|lapis-lazuli|lapislázuli|lápis-lazúli|лазурит|لَازَوَرْد|青金岩|ラピスラズリ (瑠璃)|||लाजवर्द (वैडूर्य)||||lazur taşı||lapislatsuli|lapis lazuli
@@ -2264,9 +2262,9 @@ lipa side||||crouch (squat)|s’accroupir|agacharse|agacharse|сесть на к
 lis|||fra:lisse, spa:por:liso, fas:(liz), may:licin|smooth||suave (liso)|||||||||||||glata|sileä|gładki
 lisan|||ara: لِسَان‎ (lisān), hin:लिसान (lisān), swa:lisani, may:tur:lisan, amh:ልሳን (ləsan)|tongue|langue|lengua|língua|язык|لِسَان‎|舌头|舌|혀|lưỡi|जीभ (ज़बान)|জিহ্বা|lidah (lisan)|ulimi (lisani)|dil (lisan)|lango|kieli (elin)|język
 liste|||eng:list, spa:por:lista, rus:лист (list), deu:fra:liste, fas:(list), hin:लिस्ट (lisṭ), urd:(lisṭ), jpn:リスト (risuto)|list (listing, catalogue)|liste|lista|lista|список||单子||||लिस्ट|||||listo|lista (luettelo)|lista, spis, wykaz
-litium|mate|Li||lithium||litio|||||||||||||litio|litium|lit
+lito yum|yum 003|Li||lithium|lithium|litio|lítio|литий|ليثيوم|锂|リチウム|리튬|lithi, liti|लिथियम|লিথিয়াম|litium|lithi|lityum|litio|litium|lit
 litre|||eng:fra:tur:litre, deu:may:liter, spa:por:litro, rus:литр (litr), pol:litr, ara: لتر‎(litr), hin:लीटर (līṭar), ben:লিটার (liṭar), jpn:リットル (rittoru), kor:리터 (riteo), vie:lít, swa:lita|litre (liter)|litre|litro|litro|литр|لتر‎|升|リットル|리터|lít|लीटर|লিটার|liter|lita|litre|litro|litra|litr
-livermorium|mate|Lv||livermorium||livermorio||||||||||||||livermorium|liwermor
+livermor yum|yum 116|Lv||livermorium|livermorium|livermorio|livermório|ливерморий|ليفرموريوم||リバモリウム|리버모륨|livermori|||livermorium|livermori|livermoriyum||livermorium|liwermor
 loba|bio|Raphanus raphanistrum|zho:萝卜 (luóbo), yue:蘿蔔 (lobaak), may:lobak|radish||rábano|||||||||||||rafaneto|retikka (retiisi)|rzodkiewka
 loga||||say (speak, talk)|parler|decir (hablar)|falar|говорить|تَكَلَّمَ|说话 (讲)|話す|말하다||बोलना|বলা|berbicara|kuongea||paroli|sanoa (puhua)|mówić, rozmawiać
 loga|||ell:λόγος (logos), eng:fra:-logue, spa:por:-logo, rus:-лог (-log), fas:(loğat), ara:(luğa), hin:लुग़त (luġat), swa:lugha, tur:lügat, may:logat|speech (talk, words)|parole (mots)|habla (palabras)|fala (palavras)|речь||语言|演説|말|ngôn từ|बात (बोल)|জবান|||söz|parolo|puhe (sanat)|słowo (mowa)
@@ -2301,8 +2299,8 @@ lote|||por:spa:lote, eng:fra:lot|batch (lot)||lote (grupo)||||||||||||||erä (sa
 lotra|bio|Lutrinae|eng:otter + fra:loutre, spa:tgl:lutrino, por:lontra + rus:выдра (vydra)|otter|loutre|nutria|lontra|выдра||獭|獺||||||||||wydra
 lou|||zho:漏 (lòu), yue:漏 (lau6), jpn:漏 (rō), 루 (ru)|leak||chorrear|vazar|протекать (просочиться)||漏|漏る||||||||liki|vuotaa|przeciekać, ciec
 lou sang||||bleed||sangrar|||||||||||||sangi|vuotaa verta|krwawić
-luka|rang||zho:绿 (lǜ), yue:綠 (luk6), vie:lục, kor:록/녹 (rok/nok), jpn: 緑色 (ryokushoku)|green|vert|verde|verde|зелёный|أَخْضَر|绿色|緑 (緑色)|녹색|xanh (lục)|हरा|সবুজ|hijau|kijani||verda|vihreä|zielony
 luka|nomer|6|zho:六 (liù), yue:六 (luk6), jpn:六 (roku), kor:육/륙 (六, yuk/ryuk), vie:lục|six (6)|six (6)|seis (6)|seis (6)|шесть (6)||六 (6)|六 (6)|||||||||kuusi (6)|sześć (6)
+luka|rang||zho:绿 (lǜ), yue:綠 (luk6), vie:lục, kor:록/녹 (rok/nok), jpn: 緑色 (ryokushoku)|green|vert|verde|verde|зелёный|أَخْضَر|绿色|緑 (緑色)|녹색|xanh (lục)|हरा|সবুজ|hijau|kijani||verda|vihreä|zielony
 luka fase||||hexahedron (cube)||hexaedro (cubo)||||||||||||||kuutio (kuusitahokas)|sześcian (kostka)
 luka gona||||hexagon||hexágono||||||||||||||kuusikulmio|sześciokąt (sześciobok)
 luka melon|bio|Cucumis melo, Inodorus||honeydew (green melon)||melón verde|||||ハネデューメロン||||||||||melon miodowy
@@ -2319,7 +2317,7 @@ luta|||hin:लूटना (lūṭnā), urd:(lūṭnā), ben:লুটা (lu�
 luta ja||||robber (plunderer)|brigand (bandit)|ladrón|ladrão|грабитель||强盗||||डाकू|||||rabisto|ryöväri (rosvo)|rabuś (grabieżca)
 Luter din||||Lutheranism|luthéranisme|luteranismo|luteranismo|лютера́нство||||||||||||luterilaisuus|luteranizm
 Luter din ja||||Lutheran|luthérien|luterano|luterano|лютеранский||||||||||||luterilainen|luterański
-lutetium|mate|Lu||lutetium||lutecio|||||||||||||lutecio|lutetium|lutet
+luteti yum|yum 071|Lu||lutetium|lutécium|lutecio|lutécio|лютеций|لوتيتيوم|镥|ルテニウム|루테튬|lutexi|लुटेटियम|লুটেসিয়াম|lutetium|luteti|lutesyum|lutecio|lutetium|lutet
 M||||M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M|M
 ma|||por:mãe + zho:妈 (mā), vie:má, ben:মা (ma), hin:मां (mã) + eng:swa:mama, spa:mamá, fra:maman, rus:мама (mama), jpn:ママ (mama), kor:엄마 (eomma)|mother (mom, mama)|mère (maman)|madre (mamá)|mãe|мать (мама)|أُمّ‎|妈妈|お母さん (母, ママ)|엄마|mẹ (má)|माता (मां, मादर)|মাতা (মা)|ibu (emak)|mzazi (mama)|anne|patrino|äiti (emä)|matka, mama
 ma di||||motherly (maternal)|maternel|maternal|maternal|материнский||||||||||||äidillinen|
@@ -2328,7 +2326,7 @@ ma su pa||||maternal grandfather||||||外公 (外祖父)||||नाना||||||ä
 Madagasi|desha|MG||Madagascar||Madagascar||||||||||||||Madagaskar|Madagaskar
 madagasi di||||Malagasy||malgache||||||||||||||madagaskarilainen (malagassi)|madagaskarski; malagaski
 maf|||ara: مُعَاف‎ (muʿāf), hin:माफ़ (māf), ben:মাফ (maph), may:maaf, swa:afu, tur:af, hau:yafe|pardon (forgiveness; sorry)||perdón|||||ごめんなさい|||माफ़||maaf||af (affetme)|pardono|anteeksi|przepraszam!
-magesium|mate|Mg||magnesium|magnésium|magnesio|magnésio|магний||镁|マグネシウム|마그네슘|magiê|भ्राजातु|ম্যাগনেসিয়াম|magnesium|magnesi|magnezyum|magnezio|magnesium|magnez
+magen yum|yum 012|Mg||magnesium|magnésium|magnesio|magnésio|магний|مغنيسيوم|镁|マグネシウム|마그네슘|magiê|मैग्नेशियम|ম্যাগনেসিয়াম|magnesium|magnesi|magnezyum|magnezio|magnesium|magnez
 magi|||fas: مغ‎ (moğ), ara: مُوغِيّ‎ (mūḡiyy), ell:μάγος (magos), eng:magic, fra:magie, spa:por:magia, rus:магия (magiya) + zho:魔 (mó), jpn:魔 (ma), kor:마 (ma), vie:ma|magic||magia|||||||||||||magio|taikuus (magia)|magia
 magi asar||||spell (enchantment)||||||||||||||||taika|zaklecie
 magi di||||magical||magical||||||||||||||taianomainen (maaginen)|magiczny
@@ -2338,7 +2336,6 @@ Magribi desha|desha|MA||Morocco|Maroc|Marruecos|Marrocos|Марокко|المغ
 Magyar|desha|HU||Hungary||Hungría||||||||||||||Unkari|Węgry
 mahala|||ara: مَحَلَّة‎ (maḥalla), hin:मुहल्ला (muhallā), tur:mahalle|quarter (neighbourhood, district, locality, section of town)|quartier|barrio (cuartel)|quarteirão|квартал|مَحَلَّة‎|||||मुहल्ला||||mahalle|kvartalo|kaupunginosa (kortteli, naapurusto)|dzielnica
 mais|||eng:maize, spa:maíz, fra:maïs, rus:маи́с (maís)|corn (maize)||maíz||||||||||||||maissi|kukurydza
-maitnerium|mate|Mt||meitnerium||meitnerio|||||||||||||mejtnerio|meitnerium|meitner
 majang||||mahjong|mah-jong|mahjong|mahjong|маджонг||麻将|麻雀|마작 (마장)|mạt chược|||mahjung|||maĝango|mahjong|madżong
 majenta|||eng:magenta, spa:magenta, rus:маджента (madzhenta), ara:ماجنتي (majinati), hin:मैजेंटा (maijenta), jpn:マゼンタ (mazenta), may:magenta|magenta (fuchsia)||magenta (fucsia)||маджента (фуксия)|||マゼンタ (紅紫色)||||||||||magenta
 Makah||||Mecca|||||مكَة||||||||||||Mekka
@@ -2368,7 +2365,7 @@ manera||||behave (act)||comportarse (portarse)||||||||||||||käyttäytyä|zachow
 manete|||eng:magnet, fra:magnétique, spa:magnete, rus:магнит (magnit), tur:mıknatıs, ara:مَغْنَاطِيس‎ (maḡnāṭīs), may:maknit|magnet||imán|||||||||||sumaku|||magneetti|magnes
 manete di||||magnetic||magnético||||||||||||||magneettinen|magnetyczny
 mang|||zho:忙 (máng), yue:忙 (mong4), wuu:忙 (maan), kor:망 (mang)|busy (occupied)|occupé|ocupado (atareado)|ocupado (atarefado)|занятый||忙|忙しい|||व्यस्त||ramai (sibuk)|kushugulika|işlek|okupata|kiireinen|zajęty
-mangan|mate|Mn||manganese||manganeso|||||||||||||mangano|mangaani|mangan
+mangan|yum 025|Mn||manganese|manganèse|manganeso|manganésio|марганец|منجنيز|锰|マンガン|망간, 2망가니즈|mangan|मैंगनीज|ম্যাঙ্গানিজ|manggan|manganisi|mangan|mangano|mangaani|mangan
 mango|bio||mal:മാങ്ങ (māṅṅa), eng:spa:tur:mango, por:manga, rus:манго (mango), may:mangga, jpn:マンゴー (mangō), kor:망고 (manggo)|mango||mango||||||||||||||mango|mango
 mangus|bio|Garcinia mangostana||mangosteen||mangostán (jobo de la India)||||||||||||||mangostani|mangostan
 Mani||||prophet Mani||profeta Mani||||||||||||||profeetta Mani|prorok Mani
@@ -2455,6 +2452,7 @@ mega vate|unomete|MW||megawat (MW)||megavatio||||||||||||||megawatti (MW)|megawa
 megi|||hin:मेघ (megh), ben:মেঘ (megh), tam:மேகம் (mēgam), tel:మేఘము (mēghamu), may:mega, tha:เมฆ (mek) + ara: غَيْمَة‎ (ḡayma) + vie:mây|cloud|nuage|nube|nuvem|облако|سَحَابَة|云|雲|구름|mây|मेघ (बादल)|মেঘ|awan (mega)|wingu|bulut|nubo|pilvi|chmura
 Mehiko|desha|MX||Mexico||México|||||||||||||Meksikio|Meksiko|Meksyk
 Mehiko siti|xefsite|||Mexico City||Ciudad de México|||||||||||||||Meksyk
+meitner yum|yum 109|Mt||meitnerium|meitnérium|meitnerio|meitnério|майтнерий|مايتنريوم||マイトネリウム|마이트너륨|meitneri|मेइट्नेरियम|মিটনেরিয়াম|meitnerium|meitneri|meitneriyum|mejtnerio|meitnerium|meitner
 melodi||||melodious (melodic)||melodioso||||||||||||||melodinen (sointuisa)|melodyczny
 melodi|||eng:melody, spa:melodía, por:melodia, rus:мело́дия (melódija), tur:may:melodi, fas:ملودی‎ (melodi), jpn:メロディー (merodī)|melody||melodía|||||||||||||melodio|melodia (sävelmä)|melodia
 melon|bio|Cucumis melo|eng:fra:melon, spa:melón, por:melão, jpn:メロン (meron), kor:멜론 (mellon)|muskmelon||melón|melão|дыня||厚皮甜瓜 (蜜瓜)|マスクメロン||||||||||ogórek melon
@@ -2466,6 +2464,7 @@ memo bina||||monument (memorial)||monumento|||||追悼塔 (碑)||||||||||pomnik 
 memo note||||memorandum (memo)||memorándum (nota)||меморандум||||||||||||muistio (muistiinmerkintä)|notatka, memo
 memo tehni||||mnemotechny||||||||||||||||muistitekniikka|
 men|||zho:们 (men), yue:們 (mun4) + deu:man + eng:one|one (you, they, impersonal pronoun)|on||||||||||||||oni||
+mendelevi yum|yum 101|Md||mendelevium|mendélévium|mendelevio|mendelévio|менделевий|مندلفيوم|钔|メンデレビウム|멘델레븀|menđelevi|मेण्डेलीवियम|মেন্ডেলিভিয়াম|mendelevium|mendelevi|mendelevyum||mendelevium|
 meninge|||eng:meninx, spa:por:meninge, fra:méninge|meninx (meninges)|méninge|meninge|meninge|||脑脊膜||||||||||aivokalvo|opona mózgowa
 meninge flame||||meningitis||meningitis||||||||||||||aivokalvontulehdus|zapalenie opon mózgowych
 mentor|||san:मन्त्रिन् (mantrin), hin:मंत्री (mantrī), tha:มนตรี (mon-tri), may:menteri, eng:deu:fra:por:spa:mentor, jpn:メンター (mentā), kor:멘토 (mento), rus:ментор (mentor)|advisor (counselor, mentor)||consejero (asesor)||||||||||||||neuvontantaja (mentori)|doradca (mentor)
@@ -2570,7 +2569,7 @@ mole|unomete|mol||mole (unit)|mole (unité)|mol|mol|||摩尔 (单位)|モル||||
 molekul|||eng:molecule, spa:por:molécula, fra:molécule|molecule||molécula||||分子|分子||||||||||molekuła (cząsteczka)
 moli|bio|Jasminum|kan:ಮಲ್ಲಿಗೆ  (mallige), tam:(mallikai), tel:మల్లె  (malle), may:melati, tha:มะลิ (má-lí), kor:말리 (malli), tha:มะลิ (mali), zho:茉莉 (mòlì), yue:茉莉 (mut6lei5)|jasmine|jasmin|jazmín|jasmim|жасмин||茉莉|茉莉|말리|mạt lị|चमेली|ইয়াসমিন|melati|asumini|yasemin|jasmeno|jasmiini|jaśmin
 moli hua chai||||jasmine tea||||||茉莉花茶|茉莉花茶||||||||jasmenteo|jasmiinitee|
-moliden|mate|Mo||molybdenum||molibdeno|||||||||||||molibdeno|molybdeeni|molibden
+moliden yum|yum 042|Mo||molybdenum|molybdène|molibdeno|molibdénio|молибден|مولبيدنيوم|钼|モリブデン|몰리브덴, 2몰리브덴넘|molypđen, molipđen|मोलिब्डेनम|মলিবডেনাম|molibden|molibdeni|molibden|molibdeno|molybdeeni|molibden
 moluske|bio|Mollusca|eng:mollusk, deu:Molluske, fra:mollusque, rus:моллюск (mollyusk), spa:por:molusco, may:moluska, hin:urd:(molask)|mollusk||molusco||моллюск||||||||moluska|||molusko|nilviäinen|mięczak (morski bezkręgowiec)
 Monako|desha|MC||Monaco||Mónaco||||||||||||||Monaco|Monako
 Mongol|desha|MN||Mongolia||Mongolia|||||||||||||Mongolio|Mongolia|Mongolia
@@ -2584,8 +2583,8 @@ mos|bio||eng:moss, spa:por:musgo, fra:mousse, deu:Moos, rus:мох (mox), hin:�
 mos di||||mossy|moussu|musgoso||мшистый|||苔状|||||berlumut|||||omszały (mszysty)
 mosim|||ara: موسم (mawsim), hin:मौसम (mausam), may:musim, tur:mevsim, swa:msimu + eng:monsoon, fra:mousson, por:monção, rus:муссон (musson)|season|saison|estación (temporada)|estação (sazão)|время года (сезон)|فصل‎ (موسم‎)|季|季節|계절|mùa|मौसम|ঋতু|musim|msimu|mevsim (sezon)|sezono|vuodenaika|pora roku
 moskite||biwe|eng:spa:por:mosquito, fra:moustique, deu:Moskito, rus:моски́т (moskít), ben:মশা (môśa), kor:모기 (mogi)|mosquito||mosquito||||||||||||||hyttynen (sääski)|komar, moskit
-moskovium|mate|Mc||moscovium||moscovio|||||||||||||moskovio|moskovium|moskovium
 Moskva|xefsite|RU||Moscow||||Москва||||||||||||Moskova|Moskwa
+moskva yum|yum 115|Mc||moscovium|moscovium|moscovio|moscovio|московий|ٲنون بينتيوم||モスコビウム|우눈펜튬|moscovi|||moskovium|moscovi|moscoviyum|moskovio|moscovium|moskovium
 moto|||eng:spa:por:tur:may:motor, fra;moteur, rus:мотор (motor), ara:(mutūr), zho:摩托 (mótuō), jpn:モーター (mōtā), kor:모터 (moteo), vie:mô-tơ, hin:मोटर (moṭar), ben:মোটর (moṭôr), swa:mota|engine (motor)|moteur|motor|motor|мотор||马达 (发动机)|モーター (エンジン, 機関)|모터 (기관)|động cơ (mô-tơ)|मोटर|ইঞ্জিন (মোটর)|motor|injini (ntambo, mota)|motor|motoro|moottori|silnik
 moto gar|||eng:motorcar, sna:motokari, sot:motokara, swa:motokaa, zul:imoto, hau:mota|motorcar (automobile)||automóvil (coche)||||||||||||||auto (automobiili)|samochód (automobil)
 moto sikle|||eng:motorcycle, spa:motocicleta, fra:motocyclette, rus:мотоцикл (mototsikl), tur:motosiklet, hin:मोटरसाइकिल (moṭarasāikila), may:motosikal, zho:摩托车 (mótuōchē), jpn:モーターサイクル (mōtāsaikuru)|motorcycle||motocicleta||мотоцикл|||オートバイ (モーターサイクル)|||||||||moottoripyörä|motocykl (motor)
@@ -2669,8 +2668,8 @@ nasi sim ja||||nationalist||nacionalista||||||||||||||nationalisti|nacjonalista
 nasi sosi sim||||Nazism||nazismo||||||||||||||natsismi|nazizm
 nasi sosi sim||||national socialism||socialismo nacional||||||||||||||kansallissosialismi|narodowy socjalizm
 nasi sosi sim ja||||Nazi||Nazi||||||||||||||natsi|nazista
-natre|mate|Na||sodium||sodio||натрий|||||||||||natrio|natrium|sód
 natre bilor||||natron||natrón||натрит (натр, натрон, кристаллическая сода)|||||||||||||
+natri|yum 011|Na||sodium|sodium|sodio|sódio|натрий|صوديوم|钠|ナトリウム|나트륨, 2 소듐|natri|सोडियम|সোডিয়াম|natrium|natiri|sodyum|natrio|natrium|sód
 nau|||zho:脑 (nǎo), yue:腦 (nou5), jpn:脳  (nō), kor:뇌 (noe), vie:não|brain|cerveau (cervelle)|cerebro|cérebro|мозг|دِمَاغ‎|脑|脳|뇌|óc (não)|मस्तिष्क (दिमाग़)|মগজ|otak (benak)|ubongo|beyin|cerbo|aivot|mózg
 nau di||||cerebral|cérébral|cerebral|cerebral|мозговой (церебральный)||大脑的||||||||beyinsel|cerba|aivoperäinen (aivo-)|mózgowy
 nau hin||||brainless||descerebrado||безмозглый|||||||মস্তিষ্কহীন||||sencerba|aivoton|bezmózgi
@@ -2698,11 +2697,11 @@ nen|||jpn:年 (nen), zho:年 (nián), yue:年 (nin4), kor:년 (nyeon), vie:năm
 nen festa||||anniversary||aniversario||||||||||||||vuosijuhla|rocznica
 nen mes den|||zho:年月日 (niányuèrì), jpn:年月日 (nengappi), kor:연월일 (yeonworil)|date||fecha||||年月日|年月日|연월일|||||||dato|päivämäärä|data
 nenufar|bio|Nymphaea alba|eng:nenuphar, spa:por:nenúfar, fra:nénufar, rus:ненюфа́р (nenjufár), fas:نیلوفر آبی‎ (nilufar-e âbi)|water lily (nenuphar)||nenúfar (lirio de agua)||||||||||||||lumme|lilia wodna, nenufar
-neodimium|mate|Nd||neodymium||neodimio||||||||||||||neodyymi|neodym
-neon|mate|Ne||neon||neón|||||||||||||neono|neon|neon
+neodim yum|yum 060|Nd||neodymium|néodyme|neodimio|neodímio|неодим|نيودميوم|钕|ネオジム|네오디뮴|neođim|नियोडाइमियम|নিওডিমিয়াম|neodinium|neodimi|neodim||neodyymi|neodym
+neon|yum 010|Ne||neon|néon|neón|néon|неон|نيون|氖|ネオン|네온|neon, nê-ông|नियोन|নিয়ন|neon|neoni|neon|neono|neon|neon
 Nepal|desha|NP||Nepal||Nepal|||||||||||||Nepalo|Nepal|Nepal
 Neputun|planete 8|||Neptune|Neptune|Neptuno|Netuno|Нептун|نبتون|||||||||Neptün|Neptuno|Neptunus|Neptun
-neputunium|mate|Np||neptunium||neptunio|||||||||||||neptunio|neptunium|neptun
+neputun yum|yum 093|Np||neptunium|neptunium|neptunio|neptúnio|нептуний|نبتونيوم|镎|ネプツニウム|넵투늄|neptuni|नेप्ट्यूनियम|নেপচুনিয়াম|neptunium|neptuni|neptunyum|neptunio|neptunium|neptun
 nerve|||eng:spa:por:fra:deu:neuro-, rus:невро- (nevro-)|nerve||nervio|||||||||||||nervo|hermo|nerw
 nerve di||||neural||neural|||||||||||||nerva|hermostollinen|nerwowy (neuronowy)
 nerve pati||||neuropathy||neuropatía||||||||||||||hermosairaus (neuropatia)|neuropatia
@@ -2720,23 +2719,23 @@ nia|||ara: نِيَّة‎ (niyya), hin:नीयत (niyat), may:niat, swa:nia,
 niche|||ben:নিচে (nice), hin:नीचे (nīce), urd:(nīce), rus:ниже (niže)|underside (underneath)|dessous|parte inferior|||||下|||||||||alapuoli|spód
 niche di||||lower (inferior)||inferior||||||||||||||ala-|poniższy
 nide|||eng:nest, spa:nido, por:ninho, fra:nid, rus:гнездо (gnezdo), hin:नीड़ (nīḍa), ben:নীড় (nīṛa)|nest (hive, den)|nid|nido (avispero, hormiguero, ratonera)|ninho (vespiero)|гнездо (улей)||巢 (穴)|巣|||घोंसला (नीड़, छत्ताधानी)||sarang|tundu (kiota, mzinga)||||gniazdo (ul, nora, jama, barłóg, legowisko)
-nihonium|mate|Nh||nihonium||nihonio|||||||||||||nihonio|nihonium|nihonium
 Nijer|desha|NE||Niger||Níger|||||||||||||Niĝero|Niger|Niger
 Nikaragua|desha|NI||Nicaragua||Nicaragua|||||||||||||Nikaragvo|Nikaragua|Nikaragua
-nikel|mate|Ni||nickel||níquel|||||||||||||nikelo|nikkeli|nikiel
+nikel|yum 028|Ni||nickel|nickel|níquel|níquel|никель|نيكل|镍|ニッケル|니켈|nikel|निकेल|নিকেল|nikel|nikeli|nikel|nikelo|nikkeli|nikiel
 nilon|||eng:por:fra:nylon, spa:nilón, rus:нейлон (nejlon), ara:نَايْلُون‎ (nāylūn), fas:نایلون‎ (nâylon), may:nilon, swa:nailoni, zho:尼龙 (nílóng), jpn:ナイロン (nairon)|nylon|nylon|nailon (nilón)||нейлон||尼龙|ナイロン|||||nilon|nailoni||nilono|nailon|nylon
-niobium|mate|Nb||niobium||niobio|||||||||||||niobo|niobium|niob
+niobi yum|yum 041|Nb||niobium|niobium|niobio|nióbio|ниобий|نيوبيوم|铌|ニオブ|나이오븀,니오븀, 니오브|niobi|नायोबियम|নাইওবিয়াম|niobium|niobi|niobyum|niobo|niobium|niob
 Nipon|desha|JP||Japan|Japon|Japón|Japão|Япония||日本|日本|일본|Nhật Bản|जापान|জাপান|Jepang|Japani|Japonya|Japanio|Japani|Japonia
 nipon di||||Japanese||japonés|||||日本の (日本語, 日本人)||||||||japana|japanilainen|japoński
+nipon yum|yum 113|Nh||nihonium|nihonium|nihonio|nihonium|нихоний|ٲنون يريوم||ニホニウム|우눈트륨|nihoni|||nihonium|nihoni|nihoniyum|nihonio|nihonium|nihonium
 nish|||fra:eng:niche, por:nicho, rus:ниша (niša)|niche (recess, alcove)|niche|hornacina|nicho|ниша||壁龛|壁龕|반침||||||||alkovi|nisza, alkowa
 Nistre||||Dniester||Dniéster|||||||||||||||
-nitre|mate|N||nitrogen||nitrógeno|||||||||||||nitrogeno|typpi|azot
+nitre|yum 007|N||nitrogen|azote|nitrógeno|nitrogénio|азот|نيتروجين|氮|窒素|질소|nitơ|नाइट्रोजन|নাইট্রোজেন|nitrogen|nitrojeni|azot|nitrogeno|typpi|azot
 Niue|desha|NU||Niue||Niue||||||||||||||Niue|Niue
 niuton|unomete|N||newton (N)||newton (N)|||||||||||||newtono (N)|newton (N)|niuton (N)
 no|||eng:spa:no, fra:non, por:não, ben:না (na), rus:не (nye), hin:नहीं (nahī̃), kor:아니 (ani), jpn:-ない (-nai)|not (no)|non (ne...pas)|no|não|нет (не)||不|いいえ|||नहीं|না|tidak|||ne|ei|nie
 no na lin||||offline||||||离线|||||||||||offline (nie na linii, poza siecią)
 no yau di||||unnecessary (extraneous, unneeded)|inutile|innecesario|||||不要|||||||||tarpeeton|niepotrzebny
-nobelium|mate|No||nobelium||nobelio|||||||||||||nobelio|nobelium|nobel
+nobel yum|yum 102|No||nobelium|nobélium|nobelio|nobélio|нобелий|نوبليوم|锘|ノーベリウム|노벨륨|nobeli|नोबेलियम|নোবেলিয়াম|nobelium|nobeli|nobelyum|nobelio|nobelium|nobel
 nobi||||genderqueer (non-binary)|non-binaire|no binario (género)|não-binário||||||||||||neduuma|muunsukupuolinen|genderqueer, niebinarny
 noche|||spa:noche, por:noite, rus:ночь (nočʹ), pol:noc|night|noit|noche|noite|ночь||夜|夜|||रात||malam||gece|nokto|yö|noc
 noche mode||||night mode||modo nocturno||||||||||||||yömoodi|tryb nocny
@@ -2800,7 +2799,7 @@ ofis di||||official||oficial||||||||||||||virallinen|oficjalny
 ofis ja||||officer||funcionario||||||||||||||virkailija (virkamies)|funkcjonariusz, urzędnik
 ofis kan||||office (room)||oficina|||||||||||||||biuro (pokój)
 ofis poze||||office (position)||cargo||||||||||||||virka (virka-asema)|urząd, pozycja, stanowisko, funkcja
-oganeson|mate|Og||oganesson||oganesón|||||||||||||oganesono|oganesson|oganesson
+oganeson|yum 118|Og||oganesson|oganesson|oganesón|oganesson|оганесон|||オガネソン|우누녹튬||||oganesson|||oganesono|oganesson|oganesson
 ohtopus|bio|Octopodiformes|eng:octopus, deu:Oktopus, tur:ahtapot, ara:أخطبوط (ʾuḵṭubūṭ), fas:اختاپوس‎ (oxtâpus), hin:ऑक्टोपस (okṭopasa), ben:অক্টোপাস (ôkṭopaś)|octopus|Poulpe (pieuvre)|pulpo|polvo|спрут (осьминог)|أخطبوط|章鱼|タコ|낙지 (문어)|bạch tuộc|||gurita|pweza|ahtapot||mustekala|ośmiornica
 oke|||eng:okay, spa:tur:may:okey, por:OK, rus:окей (okej), ara:أُوكِي‎‎‎ (ʾokey), hin:ओके (oke), zho:OK (ōukèi), jpn:オーケー (ōkē)|okay (acceptable)||bien (aceptable)|||||大丈夫 (ＯＫ)||||||||akceptebla (okej)|kelpo (okei)|okej, spoko, akceptowalny
 oke loga||||okay (acceptance)||||||||||||||||hyväksyntä|
@@ -2809,7 +2808,7 @@ oko di||||ocular|oculaire|ocular|ocular|глазной|عَيْنِيّ|||||||||
 oko kesha||||eyelash||pestaña||||||||||||||silmäripsi|rzęsa
 oko sui|||tam:கண்ணீர் (kaṇṇīr), mal:കണ്ണുനീർ (kaṇṇunīr), tel:(kannīru), kor:눈물 (nunmul), vie:nước mắt, may:air mata, tha:น้ำตา|tear drop||lágrima||||||||||||||kyynel|łza
 oko sui gas||||tear gas|gaz lacrymogène|gas lacrimógeno|gás lacrimogéneo|слезоточи́вый газ||催泪瓦斯|催涙ガス||hơi cay||||||||gaz łzawiący
-oksi|mate|O||oxygen||oxígeno|||||||||||||oksigeno|happi|tlen
+oksi|yum 008|O||oxygen|oxygène|oxígeno|oxigénio|кислород|أكسجين|氧|酸素|산소|oxy, oxi|ऑक्सीजन|অক্সিজেন|oksigen|oksijeni|oksijen|oksigeno|happi|tlen
 okside||||oxide|oxyde|óxide|óxide|окись (оксид)||氧化物|||||||||oksido|oksidi|tlenek
 Olande nesi|desha|AX||Aland Islands||islas Aland||||||||||||||Ahvenanmaa (Oolanti)|Wyspy Alandzkie
 Oman|desha|OM||Oman||Omán||||||||||||||Oman|Oman
@@ -2834,7 +2833,7 @@ oskope|||eng:fra:-scope, spa:por:-scopio, rus:-скоп (skop), jpn:スコープ
 oskur|||eng:obscure, spa:oscuro, por:escuro, fra:obscur|dark (dim)||oscuro||||||||||||||pimeä (hämärä)|ciemny, słabo oświetlony
 osman||||Ottoman||otomana||||||||||||||osmani (ottomaani)|Turek osmański
 Osman Imperi Desha||||Ottoman Empire||Imperio otomano||||||||||||Osmanlı İmparatorluğu||Osmanien valtakunta|Imperium Osmańskie
-osmium|mate|Os||osmium||osmio|||||||||||||osmio|osmium|osm
+osmi yum|yum 076|Os||osmium|osmium|osmio|ósmio|осмий|ازميوم|锇|オスミウム|오스뮴|osimi, osmi|अस्मियम|অসমিয়াম|osmium|osmi|osmiyum|osmio|osmium|osm
 osmos|||ell:ώσμωση (ósmosi), eng:may:osmosis, spa:ósmosis, por:fra:osmose, rus:осмос (osmos), fas:تَراران (osmoz)|osmosis||ósmosis||осмос|||||||||||osmozo|osmoosi|osmoza
 oste|bode||eng:deu:osteo-, rus:остео- (osteo-), ita:por:osso, fra:os, hin:अस्थि (asthi-)|bone||hueso|||||||||||||osto|luu|kość
 oste jama||||skeleton (frame)|squelette|esqueleto (armazón)|esqueleto|скелет (остов)||骨骼|骨格||||||||||szkielet
@@ -2856,7 +2855,7 @@ pake|||eng:pack, rus:пакет (paket), hin:पैकेट (pækeṭ), deu:tur
 Pakistan|desha|||Pakistan||Pakistán||||||||||||||Pakistan|Pakistan
 paksi|bio|Aves|hin:mar:पक्षी (pakṣī), mal:പക്ഷി (pakṣi), tel:(pakṣi), kh:បក្សី (baksəy), tha:ปักษา (pak-sa), ben:পাখী (pakhī), pnb:ਪੰਖੀ (paṅkhī)|bird|oiseau|pájaro (ave)||||||||पक्षी|পাখী||||birdo|lintu|ptak
 palaba|||eng:palaver, krio:plabah, kon:palaba|conflict (argument, dispute, quarrel)|querelle (dispute, palabre)|||||||||||||||riita (kiista)|
-paladium|mate|Pd||palladium||paladio|||||||||||||paladio|palladium|pallad
+paladi yum|yum 046|Pd||palladium|palladium|paladio|paládio|палладий|بلاديوم|钯|パラジウム|팔라듐|palađi|पलाडियम|প্যালাডিয়াম|paladium|paladi|palladyum|paladio|palladium|pallad
 Palau|desha|PW||Palau||Palaos||||||||||||||Palau|Palau
 palme|||deu:Palme, eng:palm, por:spa:palma, rus:пальма (palma), tur:palmiye, may:palem, tha:ปาล์ม (pām)|palm tree||palmera|||||||||||||palmo|palmu|palma, drzewo palmowe
 pan|||eng:fra:spa:por:pan-, rus:пан- (pan-) + zho:泛 (fàn), jpn:汎 (han), kor:범 (beom)|every (all)||todo|||||全ての||||||||ĉiu|kaikki|wszyscy, wszystkie, wszystko; każdy
@@ -3019,15 +3018,15 @@ plate geo kaske logi||||plate tectonics|tectonique des plaques|tectónica de pla
 plate geo sim ja||||flat-earther|terreplatiste|terraplanista|terraplanista|плоскоземелец||||||||||||litteän maapallon kannattaja|płaskoziemca
 plate tasa||||plate||plato||||||||||||||lautanen|talerz
 plate topo||||plain (plateau, flat lands)|plaine|llanura||||平原|草原||||||||||równina (plaskowyż, plateau)
-platin|mate|Pt||platinum||platino|||||||||||||plateno|platina|platyna
+platin|yum 078|Pt||platinum|platine|platino|platina|платина|بلاتين|铂|白金|백금|platin|प्लाटिनम|প্লাটিনাম|platina|platini|platin|plateno|platina|platyna
 Platon||||Plato||Platón||||||||||||||Platon|Platon
 Platon sim||||Platonism||platonismo||||||||||||||platonismi|platonizm
 Platon sim di||||Platonic||platónico||||||||||||||platoninen|platoniczne
 Platon sim ja||||Platonist||platonista||||||||||||||platonisti|platończyk
 plazma|||eng:plasma, spa:plasma, rus:плазма (plazma), ara:بلازما (balazima), hin:प्लाज़्मा (plaazma), jpn:プラズマ (purazuma), may:plasma|plasma (ionized gas)||plasma (gas ionizado)|||||||||||||||plazma (zjonizowany gaz)
-plumbe|mate|Pb||lead||plomo|||||||||||||plumbo|lyijy|ołów
+plumbe|yum 082|Pb||lead|plomb|plomo|chumbo|свинец|رصاص|铅|鉛|납|chì|सीसा|লেড|timbal|risasi (plumbi)|kurşun|plumbo|lyijy|ołów
 Pluton||||Pluto (dwarf planet)||Plutón||||||||||||||Pluto (kääpiöplaneetta)|Pluton (planeta karłowata)
-plutonium|mate|Pu||plutonium||plutonio|||||||||||||plutonio|plutonium|pluton
+pluton yum|yum 094|Pu||plutonium|plutonium|plutonio|plutónio|плутоний|بلوتونيوم|钚|プルトニウム|플루토늄|plutoni|प्लूटोनियम|প্লুটোনিয়াম|plutonium|plutoni|plutonyum|plutonio|plutonium|pluton
 poker|||eng:fra:tur:poker, spa:por:póquer, rus:покер (poker), ara:بُوكَر‎ (būkar), hin:पोकर (pokar), zho:扑克 (pūkè), jpn:ポーカー (pōkā), kor:포커 (pokeo)|poker||póquer|||||||||||||pokero|pokeri|poker
 polau|||fas:(polou), hin:पुलाव (pulav), tur:pilav, rus:плов (plov)|pilaf (pulao)||pilaf (pulaw)||плов||||||पुलाव||||pilav||pilahvi|pilaw
 poli||||poly- (multi-)||poli-||||||||||||||moni- (poly-, multi-)|wielo- (poli-, multi-)
@@ -3052,9 +3051,9 @@ politi ja||||politician (administrator, statesman)|administrateur|político (adm
 politi logi||||politicology||ciencia política||||||||||||||politiikantutkimus|politologia
 politi lon||||politics (political discourse)||política||||政治|政道||||||||politiko|politiikka|polityka
 politi mode||||regime||régimen|regime|||政体|政体|||||||||hallintomuoto|
-polonium|mate|Po||polonium||polonio|||||||||||||polonio|polonium|polon
 Polska|desha|PL||Poland||Polonia||||||||||||||puola|Polska
 polska basha|basha|||Polish language||idioma polaco||||||||||||||puolalainen|polski
+polska yum|yum 084|Po||polonium|polonium|polonio|polónio|полоний|بولونيوم|钋|ポロニウム|폴로늄|poloni|पोलोनियम|পোলনিয়াম|polonium|poloni|polonyum|polonio|polonium|polon
 pompe|||eng:pump, spa:por:bombear, fra:pomper, deu:pumpen|pump||bombear||||||||||||||pumppu|pompować
 ponte|||eng:point, por:apontar, spa:apuntar, fra:pointer|point at (indicate)||apuntar (indicar)|||||||||||||montri|osoittaa (näyttää)|wskazać, wskazywać
 ponte fleche||||pointer (indicator)||indicador (cursor)||||||||||||||osoitin (viisari)|wskaźnik
@@ -3075,7 +3074,7 @@ pos di||||back (posterior)|postérieur|posterior|posterior|||||||||||||myöhempi
 pos fikse||||suffix|suffixe|sufijo||||||||||||||loppuliite (jälkiliite)|przyrostek (sufiks)
 pos poza||||put back (postpone)||||||||||||||||siirtää taakse|
 pos zaman||||future time||futuro|||||||||||||estonoteco|tulevaisuus|przyszłość
-pospor|mate|P||phosphorus||fósforo|||||||||||||fosforo|fosfor|fosfor
+pospor|yum 015|P||phosphorus|phosphore|fósforo|fósforo|фосфор|فوسفور|磷|リン|인|photpho|फास्फोरस|ফসফরাস|fosfor|posfori|fosfor|fosforo|fosfori|fosfor
 posta|||eng:post, por:postagem, fra:poste, rus:почта (pochta), tur:posta, ara:بوسطة‎ (busṭa), swa:posta, may:pos, fas:پست‎ (post)|mail||correo||||||||||pos|posta|||posti (postilähetys)|poczta
 posta chape||||postal stamp||sello postal||||||||||||||postileima|znaczek pocztowy
 posta kan||||post office||oficina de correos|||||||||||||poŝtejo|postitoimisto|poczta, budynek poczty
@@ -3085,9 +3084,9 @@ pote chamacha||||ladle (dipper, scoop)|louche (cuillère à pot)|cucharón (cazo
 pote ja||||potter|potier|alfarero|oleiro|гончар|خَزَّاف‎|陶瓷工|陶工|도공||कुम्हार ||||||savenvalaja|
 pote shuta||||pottery|poterie|alfarería|cerâmica|гончарное дело||陶器制造|陶芸|||||||ufinyanzi||keramiikka|
 poze|||eng:spa:por:fra:pose, deu:Pose, rus:поза (poza), jpn:ポーズ|pose (position)||pose (postura)||||||||||||||asetelma|poza, pozycja
-praseodimium|mate|Pr||praseodymium||praseodimio||||||||||||||praseodyymi|prazeodym
 prati|||eng:practice, fra:pratique, por:prática, tur:pratik, pol:praktyka, hin:प्रथा (prathā)|practice (actuality)||práctica||||||||||||||käytäntö (pragmatia)|praktyka, aktualność
 prati di||||practical (pragmatic)||práctico||||||||||||||käytännöllinen (pragmaattinen)|practyczny, pragmatyczny
+prazedim yum|yum 059|Pr||praseodymium|praséodyme|praseodimio|praseodímio|празеодим|براسوديميوم|镨|プラセオジム|프라세오디뮴|prazeođim|प्रासियोडाइमियम|প্র্যাসেওডিমিয়াম|praseodinium|praseodimi|praseodim||praseodyymi|prazeodym
 presa|||fra:pression, spa:presión, por:pressão, rus:пресс (press), jpn:プレス (puresu)|pressure|pression|presión|pressão|давление (нажим)||压力|圧力|압력|áp lực|दाब|চাপ|tekanan||basınç|premo|puristus (paine)|
 presa gi||||press device|pressoir|prensa|prensa|пресс|||圧搾機||||||||premilo|puristin|
 prezidente|||eng:president, spa:por:presidente, rus:президент (prezident), kat:პრეზიდენტი (ṗrezidenṭi), fas:پرزیدنت‎ (perezident), may:presiden|president||presidente|||||||||||||prezidento|presidentti|prezydent
@@ -3097,9 +3096,10 @@ profesor|||eng:por:professor, spa:profesor, rus:профессор (professor), 
 program|||eng:may:tur:program, fra:programme, por:spa:programa, rus:программа (programma), jpn:プログラム (puroguramu), kor:프로그램 (peurogeuraem), hin:प्रोग्राम (progrām), swa:programu|program (set of structured activities)|programme|programa|programa|программа||计划|次第 (計画, プログラム)|계획 (프로그램)|kế hoạch|प्रोग्राम||program|programu|program|programo|ohjelma|program
 program ja||||programmer (coder)||programador||||||||||||||ohjelmoija|programista, koder
 projete|||fra:projet, por:projeto, eng:project, spa:proyecto, rus:проект (proyekt), hin:प्रोजैक्ट (projaikṭ), ben:প্রজেক্ট (prôjekṭ), jpn:プロジェクト (purojekuto), kor:프로젝트 (peurojekteu), tur:proje|project (endeavour)|projet|proyecto|projeto|проект|||プロジェクト|계획 (프로젝트)||परियोजना (प्रोजैक्ट)|প্রজেক্ট|||||hanke (projekti)|projekt, planowane przedsięwzięcie
-prometium|mate|Pm||promethium||prometio|||||||||||||prometio||promet
+Promete|name|||Prometheus|Prométhée|Prometeo|Prometeu|Прометей||||||||||||Prometheus|
+promete yum|yum 061|Pm||promethium|prométhium|prometio|promécio|прометий|بروميثيوم|钷|プロメチウム|프로메튬|prometi|प्रोमेथियम|প্রমিথিয়াম|prometium|promethi|prometyum|prometio|prometium|promet
 proses|||eng:process, spa:proceso, por:processo, rus:процесс (process), fas:پروسه‎ (prose), may:proses, jpn:プロセス (purosesu), kor:프로세스 (peuroseseu)|process (procedure)||proceso (procedimiento)||||||||||||||prosessi (proseduuri)|proces, procedura
-protacinium|mate|Pa||protactinium||proactinio|||||||||||||protaktinio|protaktinium|protaktyn
+protacini yum|yum 091|Pa||protactinium|protactinium|proactinio|protacnídio|протактиний|بروتكتنيوم|镤|プロトアクチニウム|프로트악티늄 or 프로탁티늄|protactini|प्रोटैक्टीनियम|প্রোটেক্টিনিয়াম|protaktinium|protaktini|protaktinyum|protaktinio|protaktinium|protaktyn
 puding|||eng:pudding, spa:pudín, rus:пудинг (puding), tur:may:puding, swa:pudini, ara:بودنغ (budingh), zho:布丁 (bùdīng), jpn:プディング (pudingu)|pudding||pudín||||布丁|||||||pudini|||vanukas|puding
 puja|||hin:पूजा (pūjā), urd:(pūjā), tha:บูชา (bucha), may:puja|worship (reveration)||adoración (veneración, culto)||||||||पूजा||||||palvonta|cześć, szacunek
 puja kan||||temple (place of worship)|temple|templo|templo|храм (место богослужения)|مَعْبَد‎|寺庙|神殿|절 (사원)|đền|मन्दिर|মন্দির|kuil|hekalu|tapınak (ibadethane)|templo|temppeli|świątynia
@@ -3133,9 +3133,9 @@ radi|||eng:fra:radiation, spa:radiación, por:radiação, may:radiasi, rus:ра�
 radi geter||||radio receiver||receptor de radio|||||||||||||radio|radiovastaanotin|radio
 radi metre gi||||radiometer||radiómetro||||||||||||||säteilymittari|radoiometr
 radi miser||||radiotransmitter||radiotransmisor||||||||||||||radiolähetin|nadajnik radiowy
+radi yum|yum 088|Ra||radium|radium|radio|rádio|радий|راديوم|镭|ラジウム|라듐|rađi|रेडियम|রেডিয়াম|radium|radi|radyum|radiumo|radium|rad
 radio|||eng:fra:spa:por:radio, rus:радио (radio), tur:radyo, swa:redio, hin:रेडियो (reḍiyo), ben:রেডিও (reḍio), jpn:ラジオ (rajio), kor:라디오 (radio)|radio|radio|radio|radio|радио||||||रेडियो|রেডিও||redio|radyo|||radio
-radium|mate|Ra||radium||radio|||||||||||||radiumo|radium|rad
-radon|mate|Rn||radon||radón|||||||||||||radono|radon|radon
+radon|yum 086|Rn||radon|radon|radón|rádon|радон|رادون|氡|ラドン|라돈|rađơn|रेडन|রেডন|radon|radoni|radon|radono|radon|radon
 rai|||ara:(raʾy), swa:rai, hin:राय (rāy), fas:(ra'y), tur:rey|opinion (view)|avis (opinion)|opinión (juicio, consideración)|opinião|мнение|رَأْي‎|意见 (见解)|意見 (見解)|의견 (견해)|ý kiến (kiến giải)|विचार (राय)|অভিমতি (নজর)|opini|wazo (rai)|rey|opinio|mielipide (näkemys)|opinia, pogląd
 raite|||eng:right|right hand side||lado derecho|||||右|||||||||oikea puoli|prawa strona
 raite di||||right hand||derecho|||||||||||||||prawy (prawostronny, z prawej strony)
@@ -3172,8 +3172,9 @@ re zoku||||continue (resume)|reprendre|continuar (reanudar)|||||再開する||||
 Rea|planete 6 lun 5|||Rhea|||||||||||||||||
 rebel|||eng:rebel, spa:por:rebelde fra:rebelle|rebellion||rebelión (sublevación)||||||||||||||kapina|rebelia, powstanie
 redi|||eng:ready, deu:bereit, fra:prêt, mao:reri|ready (prepared)||listo (preparado)|||||||||||||preta|valmis|gotowy
-rengenium|mate|Rg||roentgenium||roentgenio|||||||||||||rentgenio|röntgenium|roentgen
-renium|mate|Re||rhenium||renio|||||||||||||renio|rhenium|ren
+Ren|rivo|||Rhine|Rhin|Rin|Reno|Рейн||莱茵河|ライン川|라인 강||राइन||Rhein||Ren|Rejno|Rein|Ren
+ren yum|yum 075|Re||rhenium|rhénium|renio|rénio|рений|رنيوم|铼|レニウム|레늄|reni|रेनियम|রেনিয়াম|renium|reni|renyum|renio|renium|ren
+rentegen yum|yum 111|Rg||roentgenium|roentgenium|roentgenio|roentgênio|рентгений|رونتجينيوم||レントゲニウム|뢴트게늄|roentgeni|रॉन्टजैनियम|রোয়েন্টজেনিয়াম|roentgenium|roentgeni|röntgenyum|rentgenio|roentgenium|roentgen
 reporte|||eng:report, spa:reporte, fra:rapport, rus:рапорт (raport), tur:rapor, swa:ripoti, hin:रिपोर्ट (riporṭ), jpn:レポート (repōto)|report||informe (reporte, noticia)||||||||||||||raportti (selostus, selonteko)|raport
 reseta|||ita:ricetta, rus:рецепт (retsept), deu:Rezept, spa:receta, por:receita, fra:recette, may:resep, tur:reçete|instructions (recipe)|recette|instrucciones (receta)|receita|||||||||||tarif||resepti (ohje)|recepta, receptura, przepis
 reside|||fas:(resid), hin:रसीद (rasīd), urd:(rasīd), guj:રસીદ (rasīd), tel:రసీదు (rasīdu), + eng:receipt, swa:resiti, may:resit|receipt (acknowledgement)||reconocimiento (recibo)||||||||||||||kuitti (kuittaus)|paragon, pokwitowanie
@@ -3202,7 +3203,6 @@ ritim|||tur:ritim, eng:rhythm, fra:rhythme, spa:por:ritmo, rus:ритм (ritm), 
 rivo|||spa:por:rio, eng:river, fra:rivière|river (stream)|rivière (fleuve)|rio|rio|река|نَهْر|河 (江)|川|강||नदी (दरिया)|নদী|sungai|mto||rivero|joki (virta)|rzeka
 rivo kinar||||river bank|rive|ribera||||||||||tebing sungai|||||
 robote|||eng:fra:spa:tur:may:robot, por:robô, rus:робот (robot), ara:رُوبُوت‎ (rōbōt), fas:روبات‎ (rōbât), hin:रोबोट (rōbōṭ), tam:ரோபோ (rōpō), jpn:ロボット (robotto), kor:로봇 (robot)|robot (bot)|robot|robot (bot)|robô|робот|||||||||||roboto|robotti|robot
-rodium|mate|Rh||rhodium||rodio|||||||||||||rodio|rhodium|rod
 roke|||eng:fra:spa:por:rock, rus:рок (rok), hin:रॉक (rŏk), ben:রক (rôk), jpn:ロック (rokku), kor:록 (rok), ara: رُوك‎ (rūk)|rock (sway, tilt)|secouer|||качать||||||||||||keinuttaa (keikuttaa)|
 roke kursi||||rocking chair|chaise à bascule (berçante)|mecedora|cadeira de balanço|кресло-качалка||摇椅|揺り椅子|흔들 의자||||kursi goyang||||keinutuoli (kiikkutuoli)|
 roke muzika||||rock music|rock|rock|rock|рок|مُوسِيقَى اَلرُّوك‎|摇滚乐|ロック|록||रॉक संगीत|রক|||rock||rokki (rock)|rock
@@ -3232,9 +3232,11 @@ rota van gi|||eng:top, fra:toupie|top (spinning top)|toupie|trompo||волчок
 roza|bio|Rosa|fra:eng:rose, spa:por:rosa, rus:роза (roza), fas:(roz, gol-e sorx), tgl:rosas|rose|rose|rosa|rosa|роза||玫瑰|バラ|장미|hoa hồng|गुलाब|গোলাপ|mawar (ros)|waridi|gül|rozo|ruusu|róża
 roza rang|rang|||pink (rosy)||rosa||||||||||||||vaaleanpunainen|różowy, różany
 roza salmon|bio|Oncorhynchus gorbuscha||pink salmon|saumon rose|salmón rosado|salmão-rosa|горбуша||粉紅鮭|カラフトマス||||||||||gorbusza
+roza yum|yum 045|Rh||rhodium|rhodium|rodio|ródio|родий|روديوم|铑|ロジウム|로듐|rođi|रोडियम|রোডিয়াম|rodium|rodi|rodyum|rodio|rodium|rod
 Ruanda|desha|RW||Rwanda||Ruanda||||||||||||||Ruanda|Rwanda
+rubi|rang||hin:लाल (lāl), ben:লাল (lal), tur:al|red|rouge|rojo|vermelho|красный|أَحْمَر|红|赤い|빨갛다|đỏ|लाल|লাল|merah|nyekundu|kırmızı (al)|ruĝa|punainen|czerwony
 rubi|||eng:ruby, por:rubi, spa:rubí, fra:rubis, deu:Rubin, rus:рубин (rubin), jpn:ルビー (rubī)|ruby|rubis|rubí|rubi|рубин|ياقوت|红宝石|ルビー|루비|hồng ngọc|मानिक (याक़ूत)||delima|yakuti|yakut|rubeno|rubiini|rubin
-rubidium|mate|Rb||rubidium||rubidio|||||||||||||rubidio||rubid
+rubi yum|yum 037|Rb|eng:fra:may:rubidium, spa:por:rubidio, ara: رُوبِيدْيُوم‎ (rubidyum), zho:銣 (rú), jpn:ルビジウム (rubijiumu), kor:루비듐 (rubidyum), vie:rubiđi, swa:rubidi|rubidium|rubidium|rubidio|rubídio|рубидий|روبيديوم|铷|ルビジウム|루비듐|rubiđi|रुबिडियम|রুবিডিয়াম|rubidium|rubidi|rubidyum|rubidio|rubidium|rubid
 ruhu|||ara:(rūħ), may:ruh, tur:ruh, hin:रूह (rūh), swa:roho, hau:ruhu, som:ruux, + rus:дух (duh)|soul (mind, psyche)|psyché|psique||душа (дух)|||||||||||animo (psiko)|henki (sielu, mieli, psyyke)|dusza, duch, umysł
 ruhu di||||mental (psychic)||mental (psíquico)||||||||||||||henkinen (psyykkinen)|umysłowy (psychiczny)
 ruhu logi|||tur:ruh bilimi, hin:मनोविज्ञान (manovigyān), ben:মনোবিজ্ঞান (mônobiggan), may:ilmu jiwa, ara:(ʿilm an-nafs), deu:Seelenkunde, eng:psychology, spa:psicológia|psychology|psychologie|psicología|||||||||||saikolojia||psikologio|psykologia|psychologia
@@ -3244,13 +3246,13 @@ ruke|||deu:Rücken|back||espalda (lomo)|||||||||||||dorso|selkä|placy
 ruke sake|||deu:eng:rucksack, rus:рюкзак (rjukzak), jpn: リュックサック (ryukkusakku), kor:륙색 (ryuksaek)|backpack (rucksack)||mochila||рюкзак|||リュックサック|||||||||reppu (rinkka)|plecak
 Rundi|desha|BI||Burundi||Burundi||||||||||||||Burundi|Burundi
 rupa|||hin:रूप (rūp), may: rupa, tha: รูป (rūp), khm:រូប (rūp)|appearance (looks)||aspecto|||||||||||||aspekto|ilmiasu (ulkonäkö)|wygląd
+rus krepe|yam|||blini|||||||||||||||rusa krepo|blini|rosyjski naleśnik (blin)
+rus yum|yum 044|Ru||ruthenium|ruthénium|rutenio|ruténio|рутений|روتينيوم|钌|ルテニウム|루테늄|ruteni|रुथेनियम|রুথেনিয়াম|rutenium|rutheni|rutenyum|rutenio|rutenium|rut
 Rusia|desha|RU||Russia||Rusia||||||||||||||Venäjä|Rosja
 rusia basha|basha|rus||Russian language||idioma ruso||||||||||||||venäläinen|rosyjski
-rusia krepe|yam|||blini|||||||||||||||rusa krepo|blini|rosyjski naleśnik (blin)
 rute|||eng:fra:route, spa:ruta, por:rota, deu:Route, jpn:ルート (rūto), rus:маршрут (maršrut)|route (path, trail, course, itinerary)||ruta||||||||||||||polku (reitti, kurssi)|ścieżka (droga, szlak, kurs)
 rute galte di||||stray (deviant)|||||||||||||||||zbłąkany (dewiacyjny, wykolejony)
-rutenium|mate|Ru||ruthenium||rutenio|||||||||||||rutenio||rut
-ruterfordium|mate|Rf||rutherfordium||rutherfordio|||||||||||||ruterfordio||rutherford
+ruterfor yum|yum 104|Rf||rutherfordium|rutherfordium|rutherfordio|rutherfórdio|резерфордий, ²курчатовий|رذرفورديوم||ラザホージウム|러더포듐|rutherfordi|रुथरफोर्डियम|রাদারফোর্ডিয়াম|rutherfordium|rutherfordi|rutherfordiyum|ruterfordio|rutherfordium|rutherford
 rutina|||eng:fra:routine, spa:rutina, por:rotina, deu:Routine, fas:روتین‎ (rutin), rus:рутина (rutina)|routine (habit)||rutina (hábito)|||||||||||||rutino (kutimo)|tapa (rutiini)|rutyna, nawyk, zwyczaj
 S||||S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S
 saba|||heb:(sibá), hau:sabo;sababi, kon:sambu, ara:urd:(sabab), tur:sebep, may:sebab, swa:sababu|reason (cause)||razón (causa)|||||||||||||kialo|syy|powód, przyczyna
@@ -3314,7 +3316,7 @@ sama blu||||light blue (sky blue, azure)||celeste (azul celeste)||голубой
 sama di||||celestial (heavenly)||celeste (celestial)|||||||||||||||niebieski, niebiański, podniebny
 sama hal||||weather||clima (tiempo)||погода||天气|天気|날씨|thời tiết|मौसम (ऋतु)|বতৰ|cuaca (hawa)|hali ya hewa|hava|vetero|sää|pogoda
 sama kinar||||horizon||horizonte||горизонт||地平线|地平線 (水平線, 天際)||||||||||horyzont
-samarium|mate|Sm||samarium||samario|||||||||||||samario||samar
+samari yum|yum 062|Sm||samarium|samarium|samario|samário|самарий|ساماريوم|钐|サマリウム|사마륨|samari|सैमरियम|সামারিয়াম|samarium|samari|samaryum|samario|samarium|samar
 Samoa|desha|WS||Samoa||Samoa||||||||||||||Samoa|Samoa
 sana||||production||producción||||||||||||||tuotanto|produkcja
 sana basha||||artificial language (conlang)||idioma artificial (lengua construida, conlang)|||||||||||||artefarita lingvo|keinotekoinen kieli (tekokieli, keinokieli)|język sztuczny
@@ -3372,7 +3374,7 @@ sekur kopi||||backup||copia de seguridad|||||バックアップ (控え)||||||||
 sekur nomer||||personal identification number (PIN)||número de identificación personal|||||暗証番号||||||||||osobisty numer identyfikacyjny (pin)
 sela||||should (ought)||deber (se recomienda)|||||||||||||devus|pitäisi|powinien
 sela loga|||ara: صَلَاح‎ (ṣalāḥ), hin:सलाह (salāh), tel:సలహా (salahā), tur:salık + eng:counsel, fra:conseil, spa:consejo, por:conselho + rus:консультант (konsultant)|advice (counsel)|conseil|consejo|conselho|совет||||||||||||neuvo|rada, porada
-selenium|mate|Se||selenium||selenio|||||||||||||seleno|seleeni|selen
+selen yum|yum 034|Se||selenium|sélénium|selenio|selénio|селен|سيلينيوم|硒|セレン|셀렌, 2셀레늄|selen|सेलेनियम|সেলেনিয়াম|selenium|seleni|selenyum|seleno|seleeni|selen
 selge|bio|Beta vulgaris subsp. vulgaris, Cicla|ara:سلق (silqa), spa:por:acelga|chard|blettes (bettes)|acelga||мангольд|||フダンソウ (スイスチャード)||||||||||boćwina (botwina)
 selu|||may:sel, fas:sellul, tha:เซลล์ (seel), swa:seli, tgl:selula, eng:cell, fra:cellule, spa:célula|cell (biology)||célula|||||||||||||ĉelo|solu|komórka (biologia)
 selu logi||||cytology|cytologie|citología|citologia|цитология||细胞学|||||||||citologio|soluoppi (sytologia)|cytologia
@@ -3494,7 +3496,7 @@ si ja||||being (entity)||ser||||||||||||||olento (olio)|
 si membre||||belong (be a member)||pertenecer (ser miembro de)||||||||||||||kuulua (olla jäsenenä)|należeć (być członkiem)
 sian|rang||eng:cyan, spa:cian, rus:циан (tsian), ara:سيان (sayan), hin:क्यान (kyāna), jpn:シアン (shian), may:sian|cyan||cian||циан|||シアン|||||||||syaani|niebieskozielony (cyjan)
 Sibiria||||Siberia||Siberia||||||||||||||Siperia|Syberia
-siborgium|mate|Sg||seaborgium||seaborgio|seabórgio|сиборгий|||シーボーギウム|||||seaborgium|seaborgi|siborgium|seborgio||seaborg
+siborge yum|yum 106|Sg||seaborgium|seaborgium|seaborgio|seabórgio|сиборгий|سيبورجيوم||シーボーギウム|새보쥼|seaborgi|सीबोर्गियम|সিওবোর্গিয়াম|seaborgium|seaborgi|siborgiyum|seborgio|seaborgium|seaborg
 side|||rus:сидеть (sidet'), eng:sit, deu:sitzen, ita:sedere|sit down||sentarse|||||座る||||||||||usiąść
 side loka||||seat (saddle)||silla (montura)||сиденье (седло)||座部 (马鞍)|座席 (鞍)||||||||||siedzenie (siodło)
 sifa|||ara:صفة (ṣifa), fas:صفت (sefat), hin:सिफ़त (sifat), swa:sifa, tur:sıfat, may:sifat|attribute (charasteristic, quality, feature, description, property)||cualidad (atributo, descripción)||||||||||||||laatu (ominaisuus, ominaispiirre, määrite)|cecha, właściwość, parametr
@@ -3509,7 +3511,7 @@ sili|||hin:सिलसिला (silsilā), ara:(silsila), tur:silsile, swa:sil
 sili nete||||chain mail||cota de malla||кольчуга||||||||||||silmukkapanssari (rengashaarniska)|kolczuga
 sili sili||||chain||cadena|||||||||||||ĉeno|ketju|łańcuch
 sili tika||||link|maillon (chaînon)|eslabón|elo|звено||连结|連結|연결|liên kết||||||ĉenero|ketjun lenkki|
-silikium|mate|Si||silicon||silicio|||||||||||||silicio|pii|krzem
+silis|yum 014|Si||silicon|silicium|silicio|silício|кремний|سيلكون|硅|ヶィ素|규소|silic|सिलिकॉन|সিলিকন|silikon|silikoni|silisyum|silicio|pii|krzem
 silko|||zho:丝 (sī), yue:絲 (si1), wuu:絲 (sr1), eng:silk, spa:por:sérico, rus:шёлк (sholk)|silk|soie|seda|seda|шёлк||丝绸|絹|||||||||silkki|jedwab
 sim|||tha:เสริม (soem) + eng:-ism, fra:-isme, spa:por:-ismo, rus:-изм (-izm), may:-isme|advocacy (promotion, -ism)||ideología (doctrina, -ismo)||идеология|||主义|主義|||||||ismo|aate (aatteen kannatus, ismi)|
 sim ja||||advocate (promoter, supporter, adherent)||||||||||||||||kannattaja (tukija, -isti)|
@@ -3617,7 +3619,7 @@ sukar bete|bio|Beta vulgaris subsp. vulgaris, Altissima||sugar beet|betterave à
 sukar di||||sugary (sweet)||azucarado||||||||||||||sokerinen (makea)|słodki
 sukar gana|bio|||sugarcane|canne à sucre|caña de azúcar|cana-de-açúcar|сахарный тростник||甘蔗|サトウキビ|||गन्ना||tebu|muwa|||sokeriruoko|trzcina cukrowa
 sukar oranje|bio|Citrus × sinensis||sweet orange|orange douce|||апельсин|||オレンジ (アマダイダイ)||||||||||pomarańcza słodka (pomarańcza chińska)
-sulfur|mate|S||sulfur (brimstone)||azufre|||||||||||||sulfuro|rikki|siarka
+sulfu|yum 016|S||sulfur (brimstone)|soufre|azufre|enxofre|сера|كبريت|硫|硫黄|황|lưu huỳnh|गन्धक|সালফার|belerang|kibiriti (sulfuri)|kükürt|sulfuro|rikki|siarka
 sultan||||power (authority, rule)||poder (autoridad, competencia)|||||||||||||||siła, autorytet, władza
 sultan desha||||sultanate||sultanato|||||||||||||||
 sultan ja|||ara:سلطة (sulṭa), eng:tur:may:sultan, spa:sultán, rus: султан (sultan), fas:سلطان‎ (soltân), hin:सुल्तान (sultān), ben:সুলতান (śultan), swa:sultani|ruler||gobernante (soberano)|||||||||||||||władca
@@ -3669,14 +3671,14 @@ tal darja||||level down|||||||||||||||||
 tal di|||fas:ته (tah), hin:तह (tah) + zho:低 (dī), yue:低 (dai1), wuu:低 (ti1), jpn:低 (tei) + cze:dole|low (short)|bas|bajo|||||||||||||||niski
 tal moku||||bush (shrub)|buisson|arbusto (mata)|arbusto (mata)|куст||灌木|灌木 (藪)|||झाड़ी||alas gandar|||||krzak (krzew)
 tal tela||||carpet (rug)||alfombra (tapete)||ковёр|||絨毯 (カーペット)||||||||||dywan
-talium|mate|Tl||thallium||talio|||||||||||||talio|tallium|tal
+tali yum|yum 081|Tl||thallium|thallium|talio|tálio|таллий|ثاليوم|铊|タリウム|탈륨|tali|थैलियम|থ্যালিয়াম|tallium|tali|talyum|talio|tallium|tal
 tam|||ara: طَمَّاع‎ (ṭammāʿ), zho:贪 (tān), yue:貪 (taam1), kor:탐욕 (tamyok), vie:tham|greedy||codicioso (avaro)||||贪婪的|||||||||avida|ahne|chciwy (żądny)
 tamar|bio||por:tamara, ara:(tamar)|date fruit||dátil|||||||||||mtende|||taateli|daktyl
 Tamil|nas|||Tamil||tamil||||||||||||||tamil (eräs intialainen kieli)|tamilski
 tana|||fas: تنه‎ (tane), hin:तना (tanā), tam:தண்டு (taṇṭu), vie:thân, tha:ต้น (ton), may:tangkai|stem (torso, trunk, stalk)|tige|tallo|haste (talo, caule)|стебель||茎 (梗)|茎 (胴)|||तना (डाली)||tangkai|shina||||łodyga (tors, pień, trzon)
 tanah||||Tanakh (Jewish Bible)||Tanaj (Biblia hebrea)||||||||||||||tanakh|Tanach, Biblia hebrajska
 tanke|||eng:tank, hin:टंकी (ṭaṅkī), swa:tangi, spa:tanque, jpn:タンク (tanku), tgl:tangke|tank (reservoir)||tanque (cisterna)||||||||||||||tankki (säiliö)|zbiornik (cysterna, pojemnik, rezerwuar)
-tantalum|mate|Ta||tantalum||tántalo|||||||||||||tantalo||tantal
+tantal yum|yum 073|Ta||tantalum|tantale|tántalo|tântalo|тантал|تنتالم|钽|タンタル|탄탈, 2탄탈럼|tantali, tantan|टाण्टलम|ট্যান্টালাম|tantalum|tantali|tantal|tantalo|tantaali|tantal
 tanur|||fas:heb:tanur, ara:(tannūr), eng:tandoor, athanor, tur:tandır, hin:तनूर (tanūr), urd:(tanūr), pnb:ਤੰਦੂਰ (tandūr), swa:tanuri|oven (furnace)||horno|||||||||||tanuri||forno|uuni|piec (piekarnik)
 Tanzania|desha|TZ||Tanzania||Tanzania|||||||||||||Tanzanio|Tansania|Tanzania
 tapa|||spa:tur:tapa, por:tampa, ell:τάπα (tapa), bul:тапа (tapa), eng:tap|stopper (cap, peg, tap)||tapón (tapa)||||||||||||||tulppa (tappi, korkki)|korek, zatyczka, szpunt
@@ -3689,10 +3691,10 @@ tatike|||por:tática, ita:tattica, eng:tactic, rus:тактика (taktika), deu
 tatu|||sam:tah:tatau, haw:kākau, may:tato, eng:tattoo, fra:tatouage, spa:tatuaje, rus:тату (tatu)|tattoo||tatuaje||татуировка (тату)|||||||||||tatuo|tatuointi|tatuaż
 tava|||hin:तवा (tavā), tur:tava, fas:(tābe)|frying pan||sartén|||||||||||||pato|pannu (paistinpannu)|patelnia
 taza|||tur:taze, hin:ताज़ा (tāzā), ben:তাজা (taja), fas:(tâze)|fresh|frais|fresco||свежий||新鲜的|||||||||freŝa|tuore (raikas)|świeży
-tehnetium|mate|Tc||technetium||tecnetio|||||||||||||teknecio||technet
 tehni|||ell:τεχνική (tehniki), rus:техника (tehnika), fra:eng:technique, spa:por:técnica, hin:तकनीक (taknīk), may:teknik|technique (technology)|technique|técnica|técnica|техника||技术|技術|기술|kỹ thuật|||teknik||teknik|tekniko|tekniikka (keino, menetelmä)|technika, technologia
 tehni krati||||technocracy||tecnocracia||||||||||||||teknokratia|technokracja
 tehni logi||||technology (study of techniques)|technologie|tecnología||технология||工艺学|||||||||teknologio|tekniikka (teknologia)|technologia, nauka o technikach
+tehni yum|yum 043|Tc||technetium|technétium|tecnetio|tecnécio|технеций|تكنيتيوم|锝|テクネチウム|테크네튬|tecnexi|टेक्निशियम|টেকনিসিয়াম|teknetium|tekineti|teknesyum|teknecio|teknetium|technet
 tela|||spa:por:tgl:tela, fra:toile + eng:towel, hin:तौलिया (tauliyā), swa:taulo, jpn:タオル (taoru), may:tuala|cloth (fabric, textile)|tissu|tela (paño, tejido)|fazenda (tecido)|ткань||布料|布|||||||||kangas|tkanina (materiał, sukno)
 tela gi|||rus:ткать (tkat’) + may:duk + tur:doku|loom|métier à tisser|telar|tear|ткацкий станок||织机|織機|직기|khung cửi|||||dokuma tezgahı||kutomakone (kangaspuut)|krosno
 tele|||eng:spa:por:may:tele-, fra:télé-, rus:теле- (tele-)|distance (far away)||lo lejos|||||||||||||malproksimeco|etäisyys (kaukaisuus)|dystans
@@ -3704,8 +3706,8 @@ tele fon shuta||||telephony (telephone communication)||telefonía|telefonia|те
 tele ta||||distance (length)||distancia||||||||||||||etäisyys|dystans
 tele vide gi||||television|téléviseur|televisión||телевизор||电视机|||||||||televidilo|televisio|telewizja
 teleskope||||telescope|télescope (lunette)|telescopio|telescópio|телескоп||望远镜|望遠鏡 (テレスコープ)|망원경|kính thiên văn|दूरबीन|দূরবীন|teleskop|darubini|teleskop|teleskopo|kaukoputki (teleskooppi)|teleskop
+telu yum|yum 052|Te||tellurium|tellure|telurio|telúrio|теллур|تيلوريوم|碲|テルル|텔루르, 2텔루륨|telua, telu|टेलुरियम|টেলুরিয়াম|telurium|teluri|tellur|teluro|telluuri|tellur
 Telugu|nas|||Telugu||télugu||||||||||||||telugu (eräs intialainen kieli)|telugu
-telurium|mate|Te||tellurium||telurio|||||||||||||teluro||tellur
 tema|||fra: thème, spa: tema, rus: тема (tema), deu:Thema + zho:题目 (tímù)|topic (subject, theme)|sujet (thème)|tema||тема||主题目|||||||||temo|aihe (teema)|temat, motyw
 tema||||be about (discuss as a subject)||tratar de|||||||||||||esti pri; pridiskuti|aiheesta (-sta)|być o; dyskutować o
 tema name||||title (headline)|titre|título|título|название (пьесы, заголовок)|eunwan (laqab)|标题|題名 (書名, タイトル)||||||||||tytuł (nagłówek)
@@ -3713,7 +3715,7 @@ ten|||fra:tener, spa:tenir, por:ter, eng:-tain|hold (grasp, detain)|tenir|tener 
 ten bil||||accessible (within reach)|accessible (atteignable, à portée)|accesible||доступный|||とっつきやすい (アクセス可能)|||सुगम्य (सुगम, सुलभ)||dapat dicapai (dapat diakses)||||ulottuvilla|
 ten fasil ta||||accessibility (ease of access)||fácil acceso (accesibilidad)||доступность||無障礙環境|アクセシビリティ|||सुगमता (सुलभता, सुगम्यता, पहुंच)||ketercapaian|||||
 Tenesi||||Tennessee||Tennessee||||||||||||||Tennessee|
-tenesium|mate|Ts||tennessine||teneso|||||||||||||teneso||tenesyn, tennessine
+tenesi yum|yum 117|Ts||tennessine|tennessine|teneso|tennessine|теннессин|ٲنون سيبتيوم||テネシン|우눈셉튬||||tennessine|||teneso|tennessine|tenesyn, tennessine
 tenis||||tennis||tennis|||||||||||||teniso|tennis|tenis
 tense|||eng:tense, fra:tendu, spa:por:tenso|tight (tense)|tendu|tenso|tenso|тугой||||||||||||kireä (tiukka, jännittynyt)|
 tense ta||||tension||||||||||||||||jännitys (jännite)|
@@ -3721,7 +3723,7 @@ tenta|||eng:tempt, spa:por:tentar, fra:tenter|tempt (entice)||tentar (seducir)||
 teori|||eng:theory, spa:teoría, por:teoria, fra:téorie, rus:теория (teoriya), fas:تئوری‎ (teori), may:teori|theory||teoría|||||||||||||teorio|teoria|teoria
 tepe|||eng:tape, swa:tepe, jpn:テープ (tēpu), kor:테이프 (teipeu), tur:teyp, hin:टेप (tep)|tape|ruban (bande)|cinta adhesiva||лента|||||||||||bendo|teippi (nauha)|taśma
 tera|nomer||eng:fra:spa:por:may:tur:tera-, rus:тера- (tera-), jpn:テラ (tera), kor:테라- (tera-)|tera-||tera-||||||||||||||biljoona (tera-)|tera-
-terbium|mate|Tb||terbium||terbio|||||||||||||terbio|terbium|terb
+terbi yum|yum 065|Tb||terbium|terbium|terbio|térbio|тербий|تربيوم|铽|テルビウム|테르븀, 2터븀|tecbi|टर्बियम|টার্বিয়াম|terbium|taribi|terbiyum|terbio|terbium|terb
 tercha|||spa:torcido, por:torto, hin:तिरछा (tirachha), ben:তেরছা (tērachā), pan:तिरकस (tirakasa)|oblique (askew, tilted)|oblique (de travers)|oblicuo (torcido)|oblíquo (torto)|косой||斜的|斜め|||||||||vino|skośny (ukośny, pochyły)
 termo|||deu:eng:fra:thermo-, spa:por:termo-, rus:термо- (termo-)|temperature||temperatura||||||||||||||lämpötila|temperatura
 termo metre gi||||thermometer||termómetro|||||||||||||termometro|lämpömittari|termometr
@@ -3748,8 +3750,8 @@ tire yo milke||||milk (draw milk)|tirer|ordeñar||тянуть||拉|||||||||melk
 tire yo pil||||strip (peel)|écorce|quitar (pelar)||ободрать||削 (刮去)|はがす (剥ぐ)|||||||||kuoria|obrać (obierać)
 tisa|nomer|9|ara: تِسْعَة‎ (tisʿa), swa:tisa|nine (9)|neuf (9)|nueve (9)|nove (9)|девять (9)||九 (9)|九 (9)|||नौ|নয়|||||yhdeksän|dziewięć (9)
 Titan|planete 6 lun 6|||Titan||||||||||||||||Titan|
+titan yum|yum 022|Ti||titanium|titane|titanio|titânio|титан|تيتانيوم|钛|チタン|타이타늄, 타타늄, 타탄|titan|टाइटानियम|টাইটেনিয়াম|titanium|titani|titan|titanio|titaani|tytan
 Titania|planete 7 lun 4|||Titania||||||||||||||||Titania|
-titanium|mate|Ti||titanium||titanio|||||||||||||titanio|titaani|tytan
 titi|||eng:tit, fra:tété, spa:teta, rus:титьки (tit’ki), ara:ثَدْي‎ (ṯady), swa:titi, may:tetek, jpn:乳 (chichi)|breast (boob, tit)|sein|seno (teta)|seio (mama)|||||||||payudara|titi|meme|mamo|nisä (tissi)|
 tochu|||eng:touch, spa: tocar, + hin: छूना (chūnā), zho: 触 (chù)|touch|toucher|tocar (rozar)||касаться||接触|||||||||tuŝi|koskea (koskettaa)|dotyczyć
 tochu sense||||feel (sense by touch)||palpar (tocar)|||||||||||||senti|tuntea|czuć
@@ -3766,7 +3768,7 @@ Tonga|desha|TO||Tonga||Tonga||||||||||||||Tonga|Tonga
 topo|||eng:fra:spa:por:tur:mal:topo-, rus:топо- (topo-)|region (tract, land, ground)||región (zona)|||||||||||||regiono|seutu (maa, alue)|region
 topo grafi||||topography|topographie|topografía|topografia|топография||地形|地勢|||||topografi||topografi||topografia|
 topo metre grafi||||map (chart, geographic map)|carte (plan)|mapa|carta geográfica|карта (план)||地图||||||||harita||kartta|
-torium|mate|Th||thorium||torio|||||||||||||torio|torium|tor
+tor yum|yum 090|Th||thorium|thorium|torio|tório|торий|ثوريوم|钍|トリウム|토륨|thori|थोरियम|থোরিয়াম|torium|thori|toryum|torio|torium|tor
 torso|||fra:torse, rus:торс (tors), deu:eng:spa:may:torso|trunk (torso)||torso|||||||||||||torso|vartalo (varsi, torso)|tułów
 tortuga|bio|Testudines|eng:tortoise, spa:tortuga, por:tartaruga, fra:tortue|turtle (tortoise)||tortuga||||||||||||||kilpikonna|żółw
 transe|||eng:fra:spa:por:deu:may:trans-, rus:транс- (trans-)|transit (transport, passage)||tránsito (transporte)||||||||||||||läpikulku (kuljetus)|przejazd, przewóz, tranzyt, transport
@@ -3792,7 +3794,8 @@ tualete|||fra:toilettes, eng:may:toilet, por:toalete, rus:туалет (tualet),
 tubo|||spa:por:tubo, eng:fra:tube, jpn:チューブ (chūbu), zul:ithumbu, xho:íthumbu|tube (pipe)||tubo|||||||||||||tubo|putki (tuubi)|tuba, rura
 tuh|||hin: थूकना (thūknā), zho: 吐 (tǔ), tur:tükürmek|spit||escupir (bufar)|||||||||||||sputi|sylkeä|pluć
 tul|||eng: tool, kor: 툴 (tul), jpn: ツール (tsūru), Zulu: ithuluzi|tool||herramienta|||||||||||||ilo|työkalu|narzędzie
-tulium|mate|Tm||thulium||tulio|||||||||||||tulio|tulium|tul
+Tule||||Thule|Thulé|||Туле|||||||||||Tuleo|Thule|
+tule yum|yum 069|Tm||thulium|thulium|tulio|túlio|тулий|ثليوم|铥|ツリウム|툴륨|tuli|थुलियम|থুলিয়াম|tulium|thuri|tulyum|tulio|tulium|tul
 tulpan|bio|Tulipa|eng:tulip, spa:tulipá, por:túlipa, nld:tulp, rus:тюльпан (t’ul’pan), ara:توليب (tūlīb), hin:ट्यूलिप (ṭyūlip), may:tulip, jpn:チューリップ (chūrippu)|tulip||tulipán||||||||||||||tulppaani|tulipan
 tumen|pron.|||you all||ustedes||||你们|あなたたち||||||||vi ĉiu|te|wy, was
 tumen su||||your|votre|vuestro|vosso|ваш||你们的|||||||||via|teidän|
@@ -3823,6 +3826,7 @@ umami|||jpn:旨味 (umami), kor:우마미 (umami), eng:fra:por:spa:may:umami, ru
 Umbriel|planete 7 lun 3|||Umbriel||||||||||||||||Umbriel|
 un|nomer|1|fra:un, spa:uno, por:um,una, eng:one|one (1)|un (1)|uno (1)|um (1)|один (1)||一 (1)|一 (1)|||||||bir|unu (1)|yksi (1)|jeden (1)
 un deu sim||||monotheism||monoteismo||||||||||||||monoteismi (yksijumalisuus)|monoteizm
+un di||||only (single, sole, lone, just)|seul (unique)|único (únicamente, solo)|único (só)|только (единственно, единственный, уникальный)||只有 (惟独, 唯一, 独)|だけ (唯一の)|유일한|duy nhất|सिर्फ़ (एकमात्र)||unik|||sola (nur)|vain (ainoa, ainut)|tylko (jedyny, wyłączny)
 un mana di||||unambiguous||inequívoco||||||||||||||yksimerkityksinen|jednoznaczny
 un mar||||once (one time)|une fois|una vez|uma vez|один раз||一次 (一遍)||一度 (一回, 一遍)|한번|एक बार|||||unufoje|kerran|raz (jeden raz)
 un me||||first (number one)||primero (numbre uno)||||||||||||||ensimmäinen (numero yksi)|pierwszy, numer jeden
@@ -3830,7 +3834,6 @@ un oko di lense||||monocle|monocle|monóculo|monóculo|монокль|||||||||||
 un rang di||||monochrome||monocromático||||||||||||||yksivärinen|jednokolorowy (monochromatyczny)
 un she sim||||monism||monismo|||||||||||||monismo|monismi|monizm
 un verse di||||universal|universel|universal|universal|||||||||||||universaali|
-un di||||only (single, sole, lone, just)|seul (unique)|único (únicamente, solo)|único (só)|только (единственно, единственный, уникальный)||只有 (惟独, 唯一, 独)|だけ (唯一の)|유일한|duy nhất|सिर्फ़ (एकमात्र)||unik|||sola (nur)|vain (ainoa, ainut)|tylko (jedyny, wyłączny)
 un zai di||||alone (lonely, isolated, solitary, single)||solo (aislado, solitary, soltero)|só (solitário)|одинокий (единичный)||独自的 (孤单)|一人の (寂しい, ポツリ)|||एकाकी||seorangan (sendiri)||||yksinäinen|
 unta||||unity||unidad (unión)||единица||团结 (统一)|団結 (統一)|||||kesatuan|umoja|birlik (ünite)||ykseys|
 Unta Arabi Amir Desha (UAA)|desha|AE||United Arab Emirates||Emiratos Árabes Unidos||||||||||||||Yhdistyneet Arabiemiirikunnat|Zjednoczone Emiraty Arabskie
@@ -3839,7 +3842,7 @@ unta di||||united||unido||||||||||||||yhtenäinen|zjednoczony
 unta liga||||union|union|unión|união|союз||合并|連合 (接合)|||संयोग (सम्मिलन)||serikat (gabungan, ikatan)|jumuia (muungano)|birlik (kavuşma)|uniono|liitto (unioni)|unia
 ura|||rus:ура (ura), ita:urrà, deu:spa:hurra, fra:hourra, eng:hurrah, may:hore, fas:(hurâ)|cheer (hurrah, hooray)|hourra|hurra|urra|ура||好哇||||जय हो||||||hurraa (hurrata)|wiwatować; hura
 Uran|planete 7|||Uranus|Uranus|Urano|Urano|Уран|أورانوس|||||||||Uranüs||Uranus|Uran
-uranium|mate|U||uranium|uranium|uranio|||||||||||||uranio|uraani|uran
+uran yum|yum 092|U||uranium|uranium|uranio|urânio|уран|يورانيوم|铀|ウラン|우라늄|urani (uran)|युरेनियम|ইউরেনিয়াম|uranium|urani|uranyum|uranio|uraani|uran
 urdu|nas|||Urdu||urdu||||||||||||||urdu|urdu
 Urdun|desha|JO||Jordan||Jordania||||||||||||||Jordania|Jordan
 urso|bio|Ursidae|fra:ours, por:urso, spa:oso, fas:(xers)|bear|ours|oso|urso||||||||||||urso|karhu|niedźwiedź
@@ -3866,7 +3869,7 @@ vampir ohtopus|bio|Vampyroteuthis infernalis||vampire squid|vampire des abysses|
 van|||zho:玩 (wán), yue:玩 (waan4), cjy:玩 (van1), kor:완 (wan)|fun (amusement)||diversión||||娱乐|楽しみ (娯楽)||||||||amuzo|huvi (hauskuus)|zabawa, rozrywka
 van di||||funny (amusing)||divertido|||||楽しい||||||||amuza|hauska (huvittava)|zabawny
 van gi||||toy (plaything)||jugete||игрушка|||おもちゃ|||||||||leikkikalu (lelu)|
-vanadium|mate|V||vanadium||vanadio||||||||||||||vanadiini|wanad
+vanadi yum|yum 023|V||vanadium|vanadium|vanadio|vanádio|ванадий|فناديوم|钒|バナジウム|바나듐|vanađi|वनेडियम|ভ্যানাডিয়াম|vanadium|vanadi|vanadyum||vanadiini|wanad
 vanila|||eng:vanilla, spa:vainilla, por:baunilha, fra:vanille, rus:ваниль (vanil’)|vanilla||vainilla||||||||||||||vanilja|wanilia
 Vanuatu|desha|VU||Vanuatu||Vanuatu||||||||||||||Vanuatu|Vanuatu
 var|||hin:वार (vār), ben:বার (bar) + por:feira|day of the week||día de semana|||||||||||||semajntago|viikonpäivä|
@@ -3955,7 +3958,7 @@ vodun|||ewe:vodun, hat:vodou, bra:vodum, eng:voodoo, fra:vaudou, spa:vudú|voodo
 vol|||fra:voiloir, ita:volere, deu:wollen, eng:volition, spa:voluntad, rus:воля (volya), pol:wola|want (desire, wish)|vouloir|querer (desear)|querer (desejar)|хотеть|أَرَادَ|想要 (愿意)|欲しい|싶다 (원하다)|muốn|चाहना|চাওয়া|mau (mahu)||istemek|voli|haluta|chcieć, pragnąć
 vol she||||want (desire, wish)||deseo|vontade|||||소원|||||||volo|halu (toive)|wola (chęć, pragnienie)
 volfe|||deu:ned:eng:wolf, rus:волк (volk)|wolf|loup|lobo|||||||||||||lupo|susi (hukka)|wilk
-volfram|mate|W||tungsten (wolfram)||tungsteno (wolframio)||||||||||||||wolframi|wolfram
+volfram|yum 074|W||tungsten (wolfram)|tungstène|tungsteno (wolframio)|tungsténio|вольфрам|تنجستين|钨|タングステン|텅스텐|vonfam|टंग्स्टन|টাংস্টেন|wolfram|wolframi|volfram||volframi|wolfram
 Volof||||Wolof (language and people)|wolof||||||||||||kiwolofu|||wolofin kansa ja kieli|wolof
 volte|unomete|V||volt (V)||voltio (V)||||||||||||||voltti (V)|wolt (V)
 vote|||eng:vote, spa:por:voto, hin:वोट (voṭ), rus:вотум (votum)|vote (ballot)||voto|voto|||||||||||||ääni (äänestyksessä)|głos
@@ -3963,7 +3966,7 @@ vote haki||||franchise (right to vote)||sufragio (derecho al voto)||||||||||||||
 vulva|||fra:vulve, eng:por:spa:tur:vulva, rus:вульва (vul’va)|vulva|vulve|vulva|vulva|вульва||外阴 (陰门)|陰門|음문|âm hộ|||||vulva|vulvo|häpy (ulkosynnyttimet)|srom
 vutu|||zho:物 (wù), wuu:物 (veq5), jpn:物 (butsu), vie:vật + hin:mar:वस्तु (vastu), ben:বস্তু (bôstu), pan:ਵਸਤੁ (vastu), tha:วัสดุ (wạttu)|object (item, thing)|objet (article)|objeto (artículo)|item|статья (предмет)||物体 (物品)|物 (品)|||||||||esine (tavara)|przedmiot (obiekt)
 X||||X|X|X|X|X|X|X|X|X|X|X|X|X|X|X|X|X|X
-xenon|mate|Xe||xenon||xenón||ксенон|||キセノン|||||xenon|zenoni|ksenon|ksenono|ksenon|ksenon
+xenon|yum 054|Xe||xenon|xénon|xenón|xénon|ксенон|إكسينون|氙|キセノン|크세논, 2제논|xenon|ज़ेनान|জেনন|xenon|zenoni|ksenon|ksenono|ksenon|ksenon
 Y||||Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y|Y
 ya|pron.||may:ia + hin:यह (yah) + swa:yeye, zul:yena, lin:ye, ktu:ya, ibo:ya + rus:е- (ye-) + zho:伊 (yī), vie:y|he or she or it||él o ella||||他，她，它|||||||||li aŭ ŝi aŭ ĝi|hän (se)|on, ona, ono
 ya|||spa:por:eng:-ia, rus:-ия (-iya), ara: ية (-iya), jpn:屋 (-ya)|area of thinking or being||sufijo para regiónes y sustantivos abstractos|||||||||||||ejo (ujo, io)|ajattelun, olemisen tai ihmisten ala tai alue|przyrostek dla miejsca
@@ -4013,11 +4016,12 @@ yong petra||||lava|lave|lava||||熔岩|溶岩|||||||||laava|lawa
 yong safa||||smelt|fondu|||||熔炼|||||||||||topić (upłynnić, upłynniać)
 Yoruba|nas|||Yoruba (language and people)|||||||||||||kiyoruba|||joruban kansa ja kieli|Joruba
 yota|nomer||eng:fra:spa:por:yotta, may:yota-, zho:尧它- (yáotā-), jpn:ヨタ- (yota-), kor:요타- (yota-)|yotta-||||||||||||||||kvadriljoona (jotta-)|
+yum||||chemical element|élément chimique|elemento químico|elemento químico|химический элемент||元素|元素|원소|nguyên tố|रासायनिक तत्व||unsur kimia||kimyasal element|kemia elemento|alkuaine|
 yumor|||rus:юмор (yumor), spa:eng:humor, fra:humour, jpn:ユーモア (yūmoa), kor:유머 (yumeo), zho:幽默 (yōumò)|humor||humor (gracia)||юмор|||||||||||humuro|huumori|humor
 yumor di||||humorous (comical, funny)||humorístico (gracioso, cómico)|||||||||||||humura|koominen (hauska)|humorystyczny, śmieszny, zabawny, komiczny
 yumor ja||||humorist||humorista|||||||||||||humuristo|humoristi|komik
-yuterbium|mate|Yb||ytterbium||iterbio|||||||||||||iterbio|ytterbium|iterb
-yutrium|mate|Y||yttrium||itrio|||||||||||||itrio|yttrium|itr
+yuter yum|yum 039|Y||yttrium|yttrium|itrio|itrio|иттрий|يتريوم|钇|イットリウム|이트륨|ytri|इत्रियम|ইটরিয়াম|itrium|yitri|i̇triyum|itrio|yttrium|itr
+yuterbi yum|yum 070|Yb||ytterbium|ytterbium|iterbio|itérbio|иттербий|يتربيوم|镱|イッテルビウム|이테르븀, 2이터븀|ytecbi|यिट्टरबियम|ইটারবিয়াম|iterbium|yitebi|i̇tterbiyum|iterbio|ytterbium|iterb
 Z||||Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z|Z
 zai|||zho:在 (zài), jpn:在 (zai), vie:tại|exist (presently, currently)||existir (actualmente)|||||ある (いる)|||||||||olla olemassa|istnieć
 zai den||||today||hoy|||||今日||||||||hodiaŭ|tänään|dziś, dzisiaj
@@ -4052,11 +4056,11 @@ zikura|||ara:(ziqqūra), deu:Zikkurat, rus:зиккурат (zikkurat)|ziggurat|
 Zimbabue|desha|ZW||Zimbabwe||Zimbabue||Зимбабве||||||||||||Zimbabwe|Zimbabwe
 zina|||ara:(zināʾ), may:tur:zina, swa:zinaa, urd:(zinā), fas:(zenā)|adultery (infidelity)||adulterio|||||||||||||malfideleco|haureus (uskottomuus)|zdrada małżeńska, cudzołóstwo
 zinji|||tam:இஞ்சி (inji), eng:ginger, ara:(zanjabīl), tur:zencefil, fra:gingembre|ginger|gingembre|gengibre|jengibre|имбирь||姜||||अदरक||jahe||zencefil|zingibro|inkivääri|imbir
-zinke|mate|Zn||zinc||cinc||цинк|||||||||||zinko|sinkki|cynk
+zinke|yum 030|Zn||zinc|zinc|cinc|zinco|цинк|خارصين|锌|亜鉛|아연|kẽm|जस्ता|জিঙ্ক|seng|zinki (bati)|çinko|zinko|sinkki|cynk
 zipa|||eng:zipper, ben:জিপার (jipar), hin:ज़िपर (zipar), jpn:ジッパー (jippā), kor:지퍼 (jipeo), tha:ซิป (síp), fas:urd:(zip)|zipper (zip)||cremallera||||||||||||||vetoketju|zamek błyskawiczny
 zira|||ben:জিরা (zīra), hin:ज़ीरा (zīrā), tam:சீரகம் (sīrakam), swa:mjira, fas:(zire), zho:孜然 (zīrán)|cumin (jeera)||comino||тмин||孜然||||ज़ीरा|জিরা||mjira||kumino|juustokumina (jeera)|kumin, kmin
 zirkon||||zircon||circón||циркон||||||||||||zirkoni|
-zirkonium|mate|Zr||zirconium||circonio|||||||||||||zirkonio|zirkonium|cyrkon
+zirkon yum|yum 040|Zr||zirconium|zirconium|circonio|zircónio|цирконий|زيركونيوم|锆|ジルコニウム|지르코늄|ziriconi|जर्कोनियम|জিরকোনিয়াম|zirkonium|zirikoni|zirkonyum|zirkonio|zirkonium|cyrkon
 zizi|||zho:zizi eng:sizzle|sizzle||chisporrotear||||||||||||||sihistä|skwierczeć
 zoku|||wuu:续 (zoq), yue:續 (zuk6), jpn:続 (zoku), kor:속 (sok), vie:kế tục|continue (go on, keep on, carry on, proceed, still, yet)|continuer (poursuivre, encore)|todavía (aún)|ainda|ещё||还 (依然)|まだ|||||||devam etmek|ankoraŭ|vielä (yhä, jatkua)|wciąż, nadal; kontynuować, wznawiać, ponawiać
 zoku di||||continuous (analog)|continu (analogique)|continuo (analógico)|analógico|||指针式的|アナログ|||||||||jatkuva (analoginen)|ciągły (analogowy)


### PR DESCRIPTION
This is a proposal for the new names of the chemical elements in the periodic table. I used real etymologies from the [list of chemical element name etymologies](https://en.wikipedia.org/wiki/List_of_chemical_element_name_etymologies) article in the Wikipedia. Then I created new word **yum** ('chemical element'). Many elements are in the form **X yum**, like for example **bor yum**, which is named after Niels Bohr.

Translations of element names in other languages are from [Elements Multidict](https://elements.vanderkrogt.net/multidict.php).