### PR TITLE
suja do kode la putong han ton na loga jo fin ha nos fon

### DIFF
--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -380,7 +380,7 @@ be ting||||stop (halt)||pararse (detenerse)|||||止まる||||||||halti|pysähty�
 be turbe||||be bothered by (bother to, take the trouble to)||molestar en||утруждай|||悩む (わざわざする)|||||||||vaivautua|przejmować się (zawracać sobie głowę)
 be van||||enjoy (play)||disfrutar (jugar)||||玩耍|遊ぶ|||||||||leikkiä (pitää hauskaa)|cieszyć się (zażywać, bawić się)
 be vide||||be seen||ser visto||||||||||||||näkyä|być widzianym
-be yong liga||||merge (fuse)||fusionar (fundir)||||||||||||||sulaa yhteen (fuusioitua)|łączyć (złączyć)
+be yung liga||||merge (fuse)||fusionar (fundir)||||||||||||||sulaa yhteen (fuusioitua)|łączyć (złączyć)
 be zai||||appear||aparecer||||||||||||||ilmestyä|pojawić się
 bebe|||fra:bébé, por:bebê, spa:bebé, tur:bebek, eng:baby, yue:BB (bibi)|baby (infant)|bébé|bebé|bebê|младенец|رَضِيع|宝宝 (娃娃)|赤ちゃん|||शिशु||bayi|mtoto mchanga||bebo|vauva|niemowlę
 bebe bede||||crib||||детская кроватка||娃娃床|ベビーベッド|||||||||pinnasänky|kojec
@@ -559,7 +559,7 @@ Cheska|desha|CZ||Czech Republic||República Checa||||||||||||||Tšekki|Republika
 cheti|nomer|7|fra:sept, spa:siete, por:sete, hin:सात (sāt), ben:সাত (sat) + zho:七 (qī), yue:七 (cat1),  jpn:七 (shichi), kor:칠 (chil), tha:เจ็ด (chet)|seven (7)|sept (7)|siete (7)|sete (7)|семь (7)|七 (7)|七 (7)|||||||||sep (7)|seitsemän (7)|siedem (7)
 Chile|desha|CL||Chile||Chile|||||||||||||Ĉilio|Chile|Chile
 chili|||eng:chili, por:spa:chile, jpn:チリ (chiri), kor:칠리 (chilli), may:cili|pepper (capsicum)|piment|chile|cápsico|перец (паприка)||菜椒||||मिर्च||cabai (lada, cili)||||paprika|papryka
-chili fun||||paprika||||||辣椒粉|パプリカ|||||||||paprikajauhe|papryka
+chili fen||||paprika||||||辣椒粉|パプリカ|||||||||paprikajauhe|papryka
 chimpanzi|bio||eng:chimpanzee, spa:chimpancé, por:fra:chimpanzé, rus:шимпанзе (shimpanze), tur:şempanze, ara:شمبانزي‎ (šimbanzī), hin:चिंपांजी (cimpāñjī), jpn:チンパンジー (chinpanjī), may:cimpanzi|chimpanzee||chimpancé|||||||||||||ĉimpanzo|simpanssi|szympans
 chin|||zho:親 (qīn), yue:親 (can), wuu:親 (qin), jpn:親 (sin), kor:친 (chin)|parent (mother or father)||parente (madre o padre)||||||||||||||vanhempi (isä tai äiti)|rodzic (matka lub ojciec)
 chin brus ben||||cousin|cousin|primo|primo||||||||||binamu||kuzo|serkku|kuzyn
@@ -618,9 +618,9 @@ dai shula kan||||university||universidad||||||||||||||yliopisto|uniwersytet
 dai siti||||big city|||||||||||||||urbego|suurkaupunki|
 dai ta||||size||tamaño||||||||||||||suuruus (koko)|rozmiar
 daka||||cover (lid, cap, deck)||tapa (funda, cubierta)||||||||ढक्कन|||||kovrilo|peite (kansi)|pokrycie; pokrywa, wieko, dekiel; pokład
-daku|||zho:得 (dé), yue:得 (dak1), wuu:得 (teq4), jpn:得 (toku), kor:득 (deuk), kor:được|get (receive, obtain, take)||conseguir (obtener, recibir)|ter (achar, receber)|получить||获得|受ける (もらう)|||पाना|||kupata (kuget)|elde etmek|akiri (ricevi, preni)|hankkia (saada)|dostać, dostawać, otrzymać, otrzymywać, wziąć, brać
-daku ja||||getter (receiver, recipient)||engendrador||||||||||||||saaja (vastaanottaja)|odbiorca
-daku shitu||||gains and losses (pros and cons)||||||得失|得失|||||||||voitot ja tappiot|
+deku|||zho:得 (dé), yue:得 (dak1), wuu:得 (teq4), jpn:得 (toku), kor:득 (deuk), kor:được|get (receive, obtain, take)||conseguir (obtener, recibir)|ter (achar, receber)|получить||获得|受ける (もらう)|||पाना|||kupata (kuget)|elde etmek|akiri (ricevi, preni)|hankkia (saada)|dostać, dostawać, otrzymać, otrzymywać, wziąć, brać
+deku ja||||getter (receiver, recipient)||engendrador||||||||||||||saaja (vastaanottaja)|odbiorca
+deku shitu||||gains and losses (pros and cons)||||||得失|得失|||||||||voitot ja tappiot|
 dalil|||ara:(dalil), ben:দলিল (dôlil), swa:dalili, tur:delil|proof (evidence, proof, demonstration, testimony)|preuve|prueba|prova|доказательство||||||||||||todiste (todistus, osoitus, demonstraatio)|dowód; zeznanie
 dama gem|||fra:jeu de dames, spa:por:damas, ara: ضَامَة‎ (ḍāma), vie:cờ đam, may:dam, tur:dama, deu:Damespiel|checkers (draughts)|jeu de dames|damas|damas|шашки|ضَامَة‎|跳棋|チェッカー (西洋碁)|체커|cờ đam|चेकर्स (ड्राफ़्टस)|চেকারস|dam|drafti|dama|damludo|tammipeli|warcaby
 dane|||hin:दाना (dānā), tur:tane + jpn:種 (tane);銃弾 (jūdan), zho:弹 (dàn), vie:đạn, kor:탄알 (tanal)|particle (grain, bullet)||partícula (grano, bala)||||||||||||tane||jyvä (luoti)|cząstka (ziarno, kula, pocisk)
@@ -748,10 +748,10 @@ domino gem|||eng:dominoes, spa:por:dominó, fra:dominos, rus:домино (domin
 dona|||fra:donner, eng:donate, spa:por:donar|give||dar|||||あげる (くれる)||||||||doni|antaa|dać, dawać
 dona she||||gift||regalo (obsequio)|||||||||||||donaco|lahja|podarunek, dar, prezent
 dona tabi||||generous (open-handed)|généreux|generoso (dadivoso)|generoso (dadivoso, mão-aberta)|щедрый|كَرِيم‎||||||||karimu||malavara|antelias (avokätinen)|
-dong|||zho:东 (dōng), yue:東 (dōng), vie:đông, kor:동 (dong), tur:doğu|east (orient)|east (orient)|éste|este (leste)|восток (ост)||东|東|동|đông|पूर्व|পূর্ব|timur|mashariki|doğu|oriento|itä|wschód
-dong di||||eastern||oriental||||||||||||||itäinen|wschodni
-dong gorila|bio|Gorilla beringei||eastern gorilla||gorila oriental||восточная горилла|||ヒガシゴリラ|||||||||idängorilla|goryl wschodni
-Dong Timor|desha|TL||East Timor (Timor-Leste)||Timor Oriental||||||||||||||Itä-Timor|Timor Wschodni (Demokratyczna Republika Timoru Wschodniego)
+dung|||zho:东 (dōng), yue:東 (dōng), vie:đông, kor:동 (dong), tur:doğu|east (orient)|east (orient)|éste|este (leste)|восток (ост)||东|東|동|đông|पूर्व|পূর্ব|timur|mashariki|doğu|oriento|itä|wschód
+dung di||||eastern||oriental||||||||||||||itäinen|wschodni
+dung gorila|bio|Gorilla beringei||eastern gorilla||gorila oriental||восточная горилла|||ヒガシゴリラ|||||||||idängorilla|goryl wschodni
+Dung Timor|desha|TL||East Timor (Timor-Leste)||Timor Oriental||||||||||||||Itä-Timor|Timor Wschodni (Demokratyczna Republika Timoru Wschodniego)
 donjon ventur|||eng:dungeon, fra:donjon, jpn:ダンジョン (danjon)|dungeon crawl||juego de mazmorras|||||ダンジョンアドベンチャー|||||||||luolaseikkailu|przygoda w lochu
 dosha|||may:dosa, hin:दोष (doś), tha:โทษ (toot(sa))|fault (sin, blame, defect, guilt)||culpa (defecto, crimen)|||||||||||||kulpo|vika (synti)|wina, grzech; defekt, wada
 dosha di||||guilty||culpable|||||||||||||kulpa|syyllinen|winny
@@ -1195,7 +1195,7 @@ fem ben||||daughter||hija|||||||||||||filino|tyttölapsi|córka
 fem raja||||queen||reina|||||女王|||||||||kuningatar|królowa
 fem sim||||feminism||feminismo||||||||||||||feminismi|feminizm
 fem sim ja||||feminist||feministe||||||||||||||feministi|feminista (feministka)
-fen|||zho:分 (fèn), wuu:分 (fén), yue:分 (fan), vie:phần, tha:ปัน (pan), jpn:分 (bun), kor:분 (bun)|part (component, segment, fraction, distinct element of something larger)|part|parte (fracción)|parte|parte||部分|部分|부분|phần|अंश|অংশ |suku (bagian)|sehemu|parça|parto (frakcio)|osa (lohko, pala)|część, ułamek
+fun|||zho:分 (fēn), wuu:分 (fén), yue:分 (fan), vie:phần, tha:ปัน (pan), jpn:分 (bun), kor:분 (bun)|part (component, segment, fraction, distinct element of something larger)|part|parte (fracción)|parte|parte||部分|部分|부분|phần|अंश|অংশ |suku (bagian)|sehemu|parça|parto (frakcio)|osa (lohko, pala)|część, ułamek
 fen di||||partial||parcial|||||部分的|||||||||osittainen|
 fen gata||||analysis (dissection)|analyse|análisis (disección)|análise|анализ||分析|分析 (解析)|||विश्लेषण||||analiz|analizo|analyysi|analiza
 fendona||||contribute||contribuir||||||||||||||osallistua (tehdä osansa)|wnieć wkład (przyczynić się)
@@ -1290,8 +1290,8 @@ fuku|||zho:服 (fú), yue:服 (fuk6), jpn:服 (fuku), kor:의복 (uibok), vie:y 
 fuku||||wear (dress, put on)|porter (s’habiller)|llevar (verstirse)|trajar (vestir-se)|носить (одеваться)||穿|着る|입다|mặc|पहनना||pakai|kuvaa||vesti (surporti)|pukeutua (pitää vaatetta yllään)|nosić ubrania
 fuku di||||clothed (dressed)||vestido (llevando ropa)||оде́тый||||||||||||vaatetettu (pukeutunut)|
 fuku vashi gi||||washing machine||lavadora||стиральная машина||洗衣机|洗濯機||||||||lavmaŝino|pesukone|pralka
-fun|||zho:粉 (fěn), hak:粉 (fun), tha:ฝุ่น (fùn)|dust (powder)||polvo|||||||||||||polvo|pöly (tomu)|pył
-fun chupa gi|||zho:吸尘器 (xīchénqì), deu:Staubsauger|vacuum cleaner||aspiradora||||||||||||||pölynimuri|odkurzacz
+fen|||zho:粉 (fěn), hak:粉 (fun), tha:ฝุ่น (fùn)|dust (powder)||polvo|||||||||||||polvo|pöly (tomu)|pył
+fen chupa gi|||zho:吸尘器 (xīchénqì), deu:Staubsauger|vacuum cleaner||aspiradora||||||||||||||pölynimuri|odkurzacz
 fungu|||eng:fungus, fra:fongus, por:fungo, spa:hongo + zho:菇 (gū), yue:菇 (gu1)|fungus (mushroom)||hongo (moho)|fungo||||||||||||fungo|sieni|grzyb
 fungu frute||||mushroom (sporocarp)|champignon|champiñón (seta)|cogumelo|гриб||蘑菇|茸|||कुकुरमुत्ता (खुंबी, छत्रक)||cendawan|uyoga|||sienen hattu|sporokarp
 fungu nete||||mycelium|mycélium|micelio|||||菌糸体|||||||||sienirihmasto|grzybnia
@@ -2604,7 +2604,7 @@ move||||motion (movement)||movimiento|||||||||||||movo|liike|ruch
 Mozambike|desha|MZ||Mozambique||Mozambique||||||||||||||Mosambik|Mozambik
 mudan||biwe|zho:牡丹 (mǔdān), kor:모란 (moran), jpn:(botan), vie:mẫu đơn|peony||peonía||||||||||||||pioni|piwonia
 muka|||ben:মুখ (mukh), hin:मुख (mukh), tam:முகம் (mukam), tel:(mukhamu), may:muka, tgl:mukha|face|visage|cara (rosto)||||||||||muka|||vizaĝo|kasvot (naama)|twarz
-muka fun||||face powder||polvo de cara||||||||||||||puuteri|puder
+muka fen||||face powder||polvo de cara||||||||||||||puuteri|puder
 mula|||hin:mar:मूल (mūl), ben:মূল (mūl), tel:మూలము (mūlamu), may:tgl:mula, khm:មូល (mul), mya:မူလ (mula), tha:มูล (mun)|root|racine|raíz|raíz|корень|جَذْر|根|根|뿌리|rễ|मूल (जड़)|মূল|akar|mzizi|kök|radiko|juuri|korzeń
 multi|||por:muito, eng:fra:spa:multi-, rus:мульти- (mulʹti-)|many (much)||muchos|||||多い|||||||||moni (usea)|wiele
 multi ta||||number (abundance)||número (muchedumbre)|||||||||||||||liczność (mnóstwo)
@@ -3455,8 +3455,8 @@ shefe di||||main (principal)||principal||||||||||||||pää-|główny
 shefe minister||||prime minister||primer ministro|||||||||||||ĉefministro|pääministeri (suurvisiiri)|premier
 sheku|||zho: 石 (shí), yue:石 (sek3), jpn:石 (seki), kor:석 (seok)|stone (piece of rock)|pierre|piedra|pedra|камень (камешек)||石 (岩)|||||||||ŝtono|kivi (hippu)|kamień (kawał skały)
 sheku jang ja||||mason (stonemason, stonecutter)||albañil (mampostero, cantero)|||||石匠||||||||||kamieniarz
-sheng|||zho:胜 (shèng), yue:勝 (sing3), wuu:勝 (sen2), jpn:勝 (shō), kor:승 (seung), vie:thắng|victory (win, triumph)||victoria|||||||||||||venko|voitto|zwycięstwo, wygrana
-sheng bai||||outcome (victory or defeat)||||||勝敗|勝敗||||||||||
+shang|||zho:胜 (shèng), yue:勝 (sing3), wuu:勝 (sen2), jpn:勝 (shō), kor:승 (seung), vie:thắng|victory (win, triumph)||victoria|||||||||||||venko|voitto|zwycięstwo, wygrana
+shang bai||||outcome (victory or defeat)||||||勝敗|勝敗||||||||||
 shi|||zho:氏 (shì), yue:氏 (si6), jpn:氏 (-shi), kor:씨 (ssi) + may:si + hin:श्री (śrī), ben:শ্রী  (śri)|Mx. (Mr. or Ms.)|||||||さん (氏)|||श्री|শ্রী|||||herra tai rouva|
 shia|||ara: شِيعَة (šīʿa), heb: סִיעָה (si'á) + zho:系 (xì)|faction (clique)|faction (clique)|facción|facção|фракция (клика)|شيعة|派系||||||||||porukka (kuppikunta, lohko, siipi)|
 shia islam din||||Shia Islam (Shi’ism)|chiisme|chiismo (chía)|xiismo|шиизм|الشِّيعَة‎|什叶派|シーア派|||शिया|||||ŝijaismo|šiialaisuus|szyism
@@ -3577,7 +3577,7 @@ sona|||fra:sommeil, por:sono, rus:сон (son), hin:सोना (sonā), ben:�
 sona kamar||||bedroom|chambre à coucher|dormitorio|quarto (dormitório)|спальня||卧室 (寝室)|寝室|침실|phòng ngủ|शयनकक्ष||kamar tidur|chumba cha kulala|yatak odası|dormoĉambro|makuuhuone|sypialnia
 sona papi|bio|Papaver somniferum|eng:poppy, spa:amapola, por:papoula, swa:mpopi, hin:पॉपी (pŏpī), ben:পপি (papi), jpn:ポピー (popī)|opium poppy|pavot somnifère|adormidera (amapola real)|papoila-dormideira|мак снотворный||鴉片罌粟|ケシ||||||mpopi|||unikko (unikukka)|mak lekarski
 sona tabi||||drowsy|ensommeillé (somnolent)|soñoliento (somnífero)|sonolento|сонный|||||||||||dormema|unelias|
-song|bio|Pinus|zho:松 (sōng), wuu:(son), tha:สน (sǒn), kor:솔 (sol), vie:thông, + rus:сосна (sosna)|pine tree||pino|pinheiro|сосна||松|マツ|||चीड़|||||pino|mänty|sosna
+sung|bio|Pinus|zho:松 (sōng), wuu:(son), tha:สน (sǒn), kor:솔 (sol), vie:thông, + rus:сосна (sosna)|pine tree||pino|pinheiro|сосна||松|マツ|||चीड़|||||pino|mänty|sosna
 soni|||eng:sonic, fra:son, spa:son,sonido, por:som, ita:suono, + kor:소리 (sori) + zho:声 (shēng), wuu:声 (sən)|sound (audio)|son|sonido (audio)|som||||||||||||sono|ääni|dźwięk, brzmienie
 sor|||zho:锁 (suǒ), yue:鎖 (so2), wuu:鎖 (su2), jpn:錠 (jō), khm:សោ (sao), spa:cierre, fra:serrure, hun:zár|lock (fastener)|serrure|cerradura (candado)|fechadura|замок||锁|錠||||||||||zamek (zapięcie)
 sor di||||locked (secure)||||запереть|||||||||||||zamknięty (zakluczony, zapięty, bezpieczny)
@@ -4022,10 +4022,10 @@ yoga ja||||yogi||yogui||||||||||||||joogi|jogin (joginka)
 yogo|||eng:yoke, spa:yugo, por:jugo, fra:joug, rus:иго (igo), fas:  یوغ‎ (yuğ) + yue:軛 (aak1), vie:ách|yoke|joug|yugo|jugo|ярмо (иго)||轭|軛||ách|जुआ|জোয়াল|||boyunduruk|jugo|ies|jarzmo
 yogur|||eng:may:yogurt, fra:yogourt, spa:yogur, por:iogurte, rus:йогурт (yogurt), zho:优格 (yōugé), jpn:ヨーグルト (yōguruto), kor:요구르트 (yogureuteu), tur:yoğurt |yogurt|yaourt (yogourt)|yogur|iogurte|йогурт|لَبَن|酸奶 (优格)|ヨーグルト|요구르트|sữa chua|दही|দই|yogurt|maziwa ya mgando|yoğurt|jogurto|jogurtti|jogurt
 Yohan festa||||Saint John's Day||día de San Juan||Иванов день||||||||||||juhannus (kristillinen juhla)|dzień świętego Jana
-yong|||zho:溶 (róng), yue:溶 (jung4), jpn:溶 (yō), kor:용 (yong), vie:dung|melt|melt|derretirse|derretre|||融化|溶ける|||||||||sulaa|topnieć (upłynniać się)
-yong liga||||fusion (amalgamation)||fusión||||||||||||||fuusio (yhteensulautuminen)|fuzja (amalgamowanie, łączenie)
-yong petra||||lava|lave|lava||||熔岩|溶岩|||||||||laava|lawa
-yong safa||||smelt|fondu|||||熔炼|||||||||||topić (upłynnić, upłynniać)
+yung|||zho:溶 (róng), yue:溶 (jung4), jpn:溶 (yō), kor:용 (yong), vie:dung|melt|melt|derretirse|derretre|||融化|溶ける|||||||||sulaa|topnieć (upłynniać się)
+yung liga||||fusion (amalgamation)||fusión||||||||||||||fuusio (yhteensulautuminen)|fuzja (amalgamowanie, łączenie)
+yung petra||||lava|lave|lava||||熔岩|溶岩|||||||||laava|lawa
+yung safa||||smelt|fondu|||||熔炼|||||||||||topić (upłynnić, upłynniać)
 Yoruba|nas|||Yoruba (language and people)|||||||||||||kiyoruba|||joruban kansa ja kieli|Joruba
 yota|nomer||eng:fra:spa:por:yotta, may:yota-, zho:尧它- (yáotā-), jpn:ヨタ- (yota-), kor:요타- (yota-)|yotta-||||||||||||||||kvadriljoona (jotta-)|
 yumor|||rus:юмор (yumor), spa:eng:humor, fra:humour, jpn:ユーモア (yūmoa), kor:유머 (yumeo), zho:幽默 (yōumò)|humor||humor (gracia)||юмор|||||||||||humuro|huumori|humor
@@ -4077,8 +4077,8 @@ zoku|||wuu:续 (zoq), yue:續 (zuk6), jpn:続 (zoku), kor:속 (sok), vie:kế t�
 zoku di||||continuous (analog)|continu (analogique)|continuo (analógico)|analógico|||指针式的|アナログ|||||||||jatkuva (analoginen)|ciągły (analogowy)
 zombi|||kon:nzambi, eng:zombie, spa:tur:zombi, por:zumbi, rus:зомби (zombi), ara:زُومْبِي‎ (zūmbī), hin:ज़ोंबी (zombī), jpn:ゾンビ (zonbi), kor:좀비 (jombi)|zombie|zombi|zombi|zumbi|||||||ज़ोंबी||||||zombi|zombie, zombi
 zona|||ell:ζώνη (zónē), eng:fra:zone, spa:por:zona, rus:зона (zona)|belt (zone)|zone|cinturón (zona)|zona|пояс (зона)|||||||||||zono|vyö|pas, strefa
-zong|||zho:樁 (zhuāng), yue:樁 (zong1), nan:樁 (zuang1), jpn:樁 (shō), vie:thưởng|post (stake, peg, skewer)|pieu (poteau)|poste (estaca, palo)|poste (estaca)|кол||桩|杭|||||||||tanko (pinna, tolppa, paalu)|słup (pal, kołek)
-zong minte|bio|Mentha spicata||spearmint|menthe verte|hierbabuena|hortelã-verde|мята колоси́стая||留兰香|スペアミント||||||||||mięta zielona (mięta kłosowa)
+juang|||zho:樁 (zhuāng), yue:樁 (zong1), nan:樁 (zuang1), jpn:樁 (shō), vie:thưởng|post (stake, peg, skewer)|pieu (poteau)|poste (estaca, palo)|poste (estaca)|кол||桩|杭|||||||||tanko (pinna, tolppa, paalu)|słup (pal, kołek)
+juang minte|bio|Mentha spicata||spearmint|menthe verte|hierbabuena|hortelã-verde|мята колоси́стая||留兰香|スペアミント||||||||||mięta zielona (mięta kłosowa)
 zou|||eng:fra:spa:por:may:tur:zoo-, rus:зоо- (zoo-)|animal|animal (bête)|animal (bestia)|animal (besta, bicho)|животное||动物|動物|동물|thú vật (động vật)|जानवर (हैवान)|জানোয়ার|kewan|mnyama|hayvan|besto|eläin|animal
 zou agro shuta||||animal husbandry|élevage||||||畜産|||||||||karjanhoito|hodowla zwierząt
 zou bagi||||zoo (zoological garden)|zoo|zoo|zoológico|зоопарк||动物园|動物園|동물원|thảo cầm viên|चिड़ियाघर|চিড়িয়াখানা|kebun binatang|bustani ya wanyama|hayvanat bahçesi|zoo (bestoĝardeno)|eläintarha|zoo (ogród zoologiczny)

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -1248,8 +1248,8 @@ fon loga||||pronounce (articulate)||||||||||||||||ääntää (lausua)|
 fon logi||||phonology||fonología||||||||||||||fonologia (äänneoppi)|fonologia
 fon so||||phoneme||fonema||||||||||||||äänne (foneemi)|fonem
 fon zi||||letter (character, written symbol)||letra (carácter)|||||||||||herufi|harf|litero|kirjain|litera, znak
-fong|bio||zho:蜂 (fēng), yue:蜂 (fung1), wuu:蜂 (fon1), kor:봉 (bong), vie:ong, tha:ผึ้ง (pʉ̂ng), lao:ເຜິ້ງ (phœng)|bee or wasp|abeille ou guêpe|abeja o avispa|abelha ou vespa|||蜂|蜂||||||||abelo aŭ vespo|mehiläinen tai ampiainen|pszczoła lub osa
-fong nide||||bee nest (beehive, wasp's nest)|ruche (nid d'abeille)|avispero (colmena)|||||蜂の巣|||||||||mehiläispesä|ul (gniazdo pszczół lub os)
+fung|bio||zho:蜂 (fēng), yue:蜂 (fung1), wuu:蜂 (fon1), kor:봉 (bong), vie:ong, tha:ผึ้ง (pʉ̂ng), lao:ເຜິ້ງ (phœng)|bee or wasp|abeille ou guêpe|abeja o avispa|abelha ou vespa|||蜂|蜂||||||||abelo aŭ vespo|mehiläinen tai ampiainen|pszczoła lub osa
+fung nide||||bee nest (beehive, wasp's nest)|ruche (nid d'abeille)|avispero (colmena)|||||蜂の巣|||||||||mehiläispesä|ul (gniazdo pszczół lub os)
 fonte|||por:fonte, spa:fuente, rus:фонтан (fontan), fra:fontaine, eng:fountain, jpn:噴水 (funsui)|fountain (spring, well)||fuente (manantial)||||||||||||||lähde (kaivo)|fontanna (studnia, źródło)
 fonte kalam||||fountain pen|stylo-plume|estilógrafo|caneta de tinta permanente|авторучка||钢笔||||||||||mustekynä|
 fora|||fra:forer, por:furar, eng:perforate, spa:perforar|drill (bore, perforate)|forer (percer)|taladrar (perforar)|furar (perfurar)|сверлить (бурить)||钻孔|||||||||taladri|porata|wiercić, borować
@@ -2455,9 +2455,9 @@ medi gi||||instrument (means)||medio (instrumento)|meio (instrumento)|средс
 medi noche||||midnight|minuit|medianoche|meia-noite|полночь|مُنْتَصَف اَللَّيْل‎|半夜 (午夜)|真夜中|자정|nửa đêm|मध्यरात|মধ্যরাত|tengah malam||gece yarısı|noktmezo|keskiyö (puoliyö)|północ
 medi she||||medium (media)||medio||||||||||||||media|media
 medu|||rus:мёд (myod), hin:मधु (madhu), ben:মধু (môdhu), may:madu + por:mel, fra:spa:miel + yue:蜜 (mat6)|honey|miel|miel|mel|мёд||蜜|蜂蜜|꿀 (밀)|mật ong|मधु (शहद)|মধু|madu (air lebah)|uki|bal|mielo|hunaja|miód
-medu fong|bio|Apis||honeybee||abeja||||蜜蜂|蜜蜂|벌 (밀봉)|ong|मधुमक्खी|মৌমাছি|lebah (tawon)|nyuki|arı|abelo|mehiläinen|pszczoła miodna
-medu fong nide||||beehive (honeycomb)|rayon de miel|colmena (panal)||улей (соты)|||蜂の巣 (ハニカム)|||||sarang lebah|sega|||mehiläispesä|plaster
-medu fong sanduku||||beehive (beehouse)||||||蜂箱|養蜂箱||||||||||ul
+medu fung|bio|Apis||honeybee||abeja||||蜜蜂|蜜蜂|벌 (밀봉)|ong|मधुमक्खी|মৌমাছি|lebah (tawon)|nyuki|arı|abelo|mehiläinen|pszczoła miodna
+medu fung nide||||beehive (honeycomb)|rayon de miel|colmena (panal)||улей (соты)|||蜂の巣 (ハニカム)|||||sarang lebah|sega|||mehiläispesä|plaster
+medu fung sanduku||||beehive (beehouse)||||||蜂箱|養蜂箱||||||||||ul
 mega|nomer||eng:fra:spa:por:may:tur:mega-, rus:мега- (mega-), jpn:メガ (mega), kor:메가- (mega-)|million (mega-)||millón (mega-)||||百万 (兆)|１００万 (メガ)||||||||miliono|miljoona (mega-)|milion
 mega gram|unomete|t, Mg||tonne (metric ton)||tonelada||||||||||||||tonni (1000 kg)|tona
 mega vate|unomete|MW||megawat (MW)||megavatio||||||||||||||megawatti (MW)|megawat
@@ -3985,8 +3985,8 @@ ya|||spa:por:eng:-ia, rus:-ия (-iya), ara: ية (-iya), jpn:屋 (-ya)|area of 
 ya su||||his or her||||||他的|||||||||lia aŭ ŝia aŭ ĝia|hänen (sen)|
 Yahve||||Yahweh (Jehovah)|Yahweh (Jéhovah)|Yahvé (Jehová)|Javé (Jeová)|Яхве (Иегова)|يَهْوَه|耶和华 (雅威)|ヤハウェ (エホバ)|야훼 (여호와)|||||Yehova||Javeo (Jehovo)|Jahve (Jehova)|
 yake|||eng:deu:fra:spa:tur:yak, por:iaque, hin:याक (yāk)|yak||yac||||||||||||||jakki|jak (zwierzę)
-yaki|||kor:약 (yak), jpn:約 (yaku), yue:約 (yœk), tur:yaklaşık, zho:约 (yuē)|about (approximately, nearly, almost)||aproximadamente||||||||||||||noin (arviolta, suunnilleen)|około; przybliżony
-yaki nesi||||peninsula||península||||||||||||||niemi|półwysep
+yeki|||kor:약 (yak), jpn:約 (yaku), yue:約 (yœk), tur:yaklaşık, zho:约 (yuē)|about (approximately, nearly, almost)||aproximadamente||||||||||||||noin (arviolta, suunnilleen)|około; przybliżony
+yeki nesi||||peninsula||península||||||||||||||niemi|półwysep
 yam|||khm:ញ៉ាំ (nyam), ful:nyami, + spa:ñam, rus:ням (nyam), ita:gnam, eng:yum, kor:냠냠 (nyamnyam), hun:nyam|consume (eat or drink)||comer (bebir)|||||食べる||||||||manĝi (trinki)|nauttia (syödä, juoda)|skonsumować, konsumować, zjeść, jeść, wypić, pić)
 yam fito||||vegetable|légume|verdura (legumbre)|verdura (hortaliça, legume)|овощ||蔬菜||||सब्ज़ी|সবজি|||sebze|legomo|kasvis|warzywo
 yam kamar||||dining room||comedor|||||||||||||manĝoĉambro|ruokasali|jadalnia


### PR DESCRIPTION
I propose a scheme to encode Mandarin tones in Pandunia words that end in sonorants.  Chinese vowels are weerd, and don't map very well to Pandunia vowels -- especially the Mandarin ⟨e⟩.  we can map them regularly in a way that also encodes tonal informacion, which would help distinguish similar syllables inthe absence of adding vowels to the ends of them.  specifically, I suggest mapping:

- en1/2 -> un
- en3 -> en
- en4 -> an
- eng1/2 -> ung
- eng3 -> eng
- eng4 -> ang
- ong1/2 -> ung
- ong3/4 -> ong

a lot of informacion is still lost, but this is more regular than the current system, and allows for a distinction between 分 (fen1), 粉 (fen3), and 糞 (fen4), as well as 中 (zhong1) and 種 (zhong3).

to be completely regular, stop-final syllables with ⟨e⟩ should also change their central vowels according to tone.  that is, **yaki** should be **yiki**, **daku** should be **duku**, and **keka** should be **kaka**.  however, these are all bad for various reasons, so I think they should all just stick with **e**.