### PR TITLE
uze la nove kanun do fa hapu la han loga

### DIFF
--- a/english/403_loga_hapu.md
+++ b/english/403_loga_hapu.md
@@ -129,9 +129,9 @@ Additional specifications for initials that have incomplete set of finals (i.e. 
 |        | (1)    | (2)  | (3)    |
 |--------|--------|------|--------|
 | Tone 1 | bon, … | fon  | gon, … |
-| Tone 2 | bun, … | fun  |        |
-| Tone 3 |        | fun  |        |
-| Tone 4 |        | fen  | gen, … |
+| Tone 2 | bun, … |      | gon, … |
+| Tone 3 | bun, … | fun  | gon, … |
+| Tone 4 | bon, … | fen  | gen, … |
 
 
 #### Finals with -ng
@@ -153,6 +153,6 @@ Additional specifications:
 |--------|---------|---------|
 | Tone 1 | bong, … | dong, … |
 | Tone 2 | bung, … | dung, … |
-| Tone 3 |         |         |
-| Tone 4 | beng, … |         |
+| Tone 3 | bung, … | dung, … |
+| Tone 4 | beng, … | dong, … |
 

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -552,7 +552,7 @@ chen fikse||||prefix||prefijo||||||||||||||etuliite (prefiksi)|przedrostek (pref
 chen ga||||assume (presuppose)||presuponer||||||||||||||edellyttää|zakładać (założyć)
 chen vide||||expect (anticipate, predict, forsee)||prever (esperar, pensar)|||||待ち受ける (見込む)|||||||||ennustaa (nähdä ennalta)|przewidzieć (spodziewać się)
 chen vide di||||expected||||||||||||||||ennustettu|spodziewany (przewidziany)
-chen yanga di||||classic (classical)||clásico|||||古典的|||||||||klassinen|klasyczny
+chen yang di||||classic (classical)||clásico|||||古典的|||||||||klassinen|klasyczny
 chen zaman||||past times||pasado|||||||||||||pasinteco|menneisyys|przeszłość
 chen zaman di||||old (ancient, former)|vieux (ancien)|viejo (antiguo)|velho (antigo)|старый (древний)||古老 (以前)|古い|||पुराना|পুৰণা|||eski (kadim)|malnova|vanha (muinainen)|stary, starożytny
 chen zaman she||||relic||reliquia||||||||||||||muinaisjäänne|relikwia
@@ -1959,7 +1959,7 @@ ke multi di||||how many?||cuántos|||||||||||||kiom?|montako? (paljonko?)|ile?
 ke riti||||how?|comment|cómo|como|как||怎么|どのように|어떻게||कैसे|কিভাবে|bagaimana|-je|nasıl|kiel?|miten?|kiedy?
 ke sate||||when?|quand|cuándo|quando||||何時|||||kapan|lini|ne zaman|kiam?|milloin? (koska?)|zapytać, pytać
 ke she||||what thing?||cuál cosa|||||何事||||||||kio?|mikä? (mitä?)|jak?
-ke yanga||||what kind of?||qué tipo de|||||どんな||||||||kia?|millainen?|jaki?
+ke yang||||what kind of?||qué tipo de|||||どんな||||||||kia?|millainen?|jaki?
 kechape|||yue:茄汁 (kezap), eng:ketchup, hin:केचप (kecap), rus:кетчуп (ketčup), jpn:ケチャップ (kechappu), tgl:ketsap|ketchup||kétchup|||||||||||||keĉupo|ketsuppi|keczup
 kechi|||zho:客气 (kèqì), yue:客氣 (haak3 hei3), wuu:客氣 (khaq qi4)|polite||educado||||客气|||||||||ĝentila|kohtelias (kiltti)|uprzejmy
 keka|||zho:客 (kè), wuu:客 (ka’), jpn:客 (kyaku), kor:객 (gaek), vie:khách, tha:แขก (khæk)|visitation (visit)||visitar|||||||||||||viziti|käynti (vierailu, visiitti)|wizyta
@@ -2793,7 +2793,7 @@ nove ka||||novice (newbie)|néophyte|novato|novato (neófito)|новичок||�
 Nove Kaledonia|desha|NC||New Caledonia||Nueva Caledonia||||||||||||||Uusi-Kaledonia|Nowa Kaledonia
 nove loga||||neologism|néologisme|neologismo|neologismo|неологизм||新词|新語 (新造語)|신어 (신조어)||||||yenici deyim|neologismo|uudissana|neologizm
 nove ta||||newness|nouveauté|novedad|novidade|новизна||||||||||yenilik|noveco|uutuus|
-nove yanga di||||modern||moderno|||||近代的||||||||||nowoczesne
+nove yang di||||modern||moderno|||||近代的||||||||||nowoczesne
 Nove Yorke||||New York|||||||||||||||||Nowy Jork
 Nove Yorke siti|site|US||New York City|||||||||||||||||Stan Nowy Jork
 Nove Zelande|desha|NZ||New Zealand||Nueva Zelanda||||||||||||||Uusi-Seelanti|Nowa Zelandia

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -87,7 +87,7 @@ ampul|||fra:eng:ampoule, zho:安瓿 (ānbù), jpn:アンプル (anpuru), rus:а
 an|||ell:ἀν- (an-), eng:un-, hin:अन- (an-), fra:spa:por:in-|reverse (negative, un-)|inverse (négatif, in-)||||||||||||||mala|vastakohtainen (negatiivinen, epä-)|negatywny (przeciwny, nie)
 an ai||||dislike (loathe)|exécrer|detestar|||||||||||||malami|inhota|
 an air bio di||||anaerobic|anaérobique|anaeróbico|anaeróbico|||厌氧的|嫌気性|||||||||anaerobinen|
-an chenu vide di||||unexpected||||||||||||||||ennennäkemätön|niespodziewany
+an chen vide di||||unexpected||||||||||||||||ennennäkemätön|niespodziewany
 an daka||||uncover (reveal)||destapar||||||||||||||paljastaa|odsłonić, odsłaniać
 an deu sim ja||||atheist|athée|ateo|||||||||||||ateisto|ateisti (jumalankieltäjä)|ateista
 an din ja||||unbeliever (infidel)|infidèle (incroyant)|infiel (descreído)|infiel|неверующий|كافر|不信神的|不信者|불신자||नास्तिक (काफ़िर)||||kafir|malkredulo|uskonnoton|niewierny
@@ -317,7 +317,7 @@ be boi||||float (swim)|nagar (flotter)|nadar (flotar)|nadar (flutuar)|плава
 be boli|||eng:boil, fra:bouillir, ita:bollire, zul:-bila, sot:-bela, hin:उबालना (ubālnā)|boil (be boiled)||hervirse (ser cocida)|||||||||||||boli|kiehua|ugotować się, gotować się
 be bum||||explode (blow up)||explotar (estallar)||взрываться|||爆発する|||||||||räjähtää|eksplodować (wybuchnąć, wybuchać)
 be bum||||explode|exploser (détoner)|explosionar|explodir|взрываться|||||||||||eksplodi|räjähtää|
-be chenu||||predate (be before)||preceder (anteceder)|||||||||||||antaŭiri|edeltää (olla ennen)|poprzedzić, poprzedzać
+be chen||||predate (be before)||preceder (anteceder)|||||||||||||antaŭiri|edeltää (olla ennen)|poprzedzić, poprzedzać
 be dai||||grow (get bigger)||crecer (aumentar)||||||||||||||kasvaa (suurentua)|urosnąć, rosnąć, wzrosnąć, wzrastać
 be dara||||flow||fluir||||||||||||||virrata|latać (fruwać)
 be dom||||live in (reside in, inhabit)|vivre (habiter)|vivir (residir)|||||住む (居住する)||||||||loĝi|asua|mieszkać
@@ -545,17 +545,17 @@ chape|||hin:छाप (chāp), ben:ছাপ (chap), may:cap, eng:chop|print (st
 charme|||fra:por:charme, eng:charm, rus:шарм (šarm)|charm (attraction)|charme|encanto|charme|шарм||||||||||||vetovoima (šarmi)|czar (urok, wdzięk)
 chati|||hin:छत (chat); छदि (chadi), ben: ছাদ (chad), tur:çatı, kyr:чатыр (čatyr) + ara: سَطْح‎ (saṭḥ)|roof|toit|techo (tejado)|telhado|крыша (кров)|سَطْح‎|屋顶 (房顶)|屋根|지붕|mái|छत (छदि)|ছাদ|atap|paa|çatı|tekto|katto (katos)|dach
 cheke|||eng:check, spa:chequear, por:checar, deu:chekcen, jpn:チェックする (chekkusuru)|examine (inspect, check)||revisar (chequear, examinar, inspeccionar)||||检查|||||||||kontroli|tarkistaa (tsekata, tutkia)|sprawdzić, sprawdzać, skontrolować, kontrolować, zbadać, badać
-chenu||||previous (fore)||previo (anterior)||||||||||||||edellinen|poprzedni
-chenu|||zho:前 (qián), yue:前 (cin4), jpn:前 (zen), kor:전 (jeon), vie:tiền|earlier (before, in the past)|avant|más temprano (antes, haber, en el pasado)||раньше||以前|以前 (前に)|전에|||||||antaŭe (pasinte)|ennen (aikaisemmin, aiemmin)|wcześniej (uprzednio, poprzednio, przedtem)
-chenu den||||yesterday|hier|ayer|ontem|вчера|أمس|昨日|昨日|어제 (작일)|hôm qua|कल||kemarin|jana|dün|hieraū|eilen|wczoraj
-chenu fikse||||prefix||prefijo||||||||||||||etuliite (prefiksi)|przedrostek (prefiks)
-chenu ga||||assume (presuppose)||presuponer||||||||||||||edellyttää|zakładać (założyć)
-chenu vide||||expect (anticipate, predict, forsee)||prever (esperar, pensar)|||||待ち受ける (見込む)|||||||||ennustaa (nähdä ennalta)|przewidzieć (spodziewać się)
-chenu vide di||||expected||||||||||||||||ennustettu|spodziewany (przewidziany)
-chenu yanga di||||classic (classical)||clásico|||||古典的|||||||||klassinen|klasyczny
-chenu zaman||||past times||pasado|||||||||||||pasinteco|menneisyys|przeszłość
-chenu zaman di||||old (ancient, former)|vieux (ancien)|viejo (antiguo)|velho (antigo)|старый (древний)||古老 (以前)|古い|||पुराना|পুৰণা|||eski (kadim)|malnova|vanha (muinainen)|stary, starożytny
-chenu zaman she||||relic||reliquia||||||||||||||muinaisjäänne|relikwia
+chen||||previous (fore)||previo (anterior)||||||||||||||edellinen|poprzedni
+chen|||zho:前 (qián), yue:前 (cin4), jpn:前 (zen), kor:전 (jeon), vie:tiền|earlier (before, in the past)|avant|más temprano (antes, haber, en el pasado)||раньше||以前|以前 (前に)|전에|||||||antaŭe (pasinte)|ennen (aikaisemmin, aiemmin)|wcześniej (uprzednio, poprzednio, przedtem)
+chen den||||yesterday|hier|ayer|ontem|вчера|أمس|昨日|昨日|어제 (작일)|hôm qua|कल||kemarin|jana|dün|hieraū|eilen|wczoraj
+chen fikse||||prefix||prefijo||||||||||||||etuliite (prefiksi)|przedrostek (prefiks)
+chen ga||||assume (presuppose)||presuponer||||||||||||||edellyttää|zakładać (założyć)
+chen vide||||expect (anticipate, predict, forsee)||prever (esperar, pensar)|||||待ち受ける (見込む)|||||||||ennustaa (nähdä ennalta)|przewidzieć (spodziewać się)
+chen vide di||||expected||||||||||||||||ennustettu|spodziewany (przewidziany)
+chen yanga di||||classic (classical)||clásico|||||古典的|||||||||klassinen|klasyczny
+chen zaman||||past times||pasado|||||||||||||pasinteco|menneisyys|przeszłość
+chen zaman di||||old (ancient, former)|vieux (ancien)|viejo (antiguo)|velho (antigo)|старый (древний)||古老 (以前)|古い|||पुराना|পুৰণা|||eski (kadim)|malnova|vanha (muinainen)|stary, starożytny
+chen zaman she||||relic||reliquia||||||||||||||muinaisjäänne|relikwia
 cheng|||zho:层 (céng), yue:層 (cang4), wuu:層 (zen3), kor:층 (chŭng), vie:tầng|layer (level, storey, floor, stratum)||capa (piso, planta, estrato)||||层||||||||||kerros|warstwa (poziom, piętro, kondygnacja)
 cheng bede||||bunk bed|lits superposés|litera|beliche|двухъярусная кровать||双层床||2층침대||||||ranza||kerrossänky|
 cheri|pal||eng:cherry, fra:cerise, spa:cereza, por:cereja, rus:черешня (čerešnya), ara:(karaz), tur:kiraz, hin:गिलास (gilās), ben:চেরি  (ceri), may:ceri, jpn:チェリー (cherī), kor:체리 (cheri)|cherry|cerise|cereza|cereja|черешня||||||गिलास|চেরি|||||kirsikka|wiśnia (czereśnia)
@@ -574,9 +574,9 @@ chin gam ben||||step-sibling||||||||||||||||sisaruspuoli|
 chin ma||||grandmother|grand-mère|abuela|avó|бабушка|جَدَّة‎||お婆さん||||||||avino|isoäiti|babcia (babka)
 chin pa||||grandfather|grand-père|abuelo|avô|дедушка|جَدّ‎||||||||||avo|isoisä|dziadek (dziad)
 chinchila|bio||eng:spa:fra:chinchilla, por:chinchila, rus:шиншилла (šinšilla), tur:çinçilya, may:cincila, jpn:チンチラ (chinchira)|chinchilla||chinchilla|||||||||||||ĉinĉilo|chinchilla|szynszyla
-chingo||||request (petition)||||||||||||||||pyyntö|
-chingo|||zho:请 (qǐng), yue:請 (cing2), kor:청 (cheong), vie:thỉnh|ask (request, beg, plead; please)||pedir (invitar; por favor)||просить||请|請う (ーて下さい)||||||||peti (bonvolu)|pyytää (anoa)|prosić
-chingo lai||||invite||invitar|||||||||||||inviti|pyytää tulemaan|zaprosić, zapraszać
+ching||||request (petition)||||||||||||||||pyyntö|
+ching|||zho:请 (qǐng), yue:請 (cing2), kor:청 (cheong), vie:thỉnh|ask (request, beg, plead; please)||pedir (invitar; por favor)||просить||请|請う (ーて下さい)||||||||peti (bonvolu)|pyytää (anoa)|prosić
+ching lai||||invite||invitar|||||||||||||inviti|pyytää tulemaan|zaprosić, zapraszać
 chini|||zho:瓷 (cí) + eng:chinaware, hin:चीनी (cīnī), ben:চীনামাটি (cinamaṭi), ara: صِينِيَّة‎ (ṣīniyya), swa:sini|porcelain (chinaware)|porcelaine|porcelana|porcelana|фарфор|خَزَف‎|瓷器|磁器|도자기|sứ|चीनी (पॉर्सिलेन)|চীনামাটি|porselen|sini|porselen|porcelano|posliini|porcelana
 Chipe|desha|AL||Albania||Albania||||||||||||||Albania|Albania
 chira||||tear (rip, edge)|déchirer|rasgar (romper)|rasgar|рвать||撕裂|裂く|||||||||repeämä|rwać (drzeć)
@@ -721,7 +721,7 @@ din ja||||believer (religious person)|croyant|creyente|crente|верующий|�
 din shia||||sect (cult)|secte|secta (culto)|seita|секта|فِرْقَة‎|教派|教派|||||||mezhep|sekto|lahko (kultti)|
 dinamite|||eng:dynamite, spa:dinamita, rus:динамит (dinamit), tur:may:dinamit, ara:ديناميت (dinamit), hin:डायनामाइट (dāyanāmait), jpn:ダイナマイト (dainamaito)|dynamite|dynamite|dinamita|dinamite|динамит||甘油炸药|ダイナマイト|||||||||dynamiitti|dynamit
 dinde|bio|Meleagris|fra:dinde, rus:индюк (indyuk), tur:hindi, ara: دِيك هِنْدِيّ‎ (dīk hindiy)|turkey|dinde (dindon)|pavo (guajalote)|peru|индюк|دِيك رُومِيّ‎|火鸡|七面鳥|칠면조|gà tây|पीरू||kalkun (ayam belanda)|bata mzinga (piru)|hindi|meleagro|kalkkuna|indyk
-ding|||zho:钉 (dīng), yue:釘 (ding1), vie:đinh|nail (spike)||clavo (pincho, punta)||||钉子|||||||||najlo|naula (piikki)|kolec
+dingi|||zho:钉 (dīng), yue:釘 (ding1), vie:đinh|nail (spike)||clavo (pincho, punta)||||钉子|||||||||najlo|naula (piikki)|kolec
 dino saur||||dinosaur|dinosaure|dinosaurio|dinossauro|динозавр|دِينَاصَوْر‎|恐龙|恐竜|공룡|khủng long|डायनासोर (भीमसरट)|ডাইনোসর|dinosaurus||dinozor|dinosaŭro|dinosaurus (hirmulisko)|dinozaur
 Dione|planete 6 lun 4|||Dione||||||||||||||||Dione|
 diorite|||eng:fra:diorite, spa:diorita, rus:диорит (diorit), tur:diyorit, ara:ديوريت (dayurit), hin:डायोराइट (dāyorait), vie:may:diorit|diorite|diorite|diorita|diorito|диорит||闪长岩|閃緑岩|||||||||dioriitti|dioryt
@@ -1632,7 +1632,7 @@ hua|||zho:花 (huā), vie:hoa, kor:화 (-hwa-), swa:ua|flower|fleur|flor|flor|ц
 hua jara||||flower vase||florero||||花瓶|||lọ hoa|गुलदान (फूलदान)|||||vazo|kukkamaljakko|
 hua mosim|mosim|||spring (springtime)||primavera||весна|||春|||||musim bunga|||printempo|kevät|wiosna
 hua pote||||flowerpot|pot de fleur|maceta (plantera)|vaso de flores|цвето́чный горшок||花盆|植木鉢|화분|chậu hoa||||||florpoto|kukkaruukku|
-huangu|rang||zho:黄 (huáng), yue:黃 (wong4), wuu:黃 (húan), vie:vàng|yellow||amarillo|||||||||||||flava|keltainen|żółty
+huang|rang||zho:黄 (huáng), yue:黃 (wong4), wuu:黃 (húan), vie:vàng|yellow||amarillo|||||||||||||flava|keltainen|żółty
 hui|||zho:灰 (huĭ), yue:灰 (fui), jpn:灰 (hai), + kor:회색 (hoesaeg)|ash (ashes)||ceniza||||||||||||||tuhka|popiół
 hui darte||||podzol|podzol|podsol|espodossolo|подзол||灰化土|ポドゾル|||||||||podsoli|gleba bielicoziemna
 hui rang|rang|||grey (gray, ashy)||gris||||||||||||||harmaa|szary
@@ -1730,8 +1730,8 @@ jamul|bio|Syzygium|hin:जामुन (jāmun), eng:jambul, por:jambolão, ara:
 jan|||zho:人 (rén), wuu人 (zén), jpn:人 (jin) + hin:जन (jan), ben:-জন (-jôn), may:-jana, tha:ชน (chon), khm:ជន (jon) + fra:gens, por:gente|person (individual, -ist, -er)|personne|persona (ista, -ador)|pessoa|||人|人 (者, 員, 徒)||||||||persono|henkilö|osoba
 janela|||por:janela, ben:জানালা (janala), may:jendela + tam:சன்னல் (sannal), nya:zenera, kon:nêla|window|fenêtre|ventana|janela|окно|شباك‎|窗戶|窓|창|cửa sổ|खिड़की|জানালা|jendela|dirisha|pencere|fenestro|ikkuna|okno
 janela frem||||window frame||||||窗框|||||||||fenestrokadro|ikkunankehys (ikkunanpuite)|
-jianga di||||crafty (dexterous)||||||||||||||||kätevä|umiejętny (sprawny, zręczny)
-jianga ja|||zho:匠 (jiàng), yue:匠 (zoeng6), tha:ช่าง (jang), khm:ជាង (ciəng)|artisan (craftsman)||artesano||||工匠 (匠人)|||||||||metiisto|artesaani (käsityöläinen)|rzemieślnik
+jiang di||||crafty (dexterous)||||||||||||||||kätevä|umiejętny (sprawny, zręczny)
+jiang ja|||zho:匠 (jiàng), yue:匠 (zoeng6), tha:ช่าง (jang), khm:ជាង (ciəng)|artisan (craftsman)||artesano||||工匠 (匠人)|||||||||metiisto|artesaani (käsityöläinen)|rzemieślnik
 jangal|||eng:fra:jungle, spa:jungla, por:jângal, rus:джунгли (džungli), hin:जंगल (jangal), ben:জঙ্গল (jônggôl), may:jenggela, jpn:ジャングル (janguru), kor:정글 (jeonggeul), tur:cengel|forest (woods, jungle)|forêt (jungle)|bosque (jungla, selva)|selva (floresta, jângal)|лес (джунгли)||森林|森 (森林, ジャングル)|숲 (삼림 , 정글)|rừng|जंगल (वन)|বন (জঙ্গল)|hutan (jenggela)|msitu|orman (cengel)|arbaro|metsä (viidakko)|las, dżungla, zagajnik
 jara|||ara: جَرَة‎ (jara), eng:jar, fra:jarre, spa:por:jarra|jar (jug, pitcher, carafe, amphora, vase)|jarre (carafe, cruche)|jarra|jarra (jarro)|кувшин (графин)|جَرَّة‎ (زِير‎)|罐 (瓶)|||lọ (bình)||||||kruĉo|ruukku (kannu, maljakko, karahvi)|dzban, dzbanek; słój, słoik; wazon
 jau|bio|Hordeum vulgare|hin:जौ (jau), ben:যব (jôb), mar:जव (jav), guj:જવ (jav), fas: جو‎ (jow)|barley|orge|cebada|cevada|ячмень||大麦|大麦|보리|lúa mạch|जौ|যব|barli|shayiri|arpa|hordeo|ohra|jęczmień
@@ -2215,9 +2215,9 @@ le|asp.aux.||zho:了 (le, liǎo), wuu:了 (le’), yue:了 (liu), tha:แล้�
 lefte|||eng:left, rus:левый (levyy)|left||lado izquerdo|esquerdo|левый||左|左|||बायीं||kiri|kushoto|sol||vasen|lewa strona
 lefte di||||left hand||izquierdo|||||||||||||||lewy (lewostronny, z lewej strony)
 lefte sim ja||||leftist (left-winger)||izquerdista||||||||||||||vasemmistolainen|lewicowiec (lewak)
-lengo|||zho:冷 (lěng), vie:lạnh, yue:冷 (laang5)|cold||frío||||冷たい (寒い)|||||||||malvarma|kylmä|zimny, chłodny
-lengo mosim||||winter|hiver|invierno|inverno|зима||冬天||||सर्दी (जाड़ा,  शिशिर)||musim dingin||kış|vintro|talvi|zima
-lengo mosim di||||wintry|hivernal (hibernal)|invernal|invernal (hibernal)|зимний|||||||||||vintra|talvinen|zimowy
+leng|||zho:冷 (lěng), vie:lạnh, yue:冷 (laang5)|cold||frío||||冷たい (寒い)|||||||||malvarma|kylmä|zimny, chłodny
+leng mosim||||winter|hiver|invierno|inverno|зима||冬天||||सर्दी (जाड़ा,  शिशिर)||musim dingin||kış|vintro|talvi|zima
+leng mosim di||||wintry|hivernal (hibernal)|invernal|invernal (hibernal)|зимний|||||||||||vintra|talvinen|zimowy
 lense|||eng:lens, fra:lentille, spa:por:lente, rus:линза (linza), hin:लेंस (lens), ben:লেন্স (lenś), may:lensa, jpn:レンズ (renzu), kor:렌즈 (renjeu)|lens|lentille|lente|lente|линза|عَدَسَة‎|透镜|レンズ|렌즈|thấu kính|लेंस|লেন্স|lensa (kanta)||mercek (adese, lens)||linssi|soczewka
 lenshi|||zho:练习 (liànxí), jpn:練習 (renshū), kor:련습 (ryeonseup)|exercise||ensayo (ejercitio)|||||||||||||ekzerco|harjoitus|ćwiczenie
 lente|||fra:lent, spa:por:lento|slow (lethargic)|lent|lento (despacio)|lento|||慢|遅い (ゆっくり)||||||||malrapida|hidas|powolny (wolny, letargiczny)
@@ -2375,7 +2375,7 @@ manete|||eng:magnet, fra:magnétique, spa:magnete, rus:магнит (magnit), tu
 manete di||||magnetic||magnético||||||||||||||magneettinen|magnetyczny
 mangan|yum 025|Mn|eng:manganese, fra:manganèse, spa:manganeso, por:manganésio, rus:марганец, zho:锰 (měng), jpn:マンガン, kor:망가니즈, vie:mangan, hin:मैंगनीज, ben:ম্যাঙ্গানিজ, may:manggan, swa:manganisi, ara: منجنيز|manganese|manganèse|manganeso|manganésio|марганец|منجنيز|锰|マンガン|망간|mangan|मैंगनीज|ম্যাঙ্গানিজ|manggan|manganisi|mangan|mangano|mangaani|mangan
 mango|bio||mal:മാങ്ങ (māṅṅa), eng:spa:tur:mango, por:manga, rus:манго (mango), may:mangga, jpn:マンゴー (mangō), kor:망고 (manggo)|mango||mango||||||||||||||mango|mango
-mangu|||zho:忙 (máng), yue:忙 (mong4), wuu:忙 (maan), kor:망 (mang)|busy (occupied)|occupé|ocupado (atareado)|ocupado (atarefado)|занятый||忙|忙しい|||व्यस्त||ramai (sibuk)|kushugulika|işlek|okupata|kiireinen|zajęty
+mang|||zho:忙 (máng), yue:忙 (mong4), wuu:忙 (maan), kor:망 (mang)|busy (occupied)|occupé|ocupado (atareado)|ocupado (atarefado)|занятый||忙|忙しい|||व्यस्त||ramai (sibuk)|kushugulika|işlek|okupata|kiireinen|zajęty
 mangus|bio|Garcinia mangostana||mangosteen||mangostán (jobo de la India)||||||||||||||mangostani|mangostan
 Mani||||prophet Mani||profeta Mani||||||||||||||profeetta Mani|prorok Mani
 mani din||||Manichaeism|manichéisme|maniqueísmo|maniqueísmo|манихейство||摩尼教||||||||||manikealaisuus|manicheizm
@@ -2500,7 +2500,7 @@ mesi jene||||Christmas||Navidad|||||||||||||kristnasko|joulu|Boże Narodzenie
 mestre|||por:mestre, fra:maître, pol:mistrz, eng:master, rus:мастер (master), spa:maestro, deu:Meister, hin:(mistrī)|master (expert)|maître|maestro (experto)|mestre|мастер||||||||||||mestari (asiantuntija)|mistrz (ekspert)
 metal|||eng:spa:por:tur:metal, fra:métal, deu:Metall, rus:мета́лл (metáll)|metal||metal|||||金属||||||||metalo|metalli|metal
 metal bede||||anvil|enclume|yunque|bigorna|наковальня||铁砧|金敷き (鉄床)||||||||||kowadło
-metal jianga ja||||blacksmith (iron forger)||herrero||||铁匠||||||||||seppä|kowal
+metal jiang ja||||blacksmith (iron forger)||herrero||||铁匠||||||||||seppä|kowal
 metal lin||||wire|fil de fer|alambre (hilo)|arame|||线 (铁丝)|線 (針金)|철사||तार|তার||waya|tel|drato|vaijeri (metallilanka)|
 metre|||eng:meter, spa:por:-metro, rus:метр tur:metre, + hin:मात्रा (mātrā), ben:মাত্রা (matra), may:matra|measure (measurement)||medir (medida)|||||測定||||||||mezuri|mitta (koko, määrä)|zmierzyć (miara)
 metre gi||||meter (measuring device)||medidor|||||測定装置 (計)||||||||||
@@ -2565,7 +2565,7 @@ mode loge||||adverb||adverbo||||||||||||||adverbi|przysłówek
 model|||eng:model, spa:por:modelo, fra:modèle, deu:Modell, rus:моде́ль (modelʹ)|model (design)||modelar||||||||||||||malli|model, wzór, wzorzec, projekt
 moka|||zho:木 (mù), yue:木 (muk6), jpn:木 (moku), kor:목 (mok), vie:mộc, orm:muka|tree|arbre|árbol|árvore|дерево|شجر‎|树木|木|나무|cây|पेड़|গাছ (বৃক্ষ)|pohon (pokok)|mti|ağaç|arbo|puu|drzewo
 moka bano||||wood board (plank)|planche|tablón|tábua (prancha)|доска (планка)||木板|||ván||||||||deska
-moka jianga ja||||carpenter||carpintero||||木匠||||||||||puuseppä|stolarz
+moka jiang ja||||carpenter||carpintero||||木匠||||||||||puuseppä|stolarz
 moka jong parke||||arboretum|arboretum, pépinière|arboreto|||||||||||||arboĝardeno|arboretum (puulajipuisto)|arboretum
 moka kane||||stake (stick, peg, skewer)|pieu|estaca|estaca|палка|||杭|||छड़ी (लाठी)|||||paliso|keppi (puukeppi)|słup (pal, kołek)
 moka mate||||wood (timber)||madera||||木材|||||||||ligno|puuaines|drewno
@@ -2705,9 +2705,9 @@ nega|||spa:por:negar, eng:negate|refuse (deny, decline)||rechazar (negar)|||||||
 nelu|nomer|4|kor:넷 (net) + swa:nne, zul:ne, + mal:നാലു (nālu), tel:నాలుగు (nālugu), kan:ನಾಲ್ಕು (nālku) + fin:neljä, est:neli, hun:négy|four (4)|quatre (4)|cuatro (4)|quatro (4)|четыре (4)||四 (4)|四 (4)||||||||kvar (4)|neljä (4)|cztery (4)
 nelu di galope||||gallop||||||||||||||||neli (kiitolaukka)|
 nelu gona||||square (tetragon)||cuadro||||||||||||||neliö|kwadrat (czworokąt, czworobok, tetragon)
-nenu|||zho:年 (nián), yue:年 (nin4), jpn:年 (nen), kor:년 (nyeon), vie:năm,niên|year|an (année)|año||||年|年||||||||jaro|vuosi|rok
-nenu festa||||anniversary||aniversario||||||||||||||vuosijuhla|rocznica
-nenu mes den|||zho:年月日 (niányuèrì), jpn:年月日 (nengappi), kor:연월일 (yeonworil)|date||fecha||||年月日|年月日|연월일|||||||dato|päivämäärä|data
+nen|||zho:年 (nián), yue:年 (nin4), jpn:年 (nen), kor:년 (nyeon), vie:năm,niên|year|an (année)|año||||年|年||||||||jaro|vuosi|rok
+nen festa||||anniversary||aniversario||||||||||||||vuosijuhla|rocznica
+nen mes den|||zho:年月日 (niányuèrì), jpn:年月日 (nengappi), kor:연월일 (yeonworil)|date||fecha||||年月日|年月日|연월일|||||||dato|päivämäärä|data
 nenufar|bio|Nymphaea alba|eng:nenuphar, spa:por:nenúfar, fra:nénufar, rus:ненюфа́р (nenjufár), fas:نیلوفر آبی‎ (nilufar-e âbi)|water lily (nenuphar)||nenúfar (lirio de agua)||||||||||||||lumme|lilia wodna, nenufar
 neodim yum|yum 060|Nd|eng:neodymium, fra:néodyme, spa:neodimio, por:neodímio, rus:неодим, zho:钕 (nǚ), jpn:ネオジム, kor:네오디뮴, vie:neođim, hin:नियोडाइमियम, ben:নিওডিমিয়াম, may:neodinium, swa:neodimi, ara: نيودميوم|neodymium|néodyme|neodimio|neodímio|неодим|نيودميوم|钕|ネオジム|네오디뮴|neođim|नियोडाइमियम|নিওডিমিয়াম|neodinium|neodimi|neodim||neodyymi|neodym
 neon|yum 010|Ne|eng:neon, fra:néon, spa:neón, por:néon, rus:неон, zho:氖 (nǎi), jpn:ネオン, kor:네온, vie:neon, nê-ông, hin:नियोन, ben:নিয়ন, may:neon, swa:neoni, ara: نيون|neon|néon|neón|néon|неон|نيون|氖|ネオン|네온|neon, nê-ông|नियोन|নিয়ন|neon|neoni|neon|neono|neon|neon
@@ -3396,8 +3396,8 @@ sentaure|bio|Centaurea|eng:centaury, por:centáurea||Centaurée||centáurea|ва
 senti|numbe|||centi- (per cent)||centi- (por ciento)|||||||||||||centono|sentti|centy-, procent, na sto, setna część
 sentimitre|unomete|cm||centimeter (cm)||centímetro||||||||||||||senttimetri (cm)|centymetr
 sento|nomer|100|fra:cent, spa:cien, por:cem, ita:cento, eng:cent-, hin:शत (śat), ben:শত (śôt)|hundred (hecto-, 100)|cent (100)|cien (100)|cem (100)|сто|مِئَة|百|百 (１００)|백|một trăm|सौ|শত|ratus|mia|yüz|cent|sata (hehto-)|sto (100)
-sento nenu||||century|siècle (centennie)|centuria (siglo)|século|столетие||世纪|世紀|세기|thế kỷ|शताब्दी|শতাব্দী|abad||yüzyıl (asır)|jarcento (centjaro)|vuosisata|stulecie
-sento nenu di||||centenary|centenaire|centenario|centénario|столетний|||||||||||centjara|satavuotinen|
+sento nen||||century|siècle (centennie)|centuria (siglo)|século|столетие||世纪|世紀|세기|thế kỷ|शताब्दी|শতাব্দী|abad||yüzyıl (asır)|jarcento (centjaro)|vuosisata|stulecie
+sento nen di||||centenary|centenaire|centenario|centénario|столетний|||||||||||centjara|satavuotinen|
 sera|||spa:sierra, por:serra, eng:serrate|saw|scie|sierra|serra|пила||锯子|のこぎり||||||||||piła
 serami|||eng:ceramic, spa:cerámica, por:cerâmico, fra:céramique, rus:керамика (keramika), ben:সিরামিক (sirāmika), tur:mel:seramik|ceramic||cerámica|cerâmico|керамика||陶瓷|陶器|||मृत्तिकाशिल्प||seramik||||savityö (keramiikka)|ceramika
 serami sing|bio|Houstonia||bluet|||||||||||||||||houstonia
@@ -3448,9 +3448,9 @@ shefe|||fra:chef, por:chefe, spa:jefe, rus:шеф (šef), eng:chief, swa:chifu,
 shefe di||||main (principal)||principal||||||||||||||pää-|główny
 shefe minister||||prime minister||primer ministro|||||||||||||ĉefministro|pääministeri (suurvisiiri)|premier
 seku|||zho: 石 (shí), yue:石 (sek3), jpn:石 (seki), kor:석 (seok)|stone (piece of rock)|pierre|piedra|pedra|камень (камешек)||石 (岩)|||||||||ŝtono|kivi (hippu)|kamień (kawał skały)
-seku jianga ja||||mason (stonemason, stonecutter)||albañil (mampostero, cantero)|||||石匠||||||||||kamieniarz
-senga|||zho:胜 (shèng), yue:勝 (sing3), wuu:勝 (sen2), jpn:勝 (shō), kor:승 (seung), vie:thắng|victory (win, triumph)||victoria|||||||||||||venko|voitto|zwycięstwo, wygrana
-senga bai||||outcome (victory or defeat)||||||勝敗|勝敗||||||||||
+seku jiang ja||||mason (stonemason, stonecutter)||albañil (mampostero, cantero)|||||石匠||||||||||kamieniarz
+seng|||zho:胜 (shèng), yue:勝 (sing3), wuu:勝 (sen2), jpn:勝 (shō), kor:승 (seung), vie:thắng|victory (win, triumph)||victoria|||||||||||||venko|voitto|zwycięstwo, wygrana
+seng bai||||outcome (victory or defeat)||||||勝敗|勝敗||||||||||
 shi|||zho:氏 (shì), yue:氏 (si6), jpn:氏 (-shi), kor:씨 (ssi) + may:si + hin:श्री (śrī), ben:শ্রী  (śri)|Mx. (Mr. or Ms.)|||||||さん (氏)|||श्री|শ্রী|||||herra tai rouva|
 shia|||ara: شِيعَة (šīʿa), heb: סִיעָה (si'á) + zho:系 (xì)|faction (clique)|faction (clique)|facción|facção|фракция (клика)|شيعة|派系||||||||||porukka (kuppikunta, lohko, siipi)|
 shia islam din||||Shia Islam (Shi’ism)|chiisme|chiismo (chía)|xiismo|шиизм|الشِّيعَة‎|什叶派|シーア派|||शिया|||||ŝijaismo|šiialaisuus|szyism
@@ -3573,7 +3573,7 @@ sona|||fra:sommeil, por:sono, rus:сон (son), hin:सोना (sonā), ben:�
 sona kamar||||bedroom|chambre à coucher|dormitorio|quarto (dormitório)|спальня||卧室 (寝室)|寝室|침실|phòng ngủ|शयनकक्ष||kamar tidur|chumba cha kulala|yatak odası|dormoĉambro|makuuhuone|sypialnia
 sona papi|bio|Papaver somniferum|eng:poppy, spa:amapola, por:papoula, swa:mpopi, hin:पॉपी (pŏpī), ben:পপি (papi), jpn:ポピー (popī)|opium poppy|pavot somnifère|adormidera (amapola real)|papoila-dormideira|мак снотворный||鴉片罌粟|ケシ||||||mpopi|||unikko (unikukka)|mak lekarski
 sona tabi||||drowsy|ensommeillé (somnolent)|soñoliento (somnífero)|sonolento|сонный|||||||||||dormema|unelias|
-song|bio|Pinus|zho:松 (sōng), wuu:(son), tha:สน (sǒn), kor:솔 (sol), vie:thông, + rus:сосна (sosna)|pine tree||pino|pinheiro|сосна||松|マツ|||चीड़|||||pino|mänty|sosna
+songi|bio|Pinus|zho:松 (sōng), wuu:(son), tha:สน (sǒn), kor:솔 (sol), vie:thông, + rus:сосна (sosna)|pine tree||pino|pinheiro|сосна||松|マツ|||चीड़|||||pino|mänty|sosna
 soni|||eng:sonic, fra:son, spa:son,sonido, por:som, ita:suono, + kor:소리 (sori) + zho:声 (shēng), wuu:声 (sən)|sound (audio)|son|sonido (audio)|som||||||||||||sono|ääni|dźwięk, brzmienie
 sor|||zho:锁 (suǒ), yue:鎖 (so2), wuu:鎖 (su2), jpn:錠 (jō), kor:쇄 (soe), vie:toả, khm:សោ (sao) + spa:cierre, fra:serrure, hun:zár|lock (fastener)|serrure|cerradura (candado)|fechadura|замок|قُفْل‎|锁|錠|자물쇠|khóa|ताला|তালা|ibu kunci|kifungio|kilit|fermilo (seruro)|lukko|zamek (zapięcie)
 sor di||||locked (secure)||||запереть|||||||||||||zamknięty (zakluczony, zapięty, bezpieczny)
@@ -3681,7 +3681,7 @@ tal di|||fas:ته (tah), hin:तह (tah) + zho:低 (dī), yue:低 (dai1), wuu:�
 tal moka||||bush (shrub)|buisson|arbusto (mata)|arbusto (mata)|куст||灌木|灌木 (藪)|||झाड़ी||alas gandar|||||krzak (krzew)
 tal tela||||carpet (rug)||alfombra (tapete)||ковёр|||絨毯 (カーペット)||||||||||dywan
 tali yum|yum 081|Tl|eng:thallium, fra:thallium, spa:talio, por:tálio, rus:таллий, zho:铊 (tā), jpn:タリウム, kor:탈륨, vie:tali, hin:थैलियम, ben:থ্যালিয়াম, may:tallium, swa:tali, ara: ثاليوم|thallium|thallium|talio|tálio|таллий|ثاليوم|铊|タリウム|탈륨|tali|थैलियम|থ্যালিয়াম|tallium|tali|talyum|talio|tallium|tal
-tam|||ara: طَمَّاع‎ (ṭammāʿ), zho:贪 (tān), yue:貪 (taam1), kor:탐욕 (tamyok), vie:tham|greedy||codicioso (avaro)||||贪婪的|||||||||avida|ahne|chciwy (żądny)
+tami|||ara: طَمَّاع‎ (ṭammāʿ), zho:贪 (tān), yue:貪 (taam1), kor:탐욕 (tamyok), vie:tham|greedy||codicioso (avaro)||||贪婪的|||||||||avida|ahne|chciwy (żądny)
 tamar|bio||por:tamara, ara:(tamar)|date fruit||dátil|||||||||||mtende|||taateli|daktyl
 Tamil|nas|||Tamil||tamil||||||||||||||tamil (eräs intialainen kieli)|tamilski
 tana|||fas: تنه‎ (tane), hin:तना (tanā), tam:தண்டு (taṇṭu), vie:thân, tha:ต้น (ton), may:tangkai|stem (torso, trunk, stalk)|tige|tallo|haste (talo, caule)|стебель||茎 (梗)|茎 (胴)|||तना (डाली)||tangkai|shina||||łodyga (tors, pień, trzon)
@@ -4005,7 +4005,7 @@ yam sukar gana|bio|Saccharum edule||duruka||||||||||||tebu telur|||||cukrowiec j
 yam yau||||hunger|faim|hambre|fome|голод|جوع‎|饥饿|飢え|굶주림|đói|भूख|ক্ষুধা|lapar|njaa|açlık|malsato|nälkä|głód
 yamon|pron.|||they||ellos o ellas||||他们|||||||||ili|he|oni
 yamon su||||their|leur|||их||他们的||||उनका|||||ilia|heidän|
-yanga|||zho:样 (yàng), tha:อย่าง (yàang), khm:យ៉ាង (yaang)|kind (style, sort, type)||variedad (tipo, estilo)|||||タイプ||||||||speco (tipo, stilo)|laji (tyyppi, tyyli)|rodzaj, typ, styl
+yang|||zho:样 (yàng), tha:อย่าง (yàang), khm:យ៉ាង (yaang)|kind (style, sort, type)||variedad (tipo, estilo)|||||タイプ||||||||speco (tipo, stilo)|laji (tyyppi, tyyli)|rodzaj, typ, styl
 Yapetus|planete 6 lun 8|||Iapetus||||||||||||||||Japetus|
 yasen|bio|Fraxinus|rus:ясень (yasen’), pol:jesion|ash tree|frêne|fresno|freixo|ясень||白蜡树|秦皮|||||||dişbudak||saarni|jesion
 yatim|||ara:fas:(yatim), tur:yetim, swa:yatima, hin:यतीम (yatīm)|orphan||huérfano||||||||||||||orpo|sierota

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -1570,7 +1570,7 @@ Helsinki|xefsite|FI||Helsinki||||||||||||||||Helsinki|
 hem||||ponder (think, contemplate, consider, regard)|considérer|considerar (reflexionar, pensar en)|considerar|думать||深思 (考虑)|考える|||विचार करना||menung (mengirakan)|||pripensi (rigardi ia)|miettiä (pohtia, pitää jonakin)|dumać, rozmyślać, zastanawiać się, rozważać, brać pod uwagę
 hem…|||eng:hmm, rus:хм (hm), эм (em), kor:음 (eum)|hmm…|hum…|hm…|hmm…|хм…|||||hmm… (hừmm…)||||||hm…|hmm…|hmm…
 hema|||ara:(xayma), hau:laima, hin:ख़ैमा (xEmā), swa:hema, may:kemah, may:khemah, mng:майхан (mayhan)|tent|tente|carpa (toldo)||палатка (шатёр)||帐篷|||||||||tendo|teltta|namiot
-hena|||zho:恨 (hèn), yue:恨 (han6), wuu:恨 (hhen3), vie:hận, kor:한  (han) + jpn:嫌 (ken) + fra:haine|hatred (hate, resentment, odium)|haine|odio|||||||||||||malamo|viha (inho)|nienawidzić
+hen|||zho:恨 (hèn), yue:恨 (han6), wuu:恨 (hhen3), vie:hận, kor:한  (han) + jpn:嫌 (ken) + fra:haine|hatred (hate, resentment, odium)|haine|odio|||||||||||||malamo|viha (inho)|nienawidzić
 hero|||eng:hero, fra:héros, spa:héroe, por:héroi, rus:герой (geroy), hin:हीरो (hīro), jpn:ヒーロー (hīrō), kor:히로 (hiro)|hero|héros|héroe|héroi|герой||英雄 (勇士)|英雄 (勇者, ヒーロー)|영웅 (히로)|anh hùng|नायक (वीर, हीरो)|বীর|wira (pahlawan)|shujaa|kahraman|heroo|sankari (urho)|bohater, heros
 hero di||||heroic||valiente (heroico)|||||||||||||heroa|urhea (sankarillinen)|bohaterski, heroiczny, odważny, brawurowy
 hero kata||||saga (heroic tale)||||||||||||||||sankaritaru (legenda)|

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -87,7 +87,7 @@ ampul|||fra:eng:ampoule, zho:安瓿 (ānbù), jpn:アンプル (anpuru), rus:а
 an|||ell:ἀν- (an-), eng:un-, hin:अन- (an-), fra:spa:por:in-|reverse (negative, un-)|inverse (négatif, in-)||||||||||||||mala|vastakohtainen (negatiivinen, epä-)|negatywny (przeciwny, nie)
 an ai||||dislike (loathe)|exécrer|detestar|||||||||||||malami|inhota|
 an air bio di||||anaerobic|anaérobique|anaeróbico|anaeróbico|||厌氧的|嫌気性|||||||||anaerobinen|
-an chen vide di||||unexpected||||||||||||||||ennennäkemätön|niespodziewany
+an chenu vide di||||unexpected||||||||||||||||ennennäkemätön|niespodziewany
 an daka||||uncover (reveal)||destapar||||||||||||||paljastaa|odsłonić, odsłaniać
 an deu sim ja||||atheist|athée|ateo|||||||||||||ateisto|ateisti (jumalankieltäjä)|ateista
 an din ja||||unbeliever (infidel)|infidèle (incroyant)|infiel (descreído)|infiel|неверующий|كافر|不信神的|不信者|불신자||नास्तिक (काफ़िर)||||kafir|malkredulo|uskonnoton|niewierny
@@ -157,7 +157,7 @@ Ariel|planete 7 lun 2|||Ariel||||||||||||||||Ariel|
 arka|||eng:arch, spa:por:arco, fra:arc, rus:арка (arka), may:arka|bow (arch, arc)|arc|arco|arco|лук (арка)||弓 (琴弓, 拱)|弓 (弓なり)|||||||||kaari|łuk
 arka chati||||vault (arched ceiling or roof)|voûte|bóveda|abóbada|свод||拱顶||||||||tonoz|volbo|holvikatto|
 arka ja||||archer|archer|arquero||лучник|||弓兵|||||||||jousiampuja|łucznik
-arka shuta||||archery|tire à l'arc|tiro con arco||||||||||||||jousiammunta|łucznictwo
+arka suta||||archery|tire à l'arc|tiro con arco||||||||||||||jousiammunta|łucznictwo
 arme|||fra:arme, eng:arms, spa:por:arma|weapon (arms)|arme|arma|arma|||武器|||||||||armilo|ase|broń
 aroma||||smell (sniff)|sentir qqch|oler (olfatear)||понюхать||闻到|嗅ぐ|||||||||haistaa|wąchać
 aroma|||eng:spa:por:may:aroma, fra:arôme, deu:Aroma, rus:аромат (aromat), jpn:アロマ (aroma)|scent (odor, fragrance, aroma)|odeur|olor (aroma)|cheiro|запах (аромат)||气味|香り (匂い, 臭い)|||||||||haju|zapach (aromat, smród, odór)
@@ -298,7 +298,7 @@ bateri|||eng:battery, hat:batri, fas:(bātri), swa:betri, hin:बैटरी (b
 bati|nomer|8|zho:八 (bā), yue:八 (baat3), wuu:八 (baʔ), jpn:八 (hachi), kor:팔 (pal), tha:แปด (pæt) + hin:आठ (āṭh), ben:আট (aṭ)|eight (8)|huit (8)|ocho (8)|oito (8)|восемь (8)||八 (8)|八 (8)||||||||ok (8)|kahdeksan (8)|osiem (8)
 bau|||zho:宝 (bǎo), kor:보 (bo), vie:bảo, jpn:宝 (hō)|treasure (valuables)||tesoro||сокровище (казна)|||||||||||trezoro|aarre|skarb; skrabiec
 bau di||||precious|précieux|precioso|precioso|драгоценный||宝贵||귀중한||||||||arvokas|cenny
-bau sheku||||gem (gemstone, jewel)|pierre précieuse (joyau)|piedra preciosa (joya, gema)|pedra preciosa (gema)|драгоценный камень|جوهرة‎|宝石|宝石|보석|đá quý|मणि (रत्न)||permata (jauhar)|johari|mücevher|juvelo|jalokivi|klejnot
+bau seku||||gem (gemstone, jewel)|pierre précieuse (joyau)|piedra preciosa (joya, gema)|pedra preciosa (gema)|драгоценный камень|جوهرة‎|宝石|宝石|보석|đá quý|मणि (रत्न)||permata (jauhar)|johari|mücevher|juvelo|jalokivi|klejnot
 baya|||eng:bay, spa:bahía, por:baía, fra:baie|bay (gulf)|baie (golf)|bahía|baía|||||||||||||lahti|zatoka
 bazar|||fas:urd: بازار (bāzār), hin:बाज़ार (bāzār), fra:spa:por:bazar, eng:bazaar, rus:базар (bazar), may: pasar, khm:ផ្សារ (psar)|market (bazaar)|marché (bazar)|mercado (bazar)|mercado (bazar)|рынок (базар)|سُوق|市场|市場 (マーケット, バザー)|||बाज़ार||pasar|soko||merkato (bazaro)|tori (basaari)|rynek, bazar
 bazar huru sim||||market liberalism||||||||||||||||markkinaliberalismi|liberalizm rynkowy
@@ -317,7 +317,7 @@ be boi||||float (swim)|nagar (flotter)|nadar (flotar)|nadar (flutuar)|плава
 be boli|||eng:boil, fra:bouillir, ita:bollire, zul:-bila, sot:-bela, hin:उबालना (ubālnā)|boil (be boiled)||hervirse (ser cocida)|||||||||||||boli|kiehua|ugotować się, gotować się
 be bum||||explode (blow up)||explotar (estallar)||взрываться|||爆発する|||||||||räjähtää|eksplodować (wybuchnąć, wybuchać)
 be bum||||explode|exploser (détoner)|explosionar|explodir|взрываться|||||||||||eksplodi|räjähtää|
-be chen||||predate (be before)||preceder (anteceder)|||||||||||||antaŭiri|edeltää (olla ennen)|poprzedzić, poprzedzać
+be chenu||||predate (be before)||preceder (anteceder)|||||||||||||antaŭiri|edeltää (olla ennen)|poprzedzić, poprzedzać
 be dai||||grow (get bigger)||crecer (aumentar)||||||||||||||kasvaa (suurentua)|urosnąć, rosnąć, wzrosnąć, wzrastać
 be dara||||flow||fluir||||||||||||||virrata|latać (fruwać)
 be dom||||live in (reside in, inhabit)|vivre (habiter)|vivir (residir)|||||住む (居住する)||||||||loĝi|asua|mieszkać
@@ -380,7 +380,7 @@ be turbe||||be bothered by (bother to, take the trouble to)||molestar en||утр
 be vai||||exit (get out)||salir (egresar)|sair|||||||||||||poistua (mennä ulos)|
 be vanu||||enjoy (play)||disfrutar (jugar)||||玩耍|遊ぶ|||||||||leikkiä (pitää hauskaa)|cieszyć się (zażywać, bawić się)
 be vide||||be seen||ser visto||||||||||||||näkyä|być widzianym
-be yong liga||||merge (fuse)||fusionar (fundir)||||||||||||||sulaa yhteen (fuusioitua)|łączyć (złączyć)
+be yung liga||||merge (fuse)||fusionar (fundir)||||||||||||||sulaa yhteen (fuusioitua)|łączyć (złączyć)
 be zai||||appear||aparecer||||||||||||||ilmestyä|pojawić się
 bebe|||fra:bébé, por:bebê, spa:bebé, tur:bebek, eng:baby, yue:BB (bibi)|baby (infant)|bébé|bebé|bebê|младенец|رَضِيع|宝宝 (娃娃)|赤ちゃん|||शिशु||bayi|mtoto mchanga||bebo|vauva|niemowlę
 bebe bede||||crib||||детская кроватка||娃娃床|ベビーベッド|||||||||pinnasänky|kojec
@@ -537,25 +537,25 @@ chaku|||hin:चाक़ू (cāqū), fas:(čâqu), nep:चक्कु (cakku),
 chamacha|||hin:चम्मच (cammac), ben:চামচ (camôc), may:camca, kan:ಚಮಚ (camaca), fas: چمچه (čamče), tel:చెమ్చా (cemcā), pnb:ਚਮਚਾ (camcā), tur:çömçe + tha:ช้อน (chon)|spoon|cuiller|cuchara|colher|ложка||匙子|スプーン|숟가락 (스푼)||चम्मच|চামচ|sudu (sendok, camca)||kaşık|kulero|lusikka|łyżka
 champion|||eng:fra:champion, spa:campeón, por:campeão, rus:чемпион (chempion), tur:şampiyon, jpn:チャンピオン (chanpeon), kor:챔피언 (chaempieon)|champion||campeón|||||||||||||ĉampiono|mestari (voittaja)|czempion
 chanse|||fra:eng:spa:por:chance, jpn:チャンス (chansu), kor:찬스 (chanseu), rus:шанс (šans), tur:şans, hin:चांस (cāns)|opportunity (chance)|chance|oportunidad (chance)|chance|возможность (шанс)||||||||||fırsat (şans)|ŝanco|mahdollisuus (tilaisuus)|szansa
-chante||||sing||cantar|||||||||||||kanti|laulaa|śpiewać
-chante|||fra:chanter, eng:chant, por:spa:cantar, + zho:唱 (chàng), kor:창 (chang)|song||canción|||||||||||||kanto|laulu|piosenka, pieśń
-chante grupe||||choir (chorus)|chœur|coro|coro|хор|كورال‎|合唱团|合唱団|합창단|dàn hợp xướng|कोरस||||koro|ĥoro|kuoro|chór
+chanta||||sing||cantar|||||||||||||kanti|laulaa|śpiewać
+chanta|||fra:chanter, eng:chant, por:spa:cantar, + zho:唱 (chàng), kor:창 (chang)|song||canción|||||||||||||kanto|laulu|piosenka, pieśń
+chanta grupe||||choir (chorus)|chœur|coro|coro|хор|كورال‎|合唱团|合唱団|합창단|dàn hợp xướng|कोरस||||koro|ĥoro|kuoro|chór
 chapati|||hin:चपाती (ćapātī), urd:(ćapātī), eng:swa:chapati, rus:чапати (čapati), mya:ချပါတီ (kyapati)|flatbread (chapati, roti)||chapati (pan sin levadura)||||||||||||||chapati|płaski chleb, ćapati
 chape|||hin:छाप (chāp), ben:ছাপ (chap), may:cap, eng:chop|print (stamp)||grabado (sello, estampando)||||||||छाप|ছাপ||||presaĵo|painos (leima)|odcisk, ślad; stempel, pieczęć
 charme|||fra:por:charme, eng:charm, rus:шарм (šarm)|charm (attraction)|charme|encanto|charme|шарм||||||||||||vetovoima (šarmi)|czar (urok, wdzięk)
 chati|||hin:छत (chat); छदि (chadi), ben: ছাদ (chad), tur:çatı, kyr:чатыр (čatyr) + ara: سَطْح‎ (saṭḥ)|roof|toit|techo (tejado)|telhado|крыша (кров)|سَطْح‎|屋顶 (房顶)|屋根|지붕|mái|छत (छदि)|ছাদ|atap|paa|çatı|tekto|katto (katos)|dach
 cheke|||eng:check, spa:chequear, por:checar, deu:chekcen, jpn:チェックする (chekkusuru)|examine (inspect, check)||revisar (chequear, examinar, inspeccionar)||||检查|||||||||kontroli|tarkistaa (tsekata, tutkia)|sprawdzić, sprawdzać, skontrolować, kontrolować, zbadać, badać
-chen||||previous (fore)||previo (anterior)||||||||||||||edellinen|poprzedni
-chen|||zho:前 (qián), yue:前 (cin4), jpn:前 (zen), kor:전 (jeon), vie:tiền|earlier (before, in the past)|avant|más temprano (antes, haber, en el pasado)||раньше||以前|以前 (前に)|전에|||||||antaŭe (pasinte)|ennen (aikaisemmin, aiemmin)|wcześniej (uprzednio, poprzednio, przedtem)
-chen den||||yesterday|hier|ayer|ontem|вчера|أمس|昨日|昨日|어제 (작일)|hôm qua|कल||kemarin|jana|dün|hieraū|eilen|wczoraj
-chen fikse||||prefix||prefijo||||||||||||||etuliite (prefiksi)|przedrostek (prefiks)
-chen ga||||assume (presuppose)||presuponer||||||||||||||edellyttää|zakładać (założyć)
-chen vide||||expect (anticipate, predict, forsee)||prever (esperar, pensar)|||||待ち受ける (見込む)|||||||||ennustaa (nähdä ennalta)|przewidzieć (spodziewać się)
-chen vide di||||expected||||||||||||||||ennustettu|spodziewany (przewidziany)
-chen yang di||||classic (classical)||clásico|||||古典的|||||||||klassinen|klasyczny
-chen zaman||||past times||pasado|||||||||||||pasinteco|menneisyys|przeszłość
-chen zaman di||||old (ancient, former)|vieux (ancien)|viejo (antiguo)|velho (antigo)|старый (древний)||古老 (以前)|古い|||पुराना|পুৰণা|||eski (kadim)|malnova|vanha (muinainen)|stary, starożytny
-chen zaman she||||relic||reliquia||||||||||||||muinaisjäänne|relikwia
+chenu||||previous (fore)||previo (anterior)||||||||||||||edellinen|poprzedni
+chenu|||zho:前 (qián), yue:前 (cin4), jpn:前 (zen), kor:전 (jeon), vie:tiền|earlier (before, in the past)|avant|más temprano (antes, haber, en el pasado)||раньше||以前|以前 (前に)|전에|||||||antaŭe (pasinte)|ennen (aikaisemmin, aiemmin)|wcześniej (uprzednio, poprzednio, przedtem)
+chenu den||||yesterday|hier|ayer|ontem|вчера|أمس|昨日|昨日|어제 (작일)|hôm qua|कल||kemarin|jana|dün|hieraū|eilen|wczoraj
+chenu fikse||||prefix||prefijo||||||||||||||etuliite (prefiksi)|przedrostek (prefiks)
+chenu ga||||assume (presuppose)||presuponer||||||||||||||edellyttää|zakładać (założyć)
+chenu vide||||expect (anticipate, predict, forsee)||prever (esperar, pensar)|||||待ち受ける (見込む)|||||||||ennustaa (nähdä ennalta)|przewidzieć (spodziewać się)
+chenu vide di||||expected||||||||||||||||ennustettu|spodziewany (przewidziany)
+chenu yanga di||||classic (classical)||clásico|||||古典的|||||||||klassinen|klasyczny
+chenu zaman||||past times||pasado|||||||||||||pasinteco|menneisyys|przeszłość
+chenu zaman di||||old (ancient, former)|vieux (ancien)|viejo (antiguo)|velho (antigo)|старый (древний)||古老 (以前)|古い|||पुराना|পুৰণা|||eski (kadim)|malnova|vanha (muinainen)|stary, starożytny
+chenu zaman she||||relic||reliquia||||||||||||||muinaisjäänne|relikwia
 cheng|||zho:层 (céng), yue:層 (cang4), wuu:層 (zen3), kor:층 (chŭng), vie:tầng|layer (level, storey, floor, stratum)||capa (piso, planta, estrato)||||层||||||||||kerros|warstwa (poziom, piętro, kondygnacja)
 cheng bede||||bunk bed|lits superposés|litera|beliche|двухъярусная кровать||双层床||2층침대||||||ranza||kerrossänky|
 cheri|pal||eng:cherry, fra:cerise, spa:cereza, por:cereja, rus:черешня (čerešnya), ara:(karaz), tur:kiraz, hin:गिलास (gilās), ben:চেরি  (ceri), may:ceri, jpn:チェリー (cherī), kor:체리 (cheri)|cherry|cerise|cereza|cereja|черешня||||||गिलास|চেরি|||||kirsikka|wiśnia (czereśnia)
@@ -574,9 +574,9 @@ chin gam ben||||step-sibling||||||||||||||||sisaruspuoli|
 chin ma||||grandmother|grand-mère|abuela|avó|бабушка|جَدَّة‎||お婆さん||||||||avino|isoäiti|babcia (babka)
 chin pa||||grandfather|grand-père|abuelo|avô|дедушка|جَدّ‎||||||||||avo|isoisä|dziadek (dziad)
 chinchila|bio||eng:spa:fra:chinchilla, por:chinchila, rus:шиншилла (šinšilla), tur:çinçilya, may:cincila, jpn:チンチラ (chinchira)|chinchilla||chinchilla|||||||||||||ĉinĉilo|chinchilla|szynszyla
-ching||||request (petition)||||||||||||||||pyyntö|
-ching|||zho:请 (qǐng), yue:請 (cing2), kor:청 (cheong), vie:thỉnh|ask (request, beg, plead; please)||pedir (invitar; por favor)||просить||请|請う (ーて下さい)||||||||peti (bonvolu)|pyytää (anoa)|prosić
-ching lai||||invite||invitar|||||||||||||inviti|pyytää tulemaan|zaprosić, zapraszać
+chingo||||request (petition)||||||||||||||||pyyntö|
+chingo|||zho:请 (qǐng), yue:請 (cing2), kor:청 (cheong), vie:thỉnh|ask (request, beg, plead; please)||pedir (invitar; por favor)||просить||请|請う (ーて下さい)||||||||peti (bonvolu)|pyytää (anoa)|prosić
+chingo lai||||invite||invitar|||||||||||||inviti|pyytää tulemaan|zaprosić, zapraszać
 chini|||zho:瓷 (cí) + eng:chinaware, hin:चीनी (cīnī), ben:চীনামাটি (cinamaṭi), ara: صِينِيَّة‎ (ṣīniyya), swa:sini|porcelain (chinaware)|porcelaine|porcelana|porcelana|фарфор|خَزَف‎|瓷器|磁器|도자기|sứ|चीनी (पॉर्सिलेन)|চীনামাটি|porselen|sini|porselen|porcelano|posliini|porcelana
 Chipe|desha|AL||Albania||Albania||||||||||||||Albania|Albania
 chira||||tear (rip, edge)|déchirer|rasgar (romper)|rasgar|рвать||撕裂|裂く|||||||||repeämä|rwać (drzeć)
@@ -618,19 +618,19 @@ dai lasun|bio|Allium giganteum||giant onion||||лук исполинский||||
 dai pau||||gun (cannon)|canon|cañón|canhǎo|пушка||大炮|大砲|대포|đại pháo|तोप|তোপ|meriam|mzinga|top|kanono|tykki|działo
 dai pau ja||||cannoneer||cañonear|||||||||||||kanonisto|tykkimies|kanonier
 dai pote||||cauldron|chaudron|caldero||котёл||炼药锅|大釜 (大鍋)|||||||||pata|kocioł
-dai sheku||||boulder|rocher|peñasco (pedrusco)|pedregulho|валун||磐石|大石||||||||ŝtonego|lohkare (järkäle)|głaz
+dai seku||||boulder|rocher|peñasco (pedrusco)|pedregulho|валун||磐石|大石||||||||ŝtonego|lohkare (järkäle)|głaz
 dai shula kan||||university||universidad||||||||||||||yliopisto|uniwersytet
 dai siti||||big city|||||||||||||||urbego|suurkaupunki|
 dai ta||||size||tamaño||||||||||||||suuruus (koko)|rozmiar
 daka||||cover (lid, cap, deck)||tapa (funda, cubierta)||||||||ढक्कन|||||kovrilo|peite (kansi)|pokrycie; pokrywa, wieko, dekiel; pokład
-daku|||zho:得 (dé), yue:得 (dak1), wuu:得 (teq4), jpn:得 (toku), kor:득 (deuk), kor:được|get (receive, obtain, take)||conseguir (obtener, recibir)|ter (achar, receber)|получить||获得|受ける (もらう)|||पाना|||kupata (kuget)|elde etmek|akiri (ricevi, preni)|hankkia (saada)|dostać, dostawać, otrzymać, otrzymywać, wziąć, brać
-daku ja||||getter (receiver, recipient)||engendrador||||||||||||||saaja (vastaanottaja)|odbiorca
-daku shitu||||gains and losses (pros and cons)||||||得失|得失|||||||||voitot ja tappiot|
+deku|||zho:得 (dé), yue:得 (dak1), wuu:得 (teq4), jpn:得 (toku), kor:득 (deuk), kor:được|get (receive, obtain, take)||conseguir (obtener, recibir)|ter (achar, receber)|получить||获得|受ける (もらう)|||पाना|||kupata (kuget)|elde etmek|akiri (ricevi, preni)|hankkia (saada)|dostać, dostawać, otrzymać, otrzymywać, wziąć, brać
+deku ja||||getter (receiver, recipient)||engendrador||||||||||||||saaja (vastaanottaja)|odbiorca
+deku shitu||||gains and losses (pros and cons)||||||得失|得失|||||||||voitot ja tappiot|
 dalil|||ara:(dalil), ben:দলিল (dôlil), swa:dalili, tur:delil|proof (evidence, proof, demonstration, testimony)|preuve|prueba|prova|доказательство||||||||||||todiste (todistus, osoitus, demonstraatio)|dowód; zeznanie
 dama gem|||fra:jeu de dames, spa:por:damas, ara: ضَامَة‎ (ḍāma), vie:cờ đam, may:dam, tur:dama, deu:Damespiel|checkers (draughts)|jeu de dames|damas|damas|шашки|ضَامَة‎|跳棋|チェッカー (西洋碁)|체커|cờ đam|चेकर्स (ड्राफ़्टस)|চেকারস|dam|drafti|dama|damludo|tammipeli|warcaby
 dan||| jpn:段 (dan), eng:fra:may:dan + zho:等 (děng),  yue:等 (dang2), kor:등 (dang), vie:đẳng|rank (grade, dan)|rang|||ранг||等 (段)|段 (等)||đẳng|||||||sija (taso, ranking, dan)|
-dane|||hin:दाना (dānā), tur:tane + jpn:種 (tane);銃弾 (jūdan), zho:弹 (dàn), vie:đạn, kor:탄알 (tanal)|particle (grain, bullet)||partícula (grano, bala)||||||||||||tane||jyvä (luoti)|cząstka (ziarno, kula, pocisk)
-dane sekur||||bulletproof||antibalas||||||||||||||luodinkestävä|kuloodporny
+dana|||hin:दाना (dānā), tur:tane + jpn:種 (tane);銃弾 (jūdan), zho:弹 (dàn), vie:đạn, kor:탄알 (tanal)|particle (grain, bullet)||partícula (grano, bala)||||||||||||tane||jyvä (luoti)|cząstka (ziarno, kula, pocisk)
+dana sekur||||bulletproof||antibalas||||||||||||||luodinkestävä|kuloodporny
 dang|||eng:dong, por:dlim-dlão, spa:tilín, zho:叮 (dīng), jpn:がんがん (gangan), tha:กระดิ่ง (grà-dìng)|ring (toll, clang)||||звенеть||||||||||||kilistää (soittaa kelloa)|dzwonić (dźwięczeć, szczękać)
 dang gi||||bell|cloche|campana (cencerro)|sino (campainha)|звонок||钟 (摇铃)|鐘 (鈴)|||||||||soittokello|dzwon (dzwonek)
 danse|||eng:fra:dance, spa:danza, por:dança, deu:Tanz, rus:танец (taněc), tur:dans, jpn:ダンス (dansu), kor:댄스 (daenseu), swa:dansi|dance|dance|baile (danza)|baile (danza)|танец||||||||tari||dans|danco|tanssi|taniec
@@ -721,7 +721,7 @@ din ja||||believer (religious person)|croyant|creyente|crente|верующий|�
 din shia||||sect (cult)|secte|secta (culto)|seita|секта|فِرْقَة‎|教派|教派|||||||mezhep|sekto|lahko (kultti)|
 dinamite|||eng:dynamite, spa:dinamita, rus:динамит (dinamit), tur:may:dinamit, ara:ديناميت (dinamit), hin:डायनामाइट (dāyanāmait), jpn:ダイナマイト (dainamaito)|dynamite|dynamite|dinamita|dinamite|динамит||甘油炸药|ダイナマイト|||||||||dynamiitti|dynamit
 dinde|bio|Meleagris|fra:dinde, rus:индюк (indyuk), tur:hindi, ara: دِيك هِنْدِيّ‎ (dīk hindiy)|turkey|dinde (dindon)|pavo (guajalote)|peru|индюк|دِيك رُومِيّ‎|火鸡|七面鳥|칠면조|gà tây|पीरू||kalkun (ayam belanda)|bata mzinga (piru)|hindi|meleagro|kalkkuna|indyk
-ding|||zho:钉 (dīng), yue:釘 (deng1), vie:đinh|nail (spike)||clavo (pincho, punta)||||钉子|||||||||najlo|naula (piikki)|kolec
+ding|||zho:钉 (dīng), yue:釘 (ding1), vie:đinh|nail (spike)||clavo (pincho, punta)||||钉子|||||||||najlo|naula (piikki)|kolec
 dino saur||||dinosaur|dinosaure|dinosaurio|dinossauro|динозавр|دِينَاصَوْر‎|恐龙|恐竜|공룡|khủng long|डायनासोर (भीमसरट)|ডাইনোসর|dinosaurus||dinozor|dinosaŭro|dinosaurus (hirmulisko)|dinozaur
 Dione|planete 6 lun 4|||Dione||||||||||||||||Dione|
 diorite|||eng:fra:diorite, spa:diorita, rus:диорит (diorit), tur:diyorit, ara:ديوريت (dayurit), hin:डायोराइट (dāyorait), vie:may:diorit|diorite|diorite|diorita|diorito|диорит||闪长岩|閃緑岩|||||||||dioriitti|dioryt
@@ -866,7 +866,7 @@ Eskandinavia||||Scandinavia|Scandinavie|Escandinavia||||||||||||||Skandinavia|Sk
 Eskote|desha|||Scotland||Escocia||||||||||||||Skotlanti|Szkocja
 eskulte||||sculpture (statue)||escultura (estatua)|||||||||||||statuo (skultaĵo)|veistos (patsas)|rzeźba
 eskulte ja|||spa:por:escultor, fra:sculpteur, eng:sculptor, rus:скульптор (skulptor)|sculptor|sculpteur|escultor|escultor|скульптор|||||||||||skultisto|kuvanveistäjä|rzeźbiarz
-eskulte shuta||||sculpture (art of sculpting)||escultura (arte de escultura)||||||||||||||kuvanveisto|rzeźbiarstwo
+eskulte suta||||sculpture (art of sculpting)||escultura (arte de escultura)||||||||||||||kuvanveisto|rzeźbiarstwo
 Espanya|desha|ES||Spain||España|||||||||||||Hispanio|Espanja|Hiszpania
 espanya fon di||||hispanophone (Spanish speaking)||||||||||||||||espanjaa puhuva|
 esperanto|basha|||Esperanto||Esperanto|||||||||||||Esperanto|esperanto|Esperanto
@@ -914,7 +914,7 @@ fa auto||||personalize (customize)||personalizar|||||カスタマイズする|||
 fa avar||||harm (damage)||dañar||||||||||||||vahingoittaa (vaurioittaa)|
 fa baze||||found||fundar (basar)||||||||||||||perustaa|zakładać (założyć, ustanowić)
 fa bina||||build (construct)|construire|construir (edificar)|construir|строить|بَنَى‎|建设|建てる|||बनाना||bangun (bina)|kujenga||konstrui|rakentaa|zbudować, budować, konstruować
-fa biznes lon||||negotiate (arrange)||negociar|||||話し合う (話を付ける)|||||||||neuvotella|negocjować
+fa biznes lona||||negotiate (arrange)||negociar|||||話し合う (話を付ける)|||||||||neuvotella|negocjować
 fa budi||||realize||darse cuenta (notar)|||||||||||||kompreni|ymmärtää (oivaltaa)|uświadomić sobie, zdać sobie sprawę, pojąć, pojmować
 fa chape||||press (imprint)||imprimir|||||||||||||presi|painaa (leimata)|naciskać, zostawiać ślad
 fa chori||||steal||robar (hurtar)|||||||||||||ŝteli|varastaa|ukraść, kraść
@@ -996,7 +996,7 @@ fa koloni||||colonize||colonizar||||||||||||||kolonisoida|kolonizować
 fa komputa||||compute (to process data)||calcular (computar)||||||||||||||käsitellä dataa|policzyć, liczyć, przetwarzać dane
 fa komun||||share||compartir (tener en común)||||||||||||||jakaa yhteiseksi|dzielić (współdzielić)
 fa kon sabe||||communicate (inform about)||comunicar (informar)||||||||||||||tiedottaa (informoida)|poinformować, informować, zakomunikować, komunikować
-fa kong||||pierce (perforate, bore)||perforar (agujerar)||пробиться|||染みる (貫通する)|||||||||rei’ittää|przebić (perforować, dziurawić)
+fa kung||||pierce (perforate, bore)||perforar (agujerar)||пробиться|||染みる (貫通する)|||||||||rei’ittää|przebić (perforować, dziurawić)
 fa kopi||||copy (replicate)||copiar|||||||||||||kopii|kopioida (jäljentää)|kopiować, replikować
 fa krus fikse||||crucify||crucificar||||||||||||||ristiinnaulita|ukrzyżować
 fa lai||||bring|apporter|traer|trazer|приносить||带来|持って来る|가져오다|mang|लाना|আনা|bawa|kuleta|getirmek|alporti (venigi)|tuoda|
@@ -1006,7 +1006,7 @@ fa libu||||erect||erigir (montar, armar)||||||||||||||nostaa pystyyn|postawić (
 fa lika||||strengthen (reinforce)||||||||||||||||vahvistaa (voimistaa)|wzmocnić (wzmocnić, wzmóc)
 fa linke||||connect (join, link)||conectar (empalmar, enlazar, vincular)|relier (connecter)|соединить (подключить)||连接|繋ぐ|||जोड़ना (jodana)||menyambung (berangkai)|kuungana|bağlamak||yhdistää|łączyć, wiązać, złączyć
 fa loka||||put (place, set)|mettre (placer)|colocar (poner, ubicar)|colocar (pôr)|ставить||放置|||||||||lokigi|panna (asettaa, sijoittaa)|umieścić (postawić)
-fa lon||||debate (discuss)||debatir (discutir)||||||||||||||keskustelu (debatti)|debatować, prowadzić dyskurs
+fa lona||||debate (discuss)||debatir (discutir)||||||||||||||keskustelu (debatti)|debatować, prowadzić dyskurs
 fa long||||lengthen (prolong)||alargar|||||||||||||longigi|pidentää|przedłużyć, przedłużać
 fa maf||||forgive (pardon)|pardonner|perdonar (disculpar)|perdoar (desculpar)|||||||माफ करना||memaafkan|kusamehe|affetmek|pardoni|antaa anteeksi|
 fa mal||||own (possess, have)||poseer (tener, ser dueño de)||||||||||||||omistaa|mieć (posiadać)
@@ -1191,7 +1191,7 @@ fem sim ja||||feminist||feministe||||||||||||||feministi|feminista (feministka)
 fen|||zho:分 (fèn), wuu:分 (fén), yue:分 (fan), vie:phần, tha:ปัน (pan), jpn:分 (bun), kor:분 (bun)|part (component, segment, fraction, distinct element of something larger)|part|parte (fracción)|parte|parte||部分|部分|부분|phần|अंश|অংশ |suku (bagian)|sehemu|parça|parto (frakcio)|osa (lohko, pala)|część, ułamek
 fen di||||partial||parcial|||||部分的|||||||||osittainen|
 fen gata||||analysis (dissection)|analyse|análisis (disección)|análise|анализ||分析|分析 (解析)|||विश्लेषण||||analiz|analizo|analyysi|analiza
-fendona||||contribute||contribuir||||||||||||||osallistua (tehdä osansa)|wnieć wkład (przyczynić się)
+fen dona||||contribute||contribuir||||||||||||||osallistua (tehdä osansa)|wnieć wkład (przyczynić się)
 fermi yum|yum 100|Fm|eng:fermium, fra:fermium, spa:fermio, por:férmio, rus:фермий, zho:镄 (fèi), jpn:フェルミウム, kor:페르뮴, vie:fecmi, hin:फर्मियम, ben:ফার্মিয়াম, may:fermium, swa:fermi, ara: فرميوم|fermium|fermium|fermio|férmio|фермий|فرميوم|镄|フェルミウム|페르뮴|fecmi|फर्मियम|ফার্মিয়াম|fermium|fermi|fermiyum|fermio|fermium|ferm
 fero|yum 026|Fe|spa:hierro, por:ferro, fra:fer, may:ferum, swa:feri|iron|fer|hierro|ferro|железо|حديد|铁|鉄|철|sắt|लोहा|আয়রন|besi (ferum)|chuma (feri)|demir|fero|rauta|żelazo
 festa|||por:festa, spa:fiesta, fra:fête, deu:Fest, eng:festival, rus:фестиваль (festival'), may:pesta|party (celebration, festival)||celebración (fiesta)||||||||||pesta|||festo|juhlat|przyjęcie, święto, festiwal
@@ -1223,7 +1223,7 @@ fito logi||||botany (phytology)|botanique|botánica|botânica|ботаника||
 fito yam sim ja||||vegetarian|végétarien|vegetariano|vegetariano|вегетарианец|نَبَاتِيّ|素食主义者|菜食主義者 (ベジタリアン)|채식주의자|người ăn chay|शाकाहारी||||vejetaryen||kasvissyöjä|wegetarianin
 fizika||||physics||física|||||||||||||fiziko|fysiikka|fizyka
 fizika ja||||physicist||físico (científico)|||||||||||||fizikisto|fyysikko|fizyka
-fizika shuta|||eng:physics, spa:por:física, rus:физика (fizika), tur:may:fizik, ara:فِيزِيقَا‎ (fīzīqā), swa:fizikia, hin:फ़िज़िक्स (fiziks)|physics (science)||física|||||||||||||fiziko|fysiikka|fizyk
+fizika suta|||eng:physics, spa:por:física, rus:физика (fizika), tur:may:fizik, ara:فِيزِيقَا‎ (fīzīqā), swa:fizikia, hin:फ़िज़िक्स (fiziks)|physics (science)||física|||||||||||||fiziko|fysiikka|fizyk
 flame|||eng:fra:inflammation + zho:炎 (yán), yue:炎 (jim4), kor:염 (yeom), vie:viêm|inflammation (-itis)|inflammation|inflamación|inflamaçao|воспаление||炎症||||||||||tulehdus|zapalenie
 fleche|||spa:por:flecha, fra:flèche, eng:fletch|arrow (bolt)|flèche|flecha|flecha (seta)|стрела (стрелка)||箭|矢 (矢印)|||||||||nuoli|strzała (bełt)
 fleche ja||||fletcher||||||||||||||||nuolentekijä|wytwórca łuków i strzał
@@ -1258,7 +1258,7 @@ foto gola||||halo (aureola)||halo (aureola)|||||||||||||halo|sädekehä (halo)|e
 foto grafi|||eng:photograph, fra:photographie, spa:por:fotografia, rus:фотография, hin:फ़ोटो (foṭo), ben:ফটো (phôṭo), may:foto, tur:fotoğraf|photograph|photographie|foto (fotografía)|foto (fotografia)||| 照片 (相片)|写真|사진|hình|फ़ोटो|ফটো|foto||fotoğraf|foto|valokuva (foto)|zdjęcie (fotografia)
 foto grafi gi||||camera||cámara|||||||||||||fotilo|kamera|kamera, aparat fotograficzny
 foto grafi ja||||photographer||fotógrafo|||||||||||||fotisto|valokuvaaja|fotograf
-foto grafi shuta||||photography|photographie|fotografía|fotografia|фотография|||||||||||fotografio|valokuvaus|fotografia
+foto grafi suta||||photography|photographie|fotografía|fotografia|фотография|||||||||||fotografio|valokuvaus|fotografia
 foto kane||||torch||antorcha|||||||||||||torĉo|soihtu|pochochodnia (latarka)
 foto lin||||optical fibre (optical cable)||||||光线||||||||||valokuitu (valokaapeli)|
 foto mata di||||matte (opaque)|mat (opaque)|mate (opaco)|mate (opaco)|матовый||||||||||||matta|
@@ -1306,7 +1306,7 @@ ga|||yue:假 (gaa1), wuu:假 (ga) + hin:अगर (agar), fas:urd:اگر‎‎ (
 Gabon|desha|GA||Gabon||Gabón||||||||||||||Gabon|Gabon
 gabur|||ara:(qabr), hin:क़ब्र (qabra), ben:কবর (kôbôr), may:kubur, swa:kaburi, tur:kabir + deu:Grab, pol:grób, rus:гроб (grob)|grave (tomb, bury)|tombe (enterrer)|tumba (sepultura, enterrar)|sepultura (túmulo, enterrar)|могила (гроб, хоронить)||坟墓 (埋葬)|墓 (埋葬, 葬る)|무덤|mộ (phần mộ)|क़ब्र|কবর|kubur|kaburi|mezar (kabir)|tombo (enterigi)|hauta|grób (mogiła, grobowiec, zakopać, pochować)
 gabur bagi||||graveyard (cemetery, burial ground)|cimetière|cementerio|cemitério|кладбище|مقبرة‎|公墓 (墓地)|墓 (墓地)|묘지|nghĩa trang|क़ब्रिस्तान|কারবালা|pekuburan|makaburi|mezarlık (kabristan, mezaristan)|tombejo|hautausmaa|cmentarz
-gabur sheku||||tombstone (gravestone)|pierre tombale|lápida|lápide|надгробие||墓石 (墓碑)|墓石 (墓碑)|묘석|bia mộ|कब्र का पत्थर||batu nisan||mezartaşı|tomboŝtono|hautakivi|nagrobek
+gabur seku||||tombstone (gravestone)|pierre tombale|lápida|lápide|надгробие||墓石 (墓碑)|墓石 (墓碑)|묘석|bia mộ|कब्र का पत्थर||batu nisan||mezartaşı|tomboŝtono|hautakivi|nagrobek
 gadolin yum|yum 064|Gd|eng:gadolinium, fra:gadolinium, spa:gadolinio, por:gadolínio, rus:гадолиний, zho:钆 (gá), jpn:ガドリニウム, kor:가돌리늄, vie:gađolini, hin:ग्याडोलिनियम, ben:গ্যাডোলিনিয়াম, may:gadolinium, swa:gadolini, ara: جدولينيوم|gadolinium|gadolinium|gadolinio|gadolínio|гадолиний|جدولينيوم|钆|ガドリニウム|가돌리늄|gađolini|ग्याडोलिनियम|গ্যাডোলিনিয়াম|gadolinium|gadolini|gadolinyum|gadolinio|gadolinium|gadolin
 gaja|||hin:गज (gaj), tel:గజము (gajamu), kan:ಗಜ (gaja), may:gajah, tgl:gadya|elephant||elefante|||||||||||||elefanto|norsu (elefantti)|słoń
 galaksi|||eng:galaxy, spa:galaxia, por:galáxia, fra:galaxie, rus:галактика (galaktika), tur:may:galaksi, hin:गैलेक्सी (gaileksī)|galaxy|galaxie|galaxia|galáxia|галактика||恆星系|銀河|은하|thiên hà|गैलेक्सी|ছায়াপথ|galaksi||galaksi|galaksio|galaksi|galaktyka
@@ -1412,7 +1412,7 @@ ging lin||||warp||||||經紗|縦糸|||||||||loimi|
 gingam|bio|Citrus japonica|yue:柑橘 (gam1gwat1), zho:金橘 (jīnjú), jpn:キンカン (kinkan), kor:금귤 (geumgyul), vie:kim quất, eng:spa:fra:kumquat, por:cunquate, rus:кумкват (kumkvat), tur:kumkat, ara:كمكوات (kamakawat), may:kumkuat|kumquat|kumquat|kumquat (quinoto)|quincã (cunquate)|кумкват (кинкан)||金柑|キンカン (キンキツ)|||||kumkuat||kumkat||kumkvatti|kumkwat
 gio||||teach (educate, instruct, doctrine)|enseigner|enseñar (instruir, doctrina)|ensinar (lecionar)|учить (преподавать)|دَرَّسَ|教学|教える (教義, -教)|||सिखाना (पढ़ाना)|শেখান|mengajar|kufundisha|öğretmek (ders vermek)|instrui (lernigi)|opettaa|
 gio ja||||teacher (instructor)||docente (enseñante, profesor, maestro)|||||教員|||||||||opettaja|
-gioka|||zho:玉 (yù), yue:玉 (yuk6), nan:玉 (gio̍k), jpn:玉 (gyoku), vie:ngọc (玉), may:giok|jade|jade|jade|jade|нефрит (жад)||玉||||||giok||yeşim|jado|jade|żad
+giuka|||zho:玉 (yù), yue:玉 (yuk6), nan:玉 (gio̍k), jpn:玉 (gyoku), vie:ngọc (玉), may:giok|jade|jade|jade|jade|нефрит (жад)||玉||||||giok||yeşim|jado|jade|żad
 giota|||tha:หยด (yòt), vie:giọt, + eng:iota, rus:йота (yota) + spa:por:gota|drop (droplet)||gota||||||||||||||pisara (tippa)|kropla
 gitar|||eng:guitar, fra:guitare, spa:por:guitarra, rus:гитара (gitara), ara:(qīṯāra), hin:गिटार (giṭār), ben:গিটার (giṭar), zho:吉他 (jítā), jpn:ギター (gitā), kor:기타 (gita), swa:gitaa|guitar|guitare|guitarra|guitarra|гитара||吉他|ギター|기타|ghi-ta|गिटार|গিটার|gitar|gitaa|gitar|gitaro|kitara|gitara
 glis|||fra:glisser, ita:glissare + eng:glacier,glissando, spa:por:glaciar,glisando, rus:глиссандо (glissando), ara:غليساندو (ghlysandw), jpn:グリッサンド (gurissando) + may:gelangsar|slide (slip, glide, skate)|glisser|deslizar|deslizar|задвигаться (скользи́ть)||滑下|滑る|||||||||liukua (luistaa)|ślizgać się (poślizgnąć się, jeździć na łyżwach)
@@ -1426,7 +1426,7 @@ go|dem.prn.||yue:嗰 (go2), kor:그 (geo) + ben:ও (o), hin:वह (vo), tur:o|
 gol|||por:spa:gol, eng:goal, jpn:ゴール (gōru), kor:골 (gol), hin:गोल (gola), tel:గోలు (gōlu), rus:гол (gol)|goal (destination)|but (destination)|meta (gol, destinación)|meta (gol)|цель||目的|目的 (行き先, ゴール)|||लक्ष्य (गोल)||||amaç (hedef, gol)|golo|maali (pelissä)|cel
 gola|||hin:गोल (gol), ben:গোলক (golôk), tel:గోళము (gōḷamu) + ara: كُرَة‎ (kura), fas: کره‎ (kore), tur:küre|circle (sphere, round object)||círculo||||||||||||||piiri (ympyrä)|koło, okrąg
 gola di||||round (circular)||redondo (circular)||||||||||||||pyöreä|okrągły
-gola sheku||||cobblestone|pavé|adoquín||булыжник||鹅卵石|丸石 (玉石, 栗石)|||||||||mukulakivi|bruk
+gola seku||||cobblestone|pavé|adoquín||булыжник||鹅卵石|丸石 (玉石, 栗石)|||||||||mukulakivi|bruk
 golem|||heb:גולם‎ (golem), eng:spa:por:fra:may:golem, deu:Golem, rus:голем (golem), ara:غولم (ghwlm) jpn:ゴーレム (gōremu), kor:골렘 (gollem)|golem||||||||||||||||golem|golem
 gomu|||spa:tgl:goma, fra:gomme, jpn:ゴム (gomu), kor:고무 (gomu), deu:Gummi|rubber||goma (caucho, hule)|||||||||||||kaŭĉuko|kumi|guma
 gona|||hin:कोण (koṇ), tel:(kōnamu), swa:kona, eng:corner, hau:kwana, fra:-gone, spa:por:-gono|corner (angle)||esquina (rincón, ángulo)||||||||कोण|||||angulo|kulma (nurkka)|kąt
@@ -1570,7 +1570,7 @@ Helsinki|xefsite|FI||Helsinki||||||||||||||||Helsinki|
 hem||||ponder (think, contemplate, consider, regard)|considérer|considerar (reflexionar, pensar en)|considerar|думать||深思 (考虑)|考える|||विचार करना||menung (mengirakan)|||pripensi (rigardi ia)|miettiä (pohtia, pitää jonakin)|dumać, rozmyślać, zastanawiać się, rozważać, brać pod uwagę
 hem…|||eng:hmm, rus:хм (hm), эм (em), kor:음 (eum)|hmm…|hum…|hm…|hmm…|хм…|||||hmm… (hừmm…)||||||hm…|hmm…|hmm…
 hema|||ara:(xayma), hau:laima, hin:ख़ैमा (xEmā), swa:hema, may:kemah, may:khemah, mng:майхан (mayhan)|tent|tente|carpa (toldo)||палатка (шатёр)||帐篷|||||||||tendo|teltta|namiot
-hen|||zho:恨 (hèn), yue:恨 (han6), wuu:恨 (hhen3), vie:hận, kor:한  (han) + jpn:嫌 (ken) + fra:haine|hatred (hate, resentment, odium)|haine|odio|||||||||||||malamo|viha (inho)|nienawidzić
+hena|||zho:恨 (hèn), yue:恨 (han6), wuu:恨 (hhen3), vie:hận, kor:한  (han) + jpn:嫌 (ken) + fra:haine|hatred (hate, resentment, odium)|haine|odio|||||||||||||malamo|viha (inho)|nienawidzić
 hero|||eng:hero, fra:héros, spa:héroe, por:héroi, rus:герой (geroy), hin:हीरो (hīro), jpn:ヒーロー (hīrō), kor:히로 (hiro)|hero|héros|héroe|héroi|герой||英雄 (勇士)|英雄 (勇者, ヒーロー)|영웅 (히로)|anh hùng|नायक (वीर, हीरो)|বীর|wira (pahlawan)|shujaa|kahraman|heroo|sankari (urho)|bohater, heros
 hero di||||heroic||valiente (heroico)|||||||||||||heroa|urhea (sankarillinen)|bohaterski, heroiczny, odważny, brawurowy
 hero kata||||saga (heroic tale)||||||||||||||||sankaritaru (legenda)|
@@ -1599,7 +1599,7 @@ hisabu|||ara: حِسَاب‎ (ḥisāb), tur:hesap, orm:hisaaba, swa:hisabu, hi
 hisabu loge||||account|compte|cuenta|conta|счёт|حِسَاب‎|账户|口座|계좌|tài khoản|हिसाब (खाता)|হিসাব|akaun (rekening, hisab)|akaunti (hesabu)|hesap|konto|tili|konto
 hisabu logi||||mathematics (math)|mathématiques|matemática|matemática|математика||数学|数学|||गणित||hisab (matematik)|githafu (hesabu)||matematiko|matematiikka (matikka)|matematyka
 hisabu logi ja||||mathematician||matemático|||||||||||||matematikisto|matemaatikko|matematyk
-hisabu shuta||||arithmetics||aritmética (cálculos)||||||||||||||laskuoppi (aritmetiikka)|arytmetyka
+hisabu suta||||arithmetics||aritmética (cálculos)||||||||||||||laskuoppi (aritmetiikka)|arytmetyka
 histori||||history (annals)||historia (pasado)|||||||||||||historio|historia (aikakirjat)|historia; annały, roczniki
 histori ja||||historian||historiador|||||||||||||historiisto|historioitsija|historyk
 histori logi|||eng:history, spa:swa:historia, por:história, fra:histoire, rus:история (istoriya)|history (study of history)||historia (estudio de sucesos del pasado)|||||||||||||historio (studo de historio)|historia (oppiaine)|historia, badanie historii
@@ -1611,9 +1611,9 @@ hogo|||spa:fuego, por:fogo + rus:огонь (ogon’), hin:आग (āg), ben:অ
 hogo di||||fiery||ardiente (encendido)|||||||||||||fajra|tulinen|ognisty
 hogo puja||||pyrolatry||||||||||||||||tulenpalvonta|kult ognia
 hogo sanduku||||lantern||farol (linterna)|||||||||||||lanterno|lyhty|latarnia
-hogo shan||||volcano|volcan|volcán|vulcão|вулкан||火山|火山|||||||||tulivuori|wulkan
-hogo shan kancha||||volcanic glass||vidrio volcánico||||||||||||||vulkaaninen lasi|szkło wulkaniczne
-hogo sheku||||flint|silex|pedernal (sílex)|pederneira|кремень||燧石|火打ち石 (フリント)|||चक़मक़||||||piikivi|krzemień
+hogo san||||volcano|volcan|volcán|vulcão|вулкан||火山|火山|||||||||tulivuori|wulkan
+hogo san kancha||||volcanic glass||vidrio volcánico||||||||||||||vulkaaninen lasi|szkło wulkaniczne
+hogo seku||||flint|silex|pedernal (sílex)|pederneira|кремень||燧石|火打ち石 (フリント)|||चक़मक़||||||piikivi|krzemień
 hogo tehni||||fireworks (pyrotechnics)|feu d’artifice|dispositivo pirotécnico|fogos de artifício|фейерверк||烟火|花火|||||||||pyrotekniikka|pirotechnika
 hoki|||eng:fra:spa:hockey, por:hóquei, rus:хоккей (hokkey),  jpn:ホッケー (hokkē), hin:हाकी (hākī), ben:হকি (hôki), ara:(hūkī), swa:hoki|hockey|hockey|hockey|hóquei|хоккей||曲棍球|ホッケー|khúc côn cầu||हाकी|হকি|hoki||hokey|hokeo|hockey (jääkiekko)|hokej
 holera|||eng:cholera, spa:por:cólera, fra:choléra, rus:холера (holera), tur:kolera, ara:كُولِيرَا‎ (kōlīrā), hin:कॉलरा (kŏlrā), zho:虎列拉 (hǔlièlā), jpn:コレラ (korera)|cholera||cólera||||||||||||||kolera|cholera
@@ -1632,7 +1632,7 @@ hua|||zho:花 (huā), vie:hoa, kor:화 (-hwa-), swa:ua|flower|fleur|flor|flor|ц
 hua jara||||flower vase||florero||||花瓶|||lọ hoa|गुलदान (फूलदान)|||||vazo|kukkamaljakko|
 hua mosim|mosim|||spring (springtime)||primavera||весна|||春|||||musim bunga|||printempo|kevät|wiosna
 hua pote||||flowerpot|pot de fleur|maceta (plantera)|vaso de flores|цвето́чный горшок||花盆|植木鉢|화분|chậu hoa||||||florpoto|kukkaruukku|
-huang|rang||zho:黄 (huáng), yue:黃 (wong4), wuu:黃 (húan), vie:vàng|yellow||amarillo|||||||||||||flava|keltainen|żółty
+huangu|rang||zho:黄 (huáng), yue:黃 (wong4), wuu:黃 (húan), vie:vàng|yellow||amarillo|||||||||||||flava|keltainen|żółty
 hui|||zho:灰 (huĭ), yue:灰 (fui), jpn:灰 (hai), + kor:회색 (hoesaeg)|ash (ashes)||ceniza||||||||||||||tuhka|popiół
 hui darte||||podzol|podzol|podsol|espodossolo|подзол||灰化土|ポドゾル|||||||||podsoli|gleba bielicoziemna
 hui rang|rang|||grey (gray, ashy)||gris||||||||||||||harmaa|szary
@@ -1730,8 +1730,8 @@ jamul|bio|Syzygium|hin:जामुन (jāmun), eng:jambul, por:jambolão, ara:
 jan|||zho:人 (rén), wuu人 (zén), jpn:人 (jin) + hin:जन (jan), ben:-জন (-jôn), may:-jana, tha:ชน (chon), khm:ជន (jon) + fra:gens, por:gente|person (individual, -ist, -er)|personne|persona (ista, -ador)|pessoa|||人|人 (者, 員, 徒)||||||||persono|henkilö|osoba
 janela|||por:janela, ben:জানালা (janala), may:jendela + tam:சன்னல் (sannal), nya:zenera, kon:nêla|window|fenêtre|ventana|janela|окно|شباك‎|窗戶|窓|창|cửa sổ|खिड़की|জানালা|jendela|dirisha|pencere|fenestro|ikkuna|okno
 janela frem||||window frame||||||窗框|||||||||fenestrokadro|ikkunankehys (ikkunanpuite)|
-jang di||||crafty (dexterous)||||||||||||||||kätevä|umiejętny (sprawny, zręczny)
-jang ja|||zho:匠 (jiàng), tha:ช่าง (jang), khm:ជាង (ciəng)|artisan (craftsman)||artesano||||工匠 (匠人)|||||||||metiisto|artesaani (käsityöläinen)|rzemieślnik
+jianga di||||crafty (dexterous)||||||||||||||||kätevä|umiejętny (sprawny, zręczny)
+jianga ja|||zho:匠 (jiàng), yue:匠 (zoeng6), tha:ช่าง (jang), khm:ជាង (ciəng)|artisan (craftsman)||artesano||||工匠 (匠人)|||||||||metiisto|artesaani (käsityöläinen)|rzemieślnik
 jangal|||eng:fra:jungle, spa:jungla, por:jângal, rus:джунгли (džungli), hin:जंगल (jangal), ben:জঙ্গল (jônggôl), may:jenggela, jpn:ジャングル (janguru), kor:정글 (jeonggeul), tur:cengel|forest (woods, jungle)|forêt (jungle)|bosque (jungla, selva)|selva (floresta, jângal)|лес (джунгли)||森林|森 (森林, ジャングル)|숲 (삼림 , 정글)|rừng|जंगल (वन)|বন (জঙ্গল)|hutan (jenggela)|msitu|orman (cengel)|arbaro|metsä (viidakko)|las, dżungla, zagajnik
 jara|||ara: جَرَة‎ (jara), eng:jar, fra:jarre, spa:por:jarra|jar (jug, pitcher, carafe, amphora, vase)|jarre (carafe, cruche)|jarra|jarra (jarro)|кувшин (графин)|جَرَّة‎ (زِير‎)|罐 (瓶)|||lọ (bình)||||||kruĉo|ruukku (kannu, maljakko, karahvi)|dzban, dzbanek; słój, słoik; wazon
 jau|bio|Hordeum vulgare|hin:जौ (jau), ben:যব (jôb), mar:जव (jav), guj:જવ (jav), fas: جو‎ (jow)|barley|orge|cebada|cevada|ячмень||大麦|大麦|보리|lúa mạch|जौ|যব|barli|shayiri|arpa|hordeo|ohra|jęczmień
@@ -1741,7 +1741,7 @@ jaze||||jazz||jazz||||||||||||||jazz (jatsi)|jazz, dżez
 jebe|||hin:जेब (jeb), pnb:ਜੇਬ (jeb), urd:(jeb), tel:(jēbu), ara:(jayb), tur:cep, wol:jiba|pocket||bolsillo|||||||||||||poŝo|tasku|kieszeń
 jebra|||ara:fas:(jabr), tur:cebir, urd:(aljabrā), eng:algebra, fra:algèbre, swa:aljebra|algebra||álgebra|||||||||||aljebra|||algebra|algebra
 jeka|||zho:借 (jiè), yue:借 (ze3), wuu:借 (jia2), jpn:借 (shaku), kor:적 (jeok) + eng:check|borrow (lend)|prêter (empruntre)|prestar (pedir prestado)|emprestar (pedir emprestado)|||借|借用||||||||||pożyczyć
-jeka daku|||zho:借 (jiè), yue:借 (ze3), jpn:借 (shaku), kor:적 (jeok) + eng:check|borrow|empruntre|pedir prestado|pedir emprestado|||借入|借りる||||||||||pożyczać (pożyczyć)
+jeka deku|||zho:借 (jiè), yue:借 (ze3), jpn:借 (shaku), kor:적 (jeok) + eng:check|borrow|empruntre|pedir prestado|pedir emprestado|||借入|借りる||||||||||pożyczać (pożyczyć)
 jeka dona||||lend|prêter|prestar|emprestar|||借出|貸す||||||||||pożyczać komuś (pożyczyć komuś)
 jeka loga||||loanword||préstamo lingüístico|||||||||||||||zapożyczenie (wyraz obcy)
 jela|||eng:jail, fra:geôle, hin:जेल (jel), ben:জেল (jēl), tel:జైలు (jailu), urd: جیل‎ (jēl), swa:jela + spa:por:jaula|prison (imprisonment)||prisión||||||||||||||vankeus|więzienie, kara więzienia, kara pozbawienia wolności
@@ -1765,7 +1765,7 @@ jene yo zou||||breed|élever|criar||выращивать|||湧かす||||||||||ro
 jeng|||zho:爭 (zhēng), vie:tranh, kor:전쟁 (jeonjaeng), tur:kur:ceng, fas:urd:(jang), hin:जंग (jang)|fight (war, battle, combat)||pelea (guerra, batalla)|||||戦闘 (格闘)||||||||milito (batalo)|taistelu (sota)|walka, wojna
 jeng di||||military (martial, warlike)||macrial (militar)|||||||||||||milita|sotilaallinen|militarny, wojskowy, wojenny
 jeng ja||||warrior (fighter)||luchador (guerrero)||||||||||||||soturi (taistelija)|wojownik, bojownik
-jeng shuta|||zho:武术 (wǔshù), jpn:武術 (bujutsu), vie:võ thuật, kor:무술 (musul), eng:martial art|martial art||arte marcial||||||||||||||kamppailulaji|sztuka walki
+jeng suta|||zho:武术 (wǔshù), jpn:武術 (bujutsu), vie:võ thuật, kor:무술 (musul), eng:martial art|martial art||arte marcial||||||||||||||kamppailulaji|sztuka walki
 jenshen|bine|Panax|zho:人蔘 (rénshēn), min:人蔘 (jîn-sam), eng:spa:por:tur:may:ginseng, rus:женьшень (zhen’shen’), hind:जिनसेंग (jinseṅg), jpn:人参 (ninjin)|ginseng||ginseng||||||||||||||ginseng|żeń-szeń
 Jerze|desha|JE||Jersey||Jersey||||||||||||||Jersey|Jersey
 jeste|||eng:gesture, spa:por:gesto, fra:geste, rus:жест (zhest), tur:jest, fas:ژست‎ (žest)|gesture||gesto||||||||||||||ele|gest
@@ -1785,7 +1785,7 @@ jiu||||live (be alive, living)|vivant|vivo (lleno de vida)|vivo|живой||||||
 jo||||which (who, that)||||||||||||||||joka (mikä)|
 joke|||eng:fra:joke, fas:جوک‎ (jok), jpn:ジョーク (jōku) + zho:笑话 (xiàohuà), nan:笑詼 (chhiò-khoe)|joke||broma (chiste)||||||||||||||vitsi|żart
 joke ja||||joker||bromista (chistoso)||||||||||||||vitsiniekka|żartowniś, dowcipniś
-jong|||zho:種 (zhǒng), yue:種 (zung2), wuu:種 (tson2), jpn:種 (shu), kor:종 (jong), vie:chủng|species||especie||||||||||||||laji|gatunek
+jung|||zho:種 (zhǒng), yue:種 (zung2), wuu:種 (tson2), jpn:種 (shu), kor:종 (jong), vie:chủng|species||especie||||||||||||||laji|gatunek
 joven|||hin:जवान (javān), fas:urd:(javān), tel:యువ (yuva), por:jovem, spa:joven, ita:giovane, eng:juvenile, fra:juvénile|young (juvenile)|jeune (juvénile)|joven|jovem|юный||||젊다||जवान|||||juna|nuori|młody
 joven fem||||girl||niña|||||女の子||||||||knabino|tyttö (nuori neito)|dziewczyna
 joven jan||||youth (young person)||joven|||||青少年||||||||junulo|nuorukainen|młodzież, młoda osoba
@@ -1798,13 +1798,13 @@ jude di||||judicial||||||||||||||||oikeudellinen|
 jude ja|||eng:judge, fra:juge, spa:juez, por:juiz, hin:जज (jaj), ben:জজ (jôj), swa:jaji + rus:судья (sud'ya)|judge (referee)|juje|juez (árbitro, réferi)|juiz|судья|||||||||||juĝisto|tuomari|sędzia
 jul|unomete|J||joule (J)|joule (J)|joule (J)|joule (J)|джоуль (J)||焦耳 (J)|ジュール (J)|줄 (J)||जौल (J)||joule (J)||jul (J)|ĵulo (J)|joule (J)|dżul (J)
 jumla|||ara:(jumla), tur:cümle, hin:जुमला (jumlā), zho:句 (jù)|sentence (phrase)||oración||фраза||句子|||||||||||zdanie (fraza)
-jung|||zho:中 (zhōng), yue:中 (zung1), kor:중 (jung), jpn:中 (chuu-), vie:trung|middle (center)|centre|centro|centro|центр|مَرْكَز|中心|中心|중심|trung tâm|केंद्र|কেন্দ্র|pusat|kati (senta)|merkez|centro|keskus (keskikohta)|środkowy, centralny
-jung||||to be centered (amid, in the middle)||centrarse (en el centro de)||||||||||||||keskittyä (olla keskellä)|być wycentrowanym, być w środku
-Jung Afrika Komun krati|desha|CF||Central African Republic||República Centroafricana||||||||||||||Keski-Afrikan Tasavalta|Republika Środkowoafrykańska
-jung di||||central (middle)||central|||||||||||||||centralny (środkowy)
-jung fon||||vowel|voyelle|vocal|vogal|гласный||||보컬 부분||||vokal|||vokalo|vokaali|samogłoska
-jung shula kan||||secondary school|école secondaire|escuela secundaria|ensino secundário|средняя школа||中学|||trường trung học|||sekolah menengah|||gimnazio|yläaste ja lukio|
-Jungoku|desha|CN||China|Chine|China|China|Китай|اَلصِّين‎|中国|中国|중국|Trung Quốc|चीन|চীন|Cina (Tiongkok)|Uchina|Çin|Ĉinio|Kiina|Chiny
+jong|||zho:中 (zhōng), yue:中 (zung1), kor:중 (jung), jpn:中 (chuu-), vie:trung|middle (center)|centre|centro|centro|центр|مَرْكَز|中心|中心|중심|trung tâm|केंद्र|কেন্দ্র|pusat|kati (senta)|merkez|centro|keskus (keskikohta)|środkowy, centralny
+jong||||to be centered (amid, in the middle)||centrarse (en el centro de)||||||||||||||keskittyä (olla keskellä)|być wycentrowanym, być w środku
+Jong Afrika Komun krati|desha|CF||Central African Republic||República Centroafricana||||||||||||||Keski-Afrikan Tasavalta|Republika Środkowoafrykańska
+jong di||||central (middle)||central|||||||||||||||centralny (środkowy)
+jong fon||||vowel|voyelle|vocal|vogal|гласный||||보컬 부분||||vokal|||vokalo|vokaali|samogłoska
+jong shula kan||||secondary school|école secondaire|escuela secundaria|ensino secundário|средняя школа||中学|||trường trung học|||sekolah menengah|||gimnazio|yläaste ja lukio|
+Jongoku|desha|CN||China|Chine|China|China|Китай|اَلصِّين‎|中国|中国|중국|Trung Quốc|चीन|চীন|Cina (Tiongkok)|Uchina|Çin|Ĉinio|Kiina|Chiny
 jupe|||fra:jupe, ara:(jūb), rus:юбка (yubka)|skirt||falda|||||||||||||jupo|hame|spódnica
 Jupiter|planete 5|||Jupiter|Jupiter|Jupiter|Júpiter|Юпитер|المشتري|木星|木星|||||||Jüpiter||Jupiter|Jowisz
 jus|||eng:juice, swa:jusi, tam:ஜூஸ் (jūs), jpn:ジュース (jūsu), kor:주스 (juseu)|juice|jus|jugo (zumo)|suco (sumo)|сок|عَصِير‎|汁|ジュース|즙 (스)|dịch|रस|রস|jus|jusi|šire|suko|mehu|sok
@@ -1900,7 +1900,7 @@ kanun|||ara:(qānūn), tur:kanun, swa:kanuni, hin:क़ानून (qānūn), 
 kanyon|||eng:fra:canyon, spa:cañón, por:canhão, rus:каньон (kan’on), pol:kanion, jpn:キャニオン (kyanion), hun:tur:may:tgl:kanyon|canyon (ravine, gorge, gully)|canyon (ravin)|cañón (barranco, quebrada)|canhão (ravina, barranco)|овраг (ущелье, каньон)||峡谷 (深谷)|峡谷||||||||||kanion
 kape|||tur:kapmak, hun:kap, sve:kapa, fin:kaapata, ned:kapen, spa:por:capturar, eng:capture, spa:por:caber, khm:ចាប់ (cap)|catch (capture, seize, snatch, intercept)||capturar (apresar)|||||||||||||kapti|ottaa kiinni (napata, kaapata)|złapać, łapać, schwytać, chwytać
 kape truke||||trap (snare)|piège|trampa|armadilha|ловушка||陷阱|罠||||||||||pułapka
-kape yo kuang||||mine (extract minerals)|||||||||||||||||kopać (wydobywać)
+kape yo kuanga||||mine (extract minerals)|||||||||||||||||kopać (wydobywać)
 kape yo peshe||||catch fish||pescar|||||||||||||||łapać rybę
 kape yo taksi||||collect fees or taxes||gravar (cobrar tasas)||||||||||||||veloittaa (verottaa)|zbierać opłaty lub podatki (zebrać opłaty lub podatki)
 kar|||eng:car, por:spa:carro, deu:Karre, tel:(kāru) + hin:गाड़ी (gāṛī), swa:gari, fas:(gâri)|car (cart, carriage, wagon, automobile)||coche (carruaje, auto, vagón)|||||車||||||||aŭto (ĉaro)|kärry (vaunu, auto, jne)|wóz, wózek
@@ -1959,7 +1959,7 @@ ke multi di||||how many?||cuántos|||||||||||||kiom?|montako? (paljonko?)|ile?
 ke riti||||how?|comment|cómo|como|как||怎么|どのように|어떻게||कैसे|কিভাবে|bagaimana|-je|nasıl|kiel?|miten?|kiedy?
 ke sate||||when?|quand|cuándo|quando||||何時|||||kapan|lini|ne zaman|kiam?|milloin? (koska?)|zapytać, pytać
 ke she||||what thing?||cuál cosa|||||何事||||||||kio?|mikä? (mitä?)|jak?
-ke yang||||what kind of?||qué tipo de|||||どんな||||||||kia?|millainen?|jaki?
+ke yanga||||what kind of?||qué tipo de|||||どんな||||||||kia?|millainen?|jaki?
 kechape|||yue:茄汁 (kezap), eng:ketchup, hin:केचप (kecap), rus:кетчуп (ketčup), jpn:ケチャップ (kechappu), tgl:ketsap|ketchup||kétchup|||||||||||||keĉupo|ketsuppi|keczup
 kechi|||zho:客气 (kèqì), yue:客氣 (haak3 hei3), wuu:客氣 (khaq qi4)|polite||educado||||客气|||||||||ĝentila|kohtelias (kiltti)|uprzejmy
 keka|||zho:客 (kè), wuu:客 (ka’), jpn:客 (kyaku), kor:객 (gaek), vie:khách, tha:แขก (khæk)|visitation (visit)||visitar|||||||||||||viziti|käynti (vierailu, visiitti)|wizyta
@@ -2020,7 +2020,7 @@ kitabu forma||||formatting||formateo|||||書式付け|||||||||tekstin muotoilu|f
 kitabu gi||||typewriter|machine à écrire|máquina de escribir|máquina de escrever|пишущая машинка||打字机||||टंकण मशीन||mesin tik (mesin taip)||daktilo|tajpilo|kirjoituskone|maszyna do pisania
 kitabu kan||||library|bibliothèque|biblioteca|biblioteca|библиотека|مَكْتَبَة‎|图书馆|図書館|도서관|thư viện|पुस्तकालय|গ্রন্থাগার|perpustakaan|maktaba|kütüphane|librejo|kirjasto|biblioteka
 kitabu minister||||librarian||bibliotecario||библиотекарь|||図書係||||||||||bibliotekarz
-kitabu shuta||||literature|littérature|literatura|literatura|литература (словесность)|أَدَب‎|文学|文献 (文学, 文芸)|문학|văn chương (văn học)|साहित्य (अदब)|সাহিত্য|kesusasteraan|fasihi|literatür (edebiyat)|literaturo|kirjallisuus|
+kitabu suta||||literature|littérature|literatura|literatura|литература (словесность)|أَدَب‎|文学|文献 (文学, 文芸)|문학|văn chương (văn học)|साहित्य (अदब)|সাহিত্য|kesusasteraan|fasihi|literatür (edebiyat)|literaturo|kirjallisuus|
 kivi|bio||eng:fra:spa:may:swa:kiwi, por:quivi, jpn:キーウィ (kīwi), kor:키위 (kiwi), hin:कीवी (kīvī), tur:kivi|kiwi fruit|kiwi|kiwi fruta|quivi|киви||奇异果|キーウィフルーツ|다래 (키위)|trái ki wi (trái dương đào)|कीवी||buah kiwi||kivi|kivo|kiivi|owoc kiwi
 klar|||deu:klar, spa:por:claro, eng:clear, fra:clair|clear (obvious)|clair|claro|claro||||||||||||klara|selvä (selkeä)|przeźroczysty, jasny
 klar!||||of course! (obviously)|||||||||||||||kompreneble|tietysti (selvästi)|oczywiście
@@ -2076,9 +2076,9 @@ kon ten||||hold together||||||||||||||||pitää yhdessä|
 kon trati||||pact (contract, covenant, alliance)|convention (alliance, pacte)|convenion (pacto)|pacto|контракт||公約||||||||||liittosopimus|pakt (kontrakt, ugoda, umowa, konwencja)
 Konakri Ginia|desha|GN||Guinea||Guinea||||||||||||||Guinea|Gwinea
 kone|||eng:por:cone, spa:cono, fra:conique, rus:ко́нус (kónus), tur:koni, may:kon|cone||cono||||||||||||||kartio (keila)|szyszka
-kong|||zho:孔 (kǒng), yue:孔 (hung2), wuu:孔 (khon2), jpn:孔 (kō), kor:공 (gong), vie:hỏng|hole||agujero (hueco)||||||||||||||reikä|dziura
-Kong Fuzi|||zho:孔夫子 (Kǒng Fūzǐ)|Confucious||confucio|||||||||||||Konfuceo|Kungfutse|Konfucjusz
-kong fuzi sim||||Confucianism||confucianismo||||||||||||||Kungfutselaisuus|konfucjanizm
+kung|||zho:孔 (kǒng), yue:孔 (hung2), wuu:孔 (khon2), jpn:孔 (kō), kor:공 (gong), vie:hỏng|hole||agujero (hueco)||||||||||||||reikä|dziura
+Kung Fuzi|||zho:孔夫子 (Kǒng Fūzǐ)|Confucious||confucio|||||||||||||Konfuceo|Kungfutse|Konfucjusz
+kung fuzi sim||||Confucianism||confucianismo||||||||||||||Kungfutselaisuus|konfucjanizm
 Konkani|nas|||Konkani||konkani||||||||||||||konkani (eräs intialainen kieli)|konkani
 konserte|||eng:fra:concert, spa:concierto, por:concerto, deu:Konzert, rus:концерт (koncert), may:tur:konser, jpn:コンサート (konsāto), kor:콘서트 (konseoteu), hin:कॉन्सर्ट (kŏnsarṭ)|concert|concert|concierto|concerto|концерт||音乐会|コンサート (音楽会)|콘서트 (음악회)||कॉन्सर्ट|সঙ্গীতানুষ্ঠান|konser||konser|koncerto|konsertti|koncert
 kontra|coverb|||go against||estar en contra|||||||||||||kontraŭi|mennä vasten|być przeciw
@@ -2134,11 +2134,11 @@ krus arka||||crossbow (ballista)||ballesta||самострел||弩 (十字弓)|
 krus lin||||crosshair (reticle)||retículo||||十字线|十字線|||||||||ristikko|celownik optyczny (siatka lunety)
 kuan|||zho:宽 (kuān), tha:กว้าง (kwang), vie:quảng|wide (broad)||ancho||||||||||||||leveä|szeroki
 kuan ta||||width (breadth)||anchura|||||||||||||||szerokość
-kuang|||zho:矿 (kuàng), vie:khoáng, kor:광 (guang)|mineral (ore)||mineral (mena)||||||||||||||kivennäinen (mineraali)|minerał, ruda
-kuang ja||||miner||minero|||||坑夫||||||||||górnik (kopacz)
-kuang shan||||mine|mine|mina|mina|мина||矿场|鉱山||||||||||kopalnia
-kuang sui||||mineral water||agua mineral||||||||||||||kivennäisvesi|woda mineralna
-kuang tunel||||mineshaft|||||||||||||||||szyb górniczy
+kuanga|||zho:矿 (kuàng), vie:khoáng, kor:광 (guang)|mineral (ore)||mineral (mena)||||||||||||||kivennäinen (mineraali)|minerał, ruda
+kuanga ja||||miner||minero|||||坑夫||||||||||górnik (kopacz)
+kuanga san||||mine|mine|mina|mina|мина||矿场|鉱山||||||||||kopalnia
+kuanga sui||||mineral water||agua mineral||||||||||||||kivennäisvesi|woda mineralna
+kuanga tunel||||mineshaft|||||||||||||||||szyb górniczy
 kuarze|||deu:Quarz, eng:fra:quartz, spa:cuarzo, rus:кварц (kvarc), tur:kuvars, hin:क्वार्ट्ज (kvārtj), jpn:クオーツ (kuōtsu), may:kuarza|quartz|quartz|cuarzo|quartzo|кварц||石英|石英||||||||||kwarc
 Kuba|desha|CU||Cuba||Cuba||||||||||||||Kuuba|Kuba
 kube|||spa:por:cubo, deu:Kubus, eng:fra:cube, rus:куб (kub), ara:(kaʿba), may:kubus, tur:küp|cube|cube|cubo|cubo|куб|كَعْبَة|立方体|立方体|입방체|hình lập phương|घन|ঘনক|kubus||küp|kubo|kuutio|sześcian
@@ -2182,7 +2182,7 @@ lal oranje|bio|Citrus reticulata||mandarin orange (tangerine)|mandarine|mandarin
 lal salmon|bio|Oncorhynchus nerka||sockeye salmon|saumon sockeye|salmón rojo|salmão-vermelho|нерка (красница)||紅鮭|ベニザケ||||||||||nerka (łosoś czerwony)
 lala|||eng:lull, pol:lulać, fas: لالا کردن‎ (lâlâ kardan) + jpn:ララバイ (rarabai), tgl:lalay + swa:-lala|lull|||||||||||||||luli|tuudittaa|lulać
 lala bede||||cradle|berceau|cuna|berço|колыбель (люлька)||摇篮|揺り籠|요람||पालना|দোলনা|buaian||beşik|lulilo|kehto|kołyska (kolebka)
-lala chante||||lullaby|berceause|canción de cuna (nana)|canção de ninar|колыбельная песня||摇篮曲|子守歌 (ララバイ)|자장가||लोरी||nina-bobok|tumbuizo|ninni|lulkanto|tuutulaulu|
+lala chanta||||lullaby|berceause|canción de cuna (nana)|canção de ninar|колыбельная песня||摇篮曲|子守歌 (ララバイ)|자장가||लोरी||nina-bobok|tumbuizo|ninni|lulkanto|tuutulaulu|
 lama||||lama|lama (enseignant religieux du bouddhisme tibétain)|lama|lama|лама (религиозный учитель в тибетском буддизме)||喇嘛|ラマ (チベット仏教の上師)||||||||||lama
 lampa|||eng:lamp, deu:fra:lampe, spa:lámpara, por:lâmpada, rus:лампа (lampa), ara: لمبة‎(lamba), jpn:ランプ (ranpu), kor:램프 (raempeu), hin:लैंप (laimp), ben:ল্যাম্প (lyamp), may:lampu, tur:lamba|lamp|lampe|lámpara|lâmpada (luminária)|лампа|لمبة‎|灯|ランプ|램프|đèn|चिराग़ (लैंप)|ল্যাম্প|lampu|taa|lamba|lampo|lamppu|lampa
 lana|||ara:لعنة (laʿna), swa:laana, hau:la'ana, tur:lanet, fas:la'net, urd:lānat, may:laknat|curse (damn!)|malédiccion|maldición|maldição|проклятие||诅咒|呪い (たたり)||||||||||przekleństwo (cholera!)
@@ -2215,9 +2215,9 @@ le|asp.aux.||zho:了 (le, liǎo), wuu:了 (le’), yue:了 (liu), tha:แล้�
 lefte|||eng:left, rus:левый (levyy)|left||lado izquerdo|esquerdo|левый||左|左|||बायीं||kiri|kushoto|sol||vasen|lewa strona
 lefte di||||left hand||izquierdo|||||||||||||||lewy (lewostronny, z lewej strony)
 lefte sim ja||||leftist (left-winger)||izquerdista||||||||||||||vasemmistolainen|lewicowiec (lewak)
-leng|||zho:冷 (lěng), vie:lạnh, yue:冷 (laang5)|cold||frío||||冷たい (寒い)|||||||||malvarma|kylmä|zimny, chłodny
-leng mosim||||winter|hiver|invierno|inverno|зима||冬天||||सर्दी (जाड़ा,  शिशिर)||musim dingin||kış|vintro|talvi|zima
-leng mosim di||||wintry|hivernal (hibernal)|invernal|invernal (hibernal)|зимний|||||||||||vintra|talvinen|zimowy
+lengo|||zho:冷 (lěng), vie:lạnh, yue:冷 (laang5)|cold||frío||||冷たい (寒い)|||||||||malvarma|kylmä|zimny, chłodny
+lengo mosim||||winter|hiver|invierno|inverno|зима||冬天||||सर्दी (जाड़ा,  शिशिर)||musim dingin||kış|vintro|talvi|zima
+lengo mosim di||||wintry|hivernal (hibernal)|invernal|invernal (hibernal)|зимний|||||||||||vintra|talvinen|zimowy
 lense|||eng:lens, fra:lentille, spa:por:lente, rus:линза (linza), hin:लेंस (lens), ben:লেন্স (lenś), may:lensa, jpn:レンズ (renzu), kor:렌즈 (renjeu)|lens|lentille|lente|lente|линза|عَدَسَة‎|透镜|レンズ|렌즈|thấu kính|लेंस|লেন্স|lensa (kanta)||mercek (adese, lens)||linssi|soczewka
 lenshi|||zho:练习 (liànxí), jpn:練習 (renshū), kor:련습 (ryeonseup)|exercise||ensayo (ejercitio)|||||||||||||ekzerco|harjoitus|ćwiczenie
 lente|||fra:lent, spa:por:lento|slow (lethargic)|lent|lento (despacio)|lento|||慢|遅い (ゆっくり)||||||||malrapida|hidas|powolny (wolny, letargiczny)
@@ -2248,7 +2248,7 @@ lila rang|rang|||lilac color||lila (de color lila)||||||||||||||violetti (liila)
 lili|||eng:little|little (small; a little, somewhat)|petit|pequeño|pequeno|маленький (малый)||小|小さい|작은|nhỏ|छोटा||||küçük|malgranda|pieni (pienesti, vähän)|mały; mało, trochę, nieco
 lili bol||||bubble||burbuja (pompa)|||||||||||||bobelo|kupla|bańka
 lili kaboga|bio|Cucurbita pepo||zucchini|courgette|calabacín|abobrinha|цукини||西葫芦|ズッキーニ||||||||||cukinia
-lili sheku||||pebble (gravel)|caillou||pedrinha|галька||砾石|小石|자갈||||||çakıl|ŝtoneto|sorakivi|kamyk
+lili seku||||pebble (gravel)|caillou||pedrinha|галька||砾石|小石|자갈||||||çakıl|ŝtoneto|sorakivi|kamyk
 lili siti||||small town|||||||||||||||urbeto|pikkukaupunki|
 lili yam||||snack||tentempié||||||||||||||välipala (naposteltava)|przekąska
 lima|nomer|5|may:tgl:lima|five (5)|cinq (5)|cinco (5)|cinco (5)|пять (5)||五 (5)|五 (5)|||||lima|tano||kvin (5)|viisi (5)|pięć (5)
@@ -2310,12 +2310,12 @@ lote|||por:spa:lote, eng:fra:lot|batch (lot)||lote (grupo)||||||||||||||erä (sa
 lotra|bio|Lutrinae|eng:otter + fra:loutre, spa:tgl:lutrino, por:lontra + rus:выдра (vydra)|otter|loutre|nutria|lontra|выдра||獭|獺||||||||||wydra
 lou|||zho:漏 (lòu), yue:漏 (lau6), jpn:漏 (rō), 루 (ru)|leak||chorrear|vazar|протекать (просочиться)||漏|漏る||||||||liki|vuotaa|przeciekać, ciec
 lou sang||||bleed||sangrar|||||||||||||sangi|vuotaa verta|krwawić
-luka|nomer|6|zho:六 (liù), yue:六 (luk6), jpn:六 (roku), kor:육/륙 (六, yuk/ryuk), vie:lục|six (6)|six (6)|seis (6)|seis (6)|шесть (6)||六 (6)|六 (6)|||||||||kuusi (6)|sześć (6)
-luka fase||||hexahedron (cube)||hexaedro (cubo)||||||||||||||kuutio (kuusitahokas)|sześcian (kostka)
-luka gona||||hexagon||hexágono||||||||||||||kuusikulmio|sześciokąt (sześciobok)
+liuka|nomer|6|zho:六 (liù), yue:六 (luk6), jpn:六 (roku), kor:육/륙 (六, yuk/ryuk), vie:lục|six (6)|six (6)|seis (6)|seis (6)|шесть (6)||六 (6)|六 (6)|||||||||kuusi (6)|sześć (6)
+liuka fase||||hexahedron (cube)||hexaedro (cubo)||||||||||||||kuutio (kuusitahokas)|sześcian (kostka)
+liuka gona||||hexagon||hexágono||||||||||||||kuusikulmio|sześciokąt (sześciobok)
 Luksemburge|desha|LU||Luxembourg||Luxemburgo||||||||||||||Luxemburg|Luksemburg
 lulu|||amh:ሉል (lul), ara:(luʾluʾa), swa:lulu, orm:lu'ulu'a, hau:lu'ulu'u, ful:luuluuri, fas:(lo'lo')|pearl||perla|||||||||||||perlo|helmi|perła
-lun|||zho:论 (lùn), yue:論 (leo6), kor:론 (ron), jpn:論 (ron), vie:luận|discussion (debate, discourse)||discusión (debate, discurso)||||论||||||||||väittely (debatti)|dyskusja, debata, dyskurs
+lona|||zho:论 (lùn), yue:論 (leo6), kor:론 (ron), jpn:論 (ron), vie:luận|discussion (debate, discourse)||discusión (debate, discurso)||||论||||||||||väittely (debatti)|dyskusja, debata, dyskurs
 luna|planete 3 lun 1||fra:lune, spa:luna, eng:lunar, rus:луна (luná)|moon|lune|luna|lua|луна|||||||||||luno|kuu|księżyc
 luna keke||||mooncake|gâteau de lune|pastel de luna|bolo lunar|лунный пирог|كَعْكَة اَلْقَمَر‎|月饼|月餅|월병||||kue bulan||ay keki||kuukakku|
 lung|||zho:龙 (lóng), yue:龍 (lung4), vie:rồng,long, kor:용 (yong), 룡 (ryong), jpn:竜 (ryū), khm:រោង (roong), tha:มะโรง (má-roong)|dragon||dragón||||龙|竜|용 (룡)|rồng|||||||itämainen lohikäärme|smok
@@ -2425,7 +2425,7 @@ mata di||||dead (deceased)||muerto|||||||||||||morta|kuollut (vainaa)|martwy, ni
 mata ja||||killer||asesino|||||||||||||mortigisto|tappaja|zabójca
 mate|||eng:matter, fra:matière, spa:por:materia, rus:материя (materiya), deu:Materie, may:materi + ara: مادة (mādda), swa:maada, tur:madde + yue:物 (mat), vie:vật|matter (substance)|matière|sustancia (materia)|matéria|материя|مادة|物质|物質|물질|vật chất|पदार्थ|পদার্থ||maada|madde|materio|aine (materia)|materia, substancja
 mate di||||material||material||||||||||||||aineellinen (materiaalinen)|materialny
-mate lun||||materialism|matérialisme|materialismo|materialismo|материализм||唯物论 (唯物主义)|唯物論 (唯物主義)|||||||||materialismi|
+mate lona||||materialism|matérialisme|materialismo|materialismo|материализм||唯物论 (唯物主义)|唯物論 (唯物主義)|||||||||materialismi|
 matras|||eng:mattress, fra:matelas, rus:матрас (matras), may:matras, jpn:マットレス (mattoresu)|mattress||colchón||||||||||||||patja|materac
 matur||||adult|adulte|adulto||взрослый||成年人|大人||||||||plenaĝa|aikuinen|osoba dorosła
 matur|||eng:fra:mature, spa:por:maduro|mature (ripe, adult)||maduro (adulto, curado)|||||||||||||matura (plenkreska)|kypsä (aikuinen)|dorosły, dojrzały
@@ -2472,7 +2472,7 @@ memo|||eng:memory, fra:mémoire, spa:memoria, por:memória|memory (recollection)
 memo bina||||monument (memorial)||monumento|||||追悼塔 (碑)||||||||||pomnik (memoriał)
 memo note||||memorandum (memo)||memorándum (nota)||меморандум||||||||||||muistio (muistiinmerkintä)|notatka, memo
 memo tehni||||mnemotechny||||||||||||||||muistitekniikka|
-men|||zho:面 (miàn), may:mie, jpn:麺 (men), tha:หมี่ (mii), khm:មី (mi)|noodle||fideo (tallarín)|||||ヌードル||||||||nudelo|nuudeli|makaron
+mena|||zho:面 (miàn), may:mie, jpn:麺 (men), tha:หมี่ (mii), khm:មី (mi)|noodle||fideo (tallarín)|||||ヌードル||||||||nudelo|nuudeli|makaron
 mendelef yum|yum 101|Md|eng:mendelevium, fra:mendélévium, spa:mendelevio, por:mendelévio, rus:менделевий, zho:钔 (mén), jpn:メンデレビウム, kor:멘델레븀, vie:menđelevi, hin:मेण्डेलीवियम, ben:মেন্ডেলিভিয়াম, may:mendelevium, swa:mendelevi, ara: مندلفيوم|mendelevium|mendélévium|mendelevio|mendelévio|менделевий|مندلفيوم|钔|メンデレビウム|멘델레븀|menđelevi|मेण्डेलीवियम|মেন্ডেলিভিয়াম|mendelevium|mendelevi|mendelevyum||mendelevium|
 meninge|||eng:meninx, spa:por:meninge, fra:méninge|meninx (meninges)|méninge|meninge|meninge|||脑脊膜||||||||||aivokalvo|opona mózgowa
 meninge flame||||meningitis||meningitis||||||||||||||aivokalvontulehdus|zapalenie opon mózgowych
@@ -2487,7 +2487,7 @@ mes des du|mes|||December||deciembre|||||１２月|||||||||joulukuu|kwiecień
 mes des un|mes|||November||nobiembre|||||１１月|||||||||marraskuu|marzec
 mes du|mes|||February||febrero|||||２月|||||||||helmikuu|maj
 mes lima|mes|||May||mayo|||||５月|||||||||toukokuu|sierpień
-mes luka|mes|||June||junio|||||６月|||||||||kesäkuu|wrzesień
+mes liuka|mes|||June||junio|||||６月|||||||||kesäkuu|wrzesień
 mes nelu|mes|||April||abril|||||４月|||||||||huhtikuu|lipiec
 mes tisa|mes|||September||septiembre|||||９月|||||||||syyskuu|grudzień
 mes tri|mes|||March||marzo|||||３月|||||||||maaliskuu|czerwiec
@@ -2500,12 +2500,12 @@ mesi jene||||Christmas||Navidad|||||||||||||kristnasko|joulu|Boże Narodzenie
 mestre|||por:mestre, fra:maître, pol:mistrz, eng:master, rus:мастер (master), spa:maestro, deu:Meister, hin:(mistrī)|master (expert)|maître|maestro (experto)|mestre|мастер||||||||||||mestari (asiantuntija)|mistrz (ekspert)
 metal|||eng:spa:por:tur:metal, fra:métal, deu:Metall, rus:мета́лл (metáll)|metal||metal|||||金属||||||||metalo|metalli|metal
 metal bede||||anvil|enclume|yunque|bigorna|наковальня||铁砧|金敷き (鉄床)||||||||||kowadło
-metal jang ja||||blacksmith (iron forger)||herrero||||铁匠||||||||||seppä|kowal
+metal jianga ja||||blacksmith (iron forger)||herrero||||铁匠||||||||||seppä|kowal
 metal lin||||wire|fil de fer|alambre (hilo)|arame|||线 (铁丝)|線 (針金)|철사||तार|তার||waya|tel|drato|vaijeri (metallilanka)|
 metre|||eng:meter, spa:por:-metro, rus:метр tur:metre, + hin:मात्रा (mātrā), ben:মাত্রা (matra), may:matra|measure (measurement)||medir (medida)|||||測定||||||||mezuri|mitta (koko, määrä)|zmierzyć (miara)
 metre gi||||meter (measuring device)||medidor|||||測定装置 (計)||||||||||
 metre grafi||||chart (map, graph, blueprint)|carte (graphique)|carta (mapa, tabla, gráfico)|carta|карта (график, схема)||図表||peta (carta)||नक़्शा (मानचित्र)||||çizelge||kaavio (kartta)|mapa
-metre grafi shuta||||cartography|cartographie|cartografía|cartografia|картография||地图学||||||||||kartogratia|kartografia
+metre grafi suta||||cartography|cartographie|cartografía|cartografia|картография||地图学||||||||||kartogratia|kartografia
 metre unta||||unit (measurement)||unidad (medida)|||||||||||||||jednostka miary
 meza|||por:spa:mesa, hin:मेज़ (mez), swa:meza, may:meja, tam:மேசை (mesei), fas: میز‏‎ (miz), tur:masa|table|table|mesa|mesa|стол|طَاوِلَة|桌子|机 (テーブル)|||मेज़||meja|meza|masa|tablo|pöytä|stół
 meza tela||||tablecloth|nappe|mantel|toalha de mesa|скатерть|غِطَاء اَلْمَائِدَة‎|桌布|テーブル掛け|식탁보|khăn trải bàn|मेज़पोश|টেবিলক্লথ|alas meja||masa örtüsü|tablotuko|pöytäliina|obrus
@@ -2565,14 +2565,14 @@ mode loge||||adverb||adverbo||||||||||||||adverbi|przysłówek
 model|||eng:model, spa:por:modelo, fra:modèle, deu:Modell, rus:моде́ль (modelʹ)|model (design)||modelar||||||||||||||malli|model, wzór, wzorzec, projekt
 moka|||zho:木 (mù), yue:木 (muk6), jpn:木 (moku), kor:목 (mok), vie:mộc, orm:muka|tree|arbre|árbol|árvore|дерево|شجر‎|树木|木|나무|cây|पेड़|গাছ (বৃক্ষ)|pohon (pokok)|mti|ağaç|arbo|puu|drzewo
 moka bano||||wood board (plank)|planche|tablón|tábua (prancha)|доска (планка)||木板|||ván||||||||deska
-moka jang ja||||carpenter||carpintero||||木匠||||||||||puuseppä|stolarz
+moka jianga ja||||carpenter||carpintero||||木匠||||||||||puuseppä|stolarz
 moka jong parke||||arboretum|arboretum, pépinière|arboreto|||||||||||||arboĝardeno|arboretum (puulajipuisto)|arboretum
 moka kane||||stake (stick, peg, skewer)|pieu|estaca|estaca|палка|||杭|||छड़ी (लाठी)|||||paliso|keppi (puukeppi)|słup (pal, kołek)
 moka mate||||wood (timber)||madera||||木材|||||||||ligno|puuaines|drewno
 moka tana||||log (trunk)|bûche|leño (tronca)|tora|бревно||原木|丸木|||बोटा (कुन्दा)||balak|kinga (gogo)||||pień
 mol ja||||miller||molinero||||||||||||||mylläri|młynarz
 mol kan|||zho:磨 (mò), yue:磨 (mo4) tha:โม่ (mo), fra:moulin, spa:molino, rus:молоть  (molot’)|mill|moulin|molino|moenda (moinho)|мельница||磨坊||||चक्की||||||mylly|mielić
-mol sheku||||grindstone (millstone)|meule|muela|mó|жёрнов||磨石||||||||||myllynkivi|ostrzarka (kamień młyński)
+mol seku||||grindstone (millstone)|meule|muela|mó|жёрнов||磨石||||||||||myllynkivi|ostrzarka (kamień młyński)
 Moldova|desha|MD||Moldova||Moldova||||||||||||||Moldova|Mołdawia
 mole|unomete|mol||mole (unit)|mole (unité)|mol|mol|||摩尔 (单位)|モル||||||||||mol
 molekul|||eng:molecule, spa:por:molécula, fra:molécule|molecule||molécula||||分子|分子||||||||||molekuła (cząsteczka)
@@ -2705,9 +2705,9 @@ nega|||spa:por:negar, eng:negate|refuse (deny, decline)||rechazar (negar)|||||||
 nelu|nomer|4|kor:넷 (net) + swa:nne, zul:ne, + mal:നാലു (nālu), tel:నాలుగు (nālugu), kan:ನಾಲ್ಕು (nālku) + fin:neljä, est:neli, hun:négy|four (4)|quatre (4)|cuatro (4)|quatro (4)|четыре (4)||四 (4)|四 (4)||||||||kvar (4)|neljä (4)|cztery (4)
 nelu di galope||||gallop||||||||||||||||neli (kiitolaukka)|
 nelu gona||||square (tetragon)||cuadro||||||||||||||neliö|kwadrat (czworokąt, czworobok, tetragon)
-nen|||zho:年 (nián), yue:年 (nin4), jpn:年 (nen), kor:년 (nyeon), vie:năm,niên|year|an (année)|año||||年|年||||||||jaro|vuosi|rok
-nen festa||||anniversary||aniversario||||||||||||||vuosijuhla|rocznica
-nen mes den|||zho:年月日 (niányuèrì), jpn:年月日 (nengappi), kor:연월일 (yeonworil)|date||fecha||||年月日|年月日|연월일|||||||dato|päivämäärä|data
+nenu|||zho:年 (nián), yue:年 (nin4), jpn:年 (nen), kor:년 (nyeon), vie:năm,niên|year|an (année)|año||||年|年||||||||jaro|vuosi|rok
+nenu festa||||anniversary||aniversario||||||||||||||vuosijuhla|rocznica
+nenu mes den|||zho:年月日 (niányuèrì), jpn:年月日 (nengappi), kor:연월일 (yeonworil)|date||fecha||||年月日|年月日|연월일|||||||dato|päivämäärä|data
 nenufar|bio|Nymphaea alba|eng:nenuphar, spa:por:nenúfar, fra:nénufar, rus:ненюфа́р (nenjufár), fas:نیلوفر آبی‎ (nilufar-e âbi)|water lily (nenuphar)||nenúfar (lirio de agua)||||||||||||||lumme|lilia wodna, nenufar
 neodim yum|yum 060|Nd|eng:neodymium, fra:néodyme, spa:neodimio, por:neodímio, rus:неодим, zho:钕 (nǚ), jpn:ネオジム, kor:네오디뮴, vie:neođim, hin:नियोडाइमियम, ben:নিওডিমিয়াম, may:neodinium, swa:neodimi, ara: نيودميوم|neodymium|néodyme|neodimio|neodímio|неодим|نيودميوم|钕|ネオジム|네오디뮴|neođim|नियोडाइमियम|নিওডিমিয়াম|neodinium|neodimi|neodim||neodyymi|neodym
 neon|yum 010|Ne|eng:neon, fra:néon, spa:neón, por:néon, rus:неон, zho:氖 (nǎi), jpn:ネオン, kor:네온, vie:neon, nê-ông, hin:नियोन, ben:নিয়ন, may:neon, swa:neoni, ara: نيون|neon|néon|neón|néon|неон|نيون|氖|ネオン|네온|neon, nê-ông|नियोन|নিয়ন|neon|neoni|neon|neono|neon|neon
@@ -2762,7 +2762,7 @@ nong chun||||rural village||||||农村|農村|농촌|nông thôn|||||||maalaisky
 nong di||||agricultural|agricole|agrícola|agrícola|аграрный|||||||||||agrikultura|maataloudellinen (agraari-)|
 nong ja||||farmer||granjero (agricultor)||||||||||||||maanviljelijä|rolnik, farmer
 nong nomi||||agronomy|agronomie|agronomía|agronomia|агрономия|عِلْم الزِرَاعَة‎|农学|農学|농학|nông học|||||agronomi|agronomio|agronomia (maatalous)|agronomia
-nong shuta||||agriculture|||||||||||||||agrikulturo|viljely|
+nong suta||||agriculture|||||||||||||||agrikulturo|viljely|
 nong topo||||countryside||campo||||||||||||||maaseutu|wieś, tereny wiejskie
 nong topo di||||rural (rustic)||rural (rústico)||||||||||||||maalais-|wiejski, rustykalny
 norde|||eng:north, spa:por:norte, deu:Nord, fra:nord, rus:норд (nord)|north|nord|norte|norte|север (норд)||北|北|북|||||||nordo|pohjoinen|północ
@@ -2793,7 +2793,7 @@ nove ka||||novice (newbie)|néophyte|novato|novato (neófito)|новичок||�
 Nove Kaledonia|desha|NC||New Caledonia||Nueva Caledonia||||||||||||||Uusi-Kaledonia|Nowa Kaledonia
 nove loga||||neologism|néologisme|neologismo|neologismo|неологизм||新词|新語 (新造語)|신어 (신조어)||||||yenici deyim|neologismo|uudissana|neologizm
 nove ta||||newness|nouveauté|novedad|novidade|новизна||||||||||yenilik|noveco|uutuus|
-nove yang di||||modern||moderno|||||近代的||||||||||nowoczesne
+nove yanga di||||modern||moderno|||||近代的||||||||||nowoczesne
 Nove Yorke||||New York|||||||||||||||||Nowy Jork
 Nove Yorke siti|site|US||New York City|||||||||||||||||Stan Nowy Jork
 Nove Zelande|desha|NZ||New Zealand||Nueva Zelanda||||||||||||||Uusi-Seelanti|Nowa Zelandia
@@ -3057,7 +3057,7 @@ politi|||ell:πολιτική (politikē), may:politik, tur:politika, eng:politi
 politi di||||political||político|||||||||||||politika|poliittinen|polityczny
 politi ja||||politician (administrator, statesman)|administrateur|político (administrador)|administrador|управляющий|||||||||||politikisto|poliitikko (hallinnoija)|polityk
 politi logi||||politicology||ciencia política||||||||||||||politiikantutkimus|politologia
-politi lon||||politics (political discourse)||política||||政治|政道||||||||politiko|politiikka|polityka
+politi lona||||politics (political discourse)||política||||政治|政道||||||||politiko|politiikka|polityka
 politi mode||||regime||régimen|regime|||政体|政体|||||||||hallintomuoto|
 Polska|desha|PL||Poland||Polonia||||||||||||||puola|Polska
 polska basha|basha|||Polish language||idioma polaco||||||||||||||puolalainen|polski
@@ -3090,7 +3090,7 @@ posta marke||||postmark (postage stamp)|cachet de la poste|matasellos|carimbo|п
 pote|||eng:fra:pot, spa:por:pote, may:poci, jpn:ポット (potto), kor:포트 (poteu)|pot (vase, bin, jar)|pot (vase)|||||||||||||||pata|
 pote chamacha||||ladle (dipper, scoop)|louche (cuillère à pot)|cucharón (cazo)|concha|половник (черпак, ковш)||勺 (舀)||||चमचा (कलछी, डोई)||||kepçe (çömçe)||kauha|
 pote ja||||potter|potier|alfarero|oleiro|гончар|خَزَّاف‎|陶瓷工|陶工|도공||कुम्हार ||||||savenvalaja|
-pote shuta||||pottery|poterie|alfarería|cerâmica|гончарное дело||陶器制造|陶芸|||||||ufinyanzi||keramiikka|
+pote suta||||pottery|poterie|alfarería|cerâmica|гончарное дело||陶器制造|陶芸|||||||ufinyanzi||keramiikka|
 poze|||eng:spa:por:fra:pose, deu:Pose, rus:поза (poza), jpn:ポーズ|pose (position)||pose (postura)||||||||||||||asetelma|poza, pozycja
 prati|||eng:practice, fra:pratique, por:prática, tur:pratik, pol:praktyka, hin:प्रथा (prathā)|practice (actuality)||práctica||||||||||||||käytäntö (pragmatia)|praktyka, aktualność
 prati di||||practical (pragmatic)||práctico||||||||||||||käytännöllinen (pragmaattinen)|practyczny, pragmatyczny
@@ -3239,10 +3239,10 @@ rota lefte||||counterclockwise (anticlockwise)|dans le sens antihoraire|en el se
 rota raite||||clockwise||en el sentido del las agujas del reloj|||||||||||||||według ruchu wskazówek zegara
 rota she||||rotor (rotator)||rotor||||||||||||||roottori (propelli)|rotor, wirnik
 rota tafun||||cyclone (hurrican, tornado, typhoon)||huracán (tifón)||||飓风 (台风)|||||||||uragano (tajfuno)|pyörremyrsky (hurrikaani, taifuuni, tornado)|trąba powietrzna (cyklon, tornado, tajfun)
-rota van gi|||eng:top, fra:toupie|top (spinning top)|toupie|trompo||волчок|pinhão|陀螺|独楽|||gasing||||||hyrrä|bąk, bączek
+rota vanu gi|||eng:top, fra:toupie|top (spinning top)|toupie|trompo||волчок|pinhão|陀螺|独楽|||gasing||||||hyrrä|bąk, bączek
 Ruanda|desha|RW||Rwanda||Ruanda||||||||||||||Ruanda|Rwanda
 rubi|rang|||red|rouge|rojo|vermelho|красный|أَحْمَر|红|赤い|빨갛다|đỏ|लाल|লাল|merah|nyekundu|kırmızı (al)|ruĝa|punainen|czerwony
-rubi bau sheku|||eng:ruby, por:rubi, spa:rubí, fra:rubis, deu:Rubin, rus:рубин (rubin), jpn:ルビー (rubī)|ruby|rubis|rubí|rubi|рубин|ياقوت|红宝石|ルビー|루비|hồng ngọc|मानिक (याक़ूत)||delima|yakuti|yakut|rubeno|rubiini|rubin
+rubi bau seku|||eng:ruby, por:rubi, spa:rubí, fra:rubis, deu:Rubin, rus:рубин (rubin), jpn:ルビー (rubī)|ruby|rubis|rubí|rubi|рубин|ياقوت|红宝石|ルビー|루비|hồng ngọc|मानिक (याक़ूत)||delima|yakuti|yakut|rubeno|rubiini|rubin
 rubi yum|yum 037|Rb|eng:rubidium, fra:rubidium, spa:rubidio, por:rubídio, rus:рубидий, zho:铷 (rú), jpn:ルビジウム, kor:루비듐, vie:rubiđi, hin:रुबिडियम, ben:রুবিডিয়াম, may:rubidium, swa:rubidi, ara: روبيديوم|rubidium|rubidium|rubidio|rubídio|рубидий|روبيديوم|铷|ルビジウム|루비듐|rubiđi|रुबिडियम|রুবিডিয়াম|rubidium|rubidi|rubidyum|rubidio|rubidium|rubid
 ruhu|||ara:(rūħ), may:ruh, tur:ruh, hin:रूह (rūh), swa:roho, hau:ruhu, som:ruux, + rus:дух (duh)|soul (mind, psyche)|psyché|psique||душа (дух)|||||||||||animo (psiko)|henki (sielu, mieli, psyyke)|dusza, duch, umysł
 ruhu di||||mental (psychic)||mental (psíquico)||||||||||||||henkinen (psyykkinen)|umysłowy (psychiczny)
@@ -3280,7 +3280,7 @@ safar kegu||||tourism||turismo||||||||||||||turismi|turystyka
 safar kegu ja||||tourist|touriste|turista||||||||||||||turisti|turysta
 safran|||ara:(zaʿfarān), swa:zafarani, fas:(za'ferân), fra:tur:safran, eng:saffron, spa:azafrán, por:açafrão, rus:шафран (šafran)|saffron||azafrán||шафран|||||||||||safrano|sahrami|szafran
 sagu|bio|Metroxylon sagu|eng:sago, fra:sagou, spa:sagú, por:may:sagu, rus:саго (sago), ara: سَاغُو‎ (sāḡū), zho:西谷米 (xīgúmǐ), jpn:サゴ (sago), hin:सागू (sāgū)|sago palm|sagoutier|sagú|sagu|саго|سَاغُو‎|西谷米|サゴ|||सागू||pokok sagu||||saagopalmu|sago
-sagu fen||||sago|||||||サゴ澱粉|||||sagu||||saagotärkkelys|
+sagu fun||||sago|||||||サゴ澱粉|||||sagu||||saagotärkkelys|
 Sahara Desha|desha|||Sahrawi Arab Democratic Republic||República Árabe Saharaui Democrática|||||||||||||||Sahara Zachodnia (Saharyjska Arabska Republika Demokratyczna)
 sahi|||hin:सही (sahī), urd:(sahī), fas:(sahih), ara:(ṣaḥīḥ), swa:sahihi|right (correct, accurate)|correct (juste)|correcto (justo)|correto (justo)|правильный|صَحِيح|正确|正しい|옳다|phải (đúng)|सही||betul (benar)|sahihi|doğru|ĝusta (prava)|oikea (paikkansapitävä)|właściwy, poprawny
 saide||||hunt (fish)|chasser|cazar (pescar)|caçar|охотиться||打猎|狩る||||||||ĉasi|pyytää (metsästää, kalastaa)|polować (łowić)
@@ -3383,7 +3383,7 @@ selge|bio|Beta vulgaris subsp. vulgaris, Cicla|ara:سلق (silqa), spa:por:acelg
 selu|||may:sel, fas:sellul, tha:เซลล์ (seel), swa:seli, tgl:selula, eng:cell, fra:cellule, spa:célula|cell (biology)||célula|||||||||||||ĉelo|solu|komórka (biologia)
 selu logi||||cytology|cytologie|citología|citologia|цитология||细胞学|||||||||citologio|soluoppi (sytologia)|cytologia
 seme|||fra:semence, por:semente, spa:semilla, rus:семя (semya), eng:semen|seed (semen)|semence|semilla|semente|семя||种||||बीज|বীজ|biji||tohum|semo|siemen|ziarno (nasienie)
-seme dane||||seed (fertilized grain)||pepita||||种子|種|||||biji benih||||siemenjyvä|ziarno, nasienie
+seme dana||||seed (fertilized grain)||pepita||||种子|種|||||biji benih||||siemenjyvä|ziarno, nasienie
 seme di||||seminal|séminal|seminal|seminal|семенной||种子的|||||||||sema|siemen-|nasienny
 semente|||eng:cement, may:semen, spa:cemento, swa:sementi, tur:çimento, vie:xi măng, hin:सीमेंट (siment), rus:цемент (tsement), ara:(ʾasmant), kor:시멘트 (simenteu)|cement||cemento||цемент|||||||||sementi|çimento||sementti|cement
 sene|||ara: سِنّ‎ (sinn), hin:सिन (sin) + spa:por:sene + zho:岁 (suì), yue:歲 (seoi3), kor:세  (-se), jpn:歳 (-sai)|age|âge|edad|idade|возраст|عُمْر|年岁|年齢|연세||आयु (उमर)||umur|umri||aĝo|ikä|wiek
@@ -3396,8 +3396,8 @@ sentaure|bio|Centaurea|eng:centaury, por:centáurea||Centaurée||centáurea|ва
 senti|numbe|||centi- (per cent)||centi- (por ciento)|||||||||||||centono|sentti|centy-, procent, na sto, setna część
 sentimitre|unomete|cm||centimeter (cm)||centímetro||||||||||||||senttimetri (cm)|centymetr
 sento|nomer|100|fra:cent, spa:cien, por:cem, ita:cento, eng:cent-, hin:शत (śat), ben:শত (śôt)|hundred (hecto-, 100)|cent (100)|cien (100)|cem (100)|сто|مِئَة|百|百 (１００)|백|một trăm|सौ|শত|ratus|mia|yüz|cent|sata (hehto-)|sto (100)
-sento nen||||century|siècle (centennie)|centuria (siglo)|século|столетие||世纪|世紀|세기|thế kỷ|शताब्दी|শতাব্দী|abad||yüzyıl (asır)|jarcento (centjaro)|vuosisata|stulecie
-sento nen di||||centenary|centenaire|centenario|centénario|столетний|||||||||||centjara|satavuotinen|
+sento nenu||||century|siècle (centennie)|centuria (siglo)|século|столетие||世纪|世紀|세기|thế kỷ|शताब्दी|শতাব্দী|abad||yüzyıl (asır)|jarcento (centjaro)|vuosisata|stulecie
+sento nenu di||||centenary|centenaire|centenario|centénario|столетний|||||||||||centjara|satavuotinen|
 sera|||spa:sierra, por:serra, eng:serrate|saw|scie|sierra|serra|пила||锯子|のこぎり||||||||||piła
 serami|||eng:ceramic, spa:cerámica, por:cerâmico, fra:céramique, rus:керамика (keramika), ben:সিরামিক (sirāmika), tur:mel:seramik|ceramic||cerámica|cerâmico|керамика||陶瓷|陶器|||मृत्तिकाशिल्प||seramik||||savityö (keramiikka)|ceramika
 serami sing|bio|Houstonia||bluet|||||||||||||||||houstonia
@@ -3419,8 +3419,8 @@ sham yam||||dinner||cena|||||夕食||||||||vespermanĝo|illallinen|kolacja
 shaman|||eng:shaman, fra:chaman, spa:chamán, rus:шаман (šaman), tur:şaman, may:shaman, jpn:シャーマン (shāman)|shaman||chamán (brujo, hechicero)||шаман|||シャーマン|||||dukun (pawang, shaman)|||ŝamano|šamaani|szaman
 shampan|regia|||Champagne|Champagne|Champaña|Champagne|Шампань|||香槟|シャンパーニュ|||||||||Champagne
 shampan vin|alkohol|||champagne|champagne|champaña|champanhe|шампанское||||||||||||ĉampano|samppanja
-shan|||zho:山 (shān), jpn:山 (san), kor:산 (san), vie:sơn|mountain (hill)||montaña (colina)|||||||||||||monto|vuori (mäki)|góra, wzgórze
-shan pike||||top (peak, pinnacle, summit, apex, vertex)|cime (pic, sommet)|cima (pico, cumbre, vértice)|cume (pico, topo)|вершина|||頂点||||||||pinto|huippu|szczyt (wierzchołek)
+san|||zho:山 (shān), yue:山 (saan1), jpn:山 (san), kor:산 (san), vie:sơn|mountain (hill)||montaña (colina)|||||||||||||monto|vuori (mäki)|góra, wzgórze
+san pike||||top (peak, pinnacle, summit, apex, vertex)|cime (pic, sommet)|cima (pico, cumbre, vértice)|cume (pico, topo)|вершина|||頂点||||||||pinto|huippu|szczyt (wierzchołek)
 shanghai|site|||Shanghai||||||上海|||||||||||Szanghaj
 shanti|||hin:शांति (shānti), ben:শান্তি (shānti), pan:ਸ਼ਾਂਤੀ (shāntī), mar:शांत (shānta), tel:శాంతి (shānti), guj:શાંતિ (shānti), khm:សន្តិ (sɑnte’), eng:por:shanti, rus:шанти (shanti), jpn:シャンティ (shanti)|rest (relief, repose)|repos|descanso (alivio)|descanso (repouso)|отдых||||||||||||lepo|zostawić (zostawiać)
 shanti di||||calm (peaceful, quiet)|calme (tranquille)|tranquilo (calmado)|tranquilo (calmo)|спокойный||||||शांत|||||trankvila (serena)|rauhallinen (levollinen, tyyni)|spokojny
@@ -3447,10 +3447,10 @@ she hal ironi||||situational irony|||||||||||||||||ironia sytuacyjna
 shefe|||fra:chef, por:chefe, spa:jefe, rus:шеф (šef), eng:chief, swa:chifu, jpn:チーフ (chīfu), + ara:(šeyx)|chief (boss)|chef|jefe|chefe|шеф|||||||||||estro (ĉefulo)|päällikkö (pomo)|szef, kierownik
 shefe di||||main (principal)||principal||||||||||||||pää-|główny
 shefe minister||||prime minister||primer ministro|||||||||||||ĉefministro|pääministeri (suurvisiiri)|premier
-sheku|||zho: 石 (shí), yue:石 (sek3), jpn:石 (seki), kor:석 (seok)|stone (piece of rock)|pierre|piedra|pedra|камень (камешек)||石 (岩)|||||||||ŝtono|kivi (hippu)|kamień (kawał skały)
-sheku jang ja||||mason (stonemason, stonecutter)||albañil (mampostero, cantero)|||||石匠||||||||||kamieniarz
-shenga|||zho:胜 (shèng), yue:勝 (sing3), wuu:勝 (sen2), jpn:勝 (shō), kor:승 (seung), vie:thắng|victory (win, triumph)||victoria|||||||||||||venko|voitto|zwycięstwo, wygrana
-shenga bai||||outcome (victory or defeat)||||||勝敗|勝敗||||||||||
+seku|||zho: 石 (shí), yue:石 (sek3), jpn:石 (seki), kor:석 (seok)|stone (piece of rock)|pierre|piedra|pedra|камень (камешек)||石 (岩)|||||||||ŝtono|kivi (hippu)|kamień (kawał skały)
+seku jianga ja||||mason (stonemason, stonecutter)||albañil (mampostero, cantero)|||||石匠||||||||||kamieniarz
+senga|||zho:胜 (shèng), yue:勝 (sing3), wuu:勝 (sen2), jpn:勝 (shō), kor:승 (seung), vie:thắng|victory (win, triumph)||victoria|||||||||||||venko|voitto|zwycięstwo, wygrana
+senga bai||||outcome (victory or defeat)||||||勝敗|勝敗||||||||||
 shi|||zho:氏 (shì), yue:氏 (si6), jpn:氏 (-shi), kor:씨 (ssi) + may:si + hin:श्री (śrī), ben:শ্রী  (śri)|Mx. (Mr. or Ms.)|||||||さん (氏)|||श्री|শ্রী|||||herra tai rouva|
 shia|||ara: شِيعَة (šīʿa), heb: סִיעָה (si'á) + zho:系 (xì)|faction (clique)|faction (clique)|facción|facção|фракция (клика)|شيعة|派系||||||||||porukka (kuppikunta, lohko, siipi)|
 shia islam din||||Shia Islam (Shi’ism)|chiisme|chiismo (chía)|xiismo|шиизм|الشِّيعَة‎|什叶派|シーア派|||शिया|||||ŝijaismo|šiialaisuus|szyism
@@ -3493,8 +3493,8 @@ shuru|||ara: شُرُوع‎ (šurūʿ), fas: شروع (šoru') , hin:शुर�
 shuru di||||initial (first)||primer (inicial, inaugural)||||||||||||||ensimmäinen (alku-)|pierwszy, początkowy
 shush|||eng:shh, fra:chut, rus:ш-ш-ш, zho:噓 (xū), jpn:しーっ (shīt), kor:쉿 (swit), tur:sus|hush (shh)||chito (chist)||||噓|しーっ|쉿|suỵt|||||||hiljaa (hys, shhh)|ćsi
 shush di||||silent||silencioso||тихий|||||||||||silenta|hiljainen|cichy
-shuta|||zho:术 (shù), yue:術 (seot6), jpn:術 (jutsu), kor:술 (sul)|skill (art, craft)|art|dotes (arte, habilidad)|arte|искусство||技术|術|||||||||taito|umiejętność (kompetencja)
-shuta tabi||||skillful (crafty)|||||||||||||||||
+suta|||zho:术 (shù), yue:術 (seot6), jpn:術 (jutsu), kor:술 (sul)|skill (art, craft)|art|dotes (arte, habilidad)|arte|искусство||技术|術|||||||||taito|umiejętność (kompetencja)
+suta tabi||||skillful (crafty)|||||||||||||||||
 si|||zho:是 (shì), yue:是 (si4) + spa:por:ser|be|être|ser (estar)|ser (estar)|быть||对||||होना||ialah||olmak|esti|olla|być
 si dura||||elapse (pass by, go by)|se passer|transcurrir|transcorrer|||||||||||||kulua (vieriä)|
 si ja||||being (entity)||ser||||||||||||||olento (olio)|
@@ -3638,7 +3638,7 @@ suna di||||conventional (customary, traditional)||traditional (convencional)||||
 suna islam din||||Sunni Islam (Sunnism)|sunnisme|sunismo|sunismo|сунниты|||||||||||sunaismo|sunnalaisuus|
 sundar|||hin:सुन्दर (sundar), ben:সুন্দর (sundôr), guj:સુંદર (sundar),|beautiful (handsome, pretty)|beau|hermoso (bello, lindo)|belo (lindo)|красивый|جَمِيل|漂亮 (美)|美しい|아름답다|đẹp|सुन्दर (ख़ूबसूरत)|সুন্দর|indah (cantik)|zuri|güzel|bela|kaunis (komea, sievä)|piękny, przystojny
 sundar daka||||decoration (ornament)||decoración (adorno)||украшение||装饰|装飾||||||||||dekoracja (ornament)
-sundar shuta||||fine arts||bellas artes||||艺术 (美术)|芸術 (美術)|예술|nghệ thuật|कला|শিল্প|seni|sanaa|sanat|arto|taide|sztuka
+sundar suta||||fine arts||bellas artes||||艺术 (美术)|芸術 (美術)|예술|nghệ thuật|कला|শিল্প|seni|sanaa|sanat|arto|taide|sztuka
 sundar ta||||beauty|beauté|belleza (hermosura)|beleza|красота|جَمَال|美丽|美しさ|아름다움||सौन्दर्य|||uzuri (jamala, urembo)|güzellik|beleco|kauneus|piękno
 Suomi|desha|FI||Finland||Finlandia|||||||||||||Finnlando|Suomi|Finlandia
 suomi basha|basha|||Finnish language||idioma finés|||||||||||||lingvo|suomen kieli|
@@ -3711,7 +3711,7 @@ tele di||||far||lejano (lejos)|||||||||||||malproksima|kaukainen|daleki, odległ
 tele fon gi||||telephone|téléphone|telefono||телефон|تِلِفُون|电话机|電話|전화||दूरभाष (टेलीफ़ोन)|দূরভাষা (টেলিফোন)|telepon|simu|telefon|telefono|puhelin|telefon
 tele fon lin||||telephone line|ligne téléphonique|||телефонная линия||电话线||||||||||puhelinjohto|
 tele fon nomer||||telephone number||||||||||||||||puhelinnumero|
-tele fon shuta||||telephony (telephone communication)||telefonía|telefonia|телефония||||||||||||puhelintekniikka|
+tele fon suta||||telephony (telephone communication)||telefonía|telefonia|телефония||||||||||||puhelintekniikka|
 tele ta||||distance (length)||distancia||||||||||||||etäisyys|dystans
 tele vide gi||||television|téléviseur|televisión||телевизор||电视机|||||||||televidilo|televisio|telewizja
 teleskope||||telescope|télescope (lunette)|telescopio|telescópio|телескоп||望远镜|望遠鏡 (テレスコープ)|망원경|kính thiên văn|दूरबीन|দূরবীন|teleskop|darubini|teleskop|teleskopo|kaukoputki (teleskooppi)|teleskop
@@ -3791,7 +3791,7 @@ tren dau||||rail (railway, railroad)||vía férrea|||||||||||||fervojo|junarata 
 tren kape ja||||train hijacker||||||||||||||||junakaappari|porywacz pociągu
 tri|nomer|3|eng:three, fra:trois, spa:tres, por:três, rus:три (tri), hin:त्रि-  (tri-), ben:ত্রি- (tri-), may:tri-|three (3)|trois (3)|tres (3)|três (3)|три (3)||三 (3)|三 (3)||||||||tri (3)|kolme (3)|trzy (3)
 tri gona||||triangle||triángulo||||||||||||||kolmio|trójkąt
-tri zong||||trident||tridente||трезубец||三叉戟|三つまた (トライデント)|||||||||atrain|trójząb
+tri pike||||trident||tridente||трезубец||三叉戟|三つまた (トライデント)|||||||||atrain|trójząb
 tribu|||fra:spa:tribu, por:tgl:tribo, eng:tribe|tribe||tribu|||||||||||||tribo|heimo|plemię
 Trinidade e Tobago|desha|TT||Trinidad and Tobago||Trinidad y Tobago||||||||||||||Trinidad ja Tobago|Trynidad i Tobago
 Triton|planete 8 lun 1|||Triton||||||||||||||||Triton|
@@ -3808,7 +3808,7 @@ tulpan|bio|Tulipa|eng:tulip, spa:tulipá, por:túlipa, nld:tulp, rus:тюльп�
 tumon|pron.|||you all||ustedes||||你们|あなたたち||||||||vi ĉiu|te|wy, was
 tumon su||||your|votre|vuestro|vosso|ваш||你们的|||||||||via|teidän|
 tundra|||eng:spa:por:tur:tundra, rus:тундра (tundra), ara:تندرا‎ (tundrā), hin:टुंड्रा (ṭuṇḍrā), jpn:ツンドラ (tsundora)|tundra||tundra|||||||||||||tundro|tundra|tundra
-tundra shan||||fell||||фьельды||||||||||||tunturi|
+tundra san||||fell||||фьельды||||||||||||tunturi|
 tunel|||eng:fra:tunnel, spa:por:túnel, rus:тоннель (tonnel’), tur:tünel, jpn:トンネル (tonneru), 터널 (teoneol)|tunnel||túnel|||||||||||||tunelo|tunneli|tunel
 tunel tren||||subway (metro)||metro|||||||||||||metroo|metrojuna (maanalainen)|metro
 tunika|||spa:túnica, eng:tunic, rus:туника (tunika)|tunic (gown)||túnica|||||||||||||robo|mekko (tunika)|tunika, toga
@@ -3899,7 +3899,7 @@ var|||hin:वार (vār), ben:বার (bar) + por:feira|day of the week||dí
 var cheti||||Sunday|dimanche|domingo|domingo|воскресенье|يوم الأحد|星期日 (禮拜日)|日曜日|일요일|chủ nhật|रविवार|রবিবার|minggu|jumapili|pazar|dimanĉosunnuntai|niedziela|niedziela
 var du||||Tuesday|mardi|martes|terça-feira|вторник|يوم الثلاثاء|星期二 (禮拜二)|火曜日|화요일|thứ ba|मंगलवार|মঙ্গলবার|selasa|jumanne|salı|mardo|tiistai|wtorek
 var lima||||Friday|vendredi|viernes|sexta-feira|пятница|يوم الجمعة|星期五 (禮拜五)|金曜日|금요일|thứ sáu|शुक्रवार|সুক্রবার|jumat|ijumaa|cuma|vendredo|perjantai|piątek
-var luka||||Saturday|samedi|sábado|sábado|суббота|يَوم السبت|星期六 (礼拜六)|土曜日|토요일|thứ bảy|शनिवार|শনিবার|sabtu|jumamosi|cumartesi|sabato|lauantai|sobota
+var liuka||||Saturday|samedi|sábado|sábado|суббота|يَوم السبت|星期六 (礼拜六)|土曜日|토요일|thứ bảy|शनिवार|শনিবার|sabtu|jumamosi|cumartesi|sabato|lauantai|sobota
 var nelu||||Thursday|jeudi|jueves|quinta-feira|четверг|يوم الخميس|星期四 (禮拜四)|木曜日|목요일|thứ năm|गुरुवार|বৃহস্পতিবার|kamis|alhamisi|perşembe|ĵaŭdo|torstai|czwartek
 var tri||||Wednesday|mercredi|miércoles|quarta-feira|среда|يوم الأربعاء|星期三 (禮拜三)|水曜日|수요일|thứ tư|बुधवार|বুধবার|rabu|jumatano|çarşamba|merredo|keskiviikko|środa
 var un||||Monday|lundi|lunes|segunda-feira|понедельник|يوم الإثنين|星期一 (禮拜一)|月曜日|월요일|thứ hai|सोमवार|সোমবার|senin|jumatatu|pazartesi|luno|maanantai|poniedziałek
@@ -4005,7 +4005,7 @@ yam sukar gana|bio|Saccharum edule||duruka||||||||||||tebu telur|||||cukrowiec j
 yam yau||||hunger|faim|hambre|fome|голод|جوع‎|饥饿|飢え|굶주림|đói|भूख|ক্ষুধা|lapar|njaa|açlık|malsato|nälkä|głód
 yamon|pron.|||they||ellos o ellas||||他们|||||||||ili|he|oni
 yamon su||||their|leur|||их||他们的||||उनका|||||ilia|heidän|
-yang|||zho:样 (yàng), tha:อย่าง (yàang), khm:យ៉ាង (yaang)|kind (style, sort, type)||variedad (tipo, estilo)|||||タイプ||||||||speco (tipo, stilo)|laji (tyyppi, tyyli)|rodzaj, typ, styl
+yanga|||zho:样 (yàng), tha:อย่าง (yàang), khm:យ៉ាង (yaang)|kind (style, sort, type)||variedad (tipo, estilo)|||||タイプ||||||||speco (tipo, stilo)|laji (tyyppi, tyyli)|rodzaj, typ, styl
 Yapetus|planete 6 lun 8|||Iapetus||||||||||||||||Japetus|
 yasen|bio|Fraxinus|rus:ясень (yasen’), pol:jesion|ash tree|frêne|fresno|freixo|ясень||白蜡树|秦皮|||||||dişbudak||saarni|jesion
 yatim|||ara:fas:(yatim), tur:yetim, swa:yatima, hin:यतीम (yatīm)|orphan||huérfano||||||||||||||orpo|sierota
@@ -4035,10 +4035,10 @@ yoga ja||||yogi||yogui||||||||||||||joogi|jogin (joginka)
 yogo|||eng:yoke, spa:yugo, por:jugo, fra:joug, rus:иго (igo), fas:  یوغ‎ (yuğ) + yue:軛 (aak1), vie:ách|yoke|joug|yugo|jugo|ярмо (иго)||轭|軛||ách|जुआ|জোয়াল|||boyunduruk|jugo|ies|jarzmo
 yogur|||eng:may:yogurt, fra:yogourt, spa:yogur, por:iogurte, rus:йогурт (yogurt), zho:优格 (yōugé), jpn:ヨーグルト (yōguruto), kor:요구르트 (yogureuteu), tur:yoğurt |yogurt|yaourt (yogourt)|yogur|iogurte|йогурт|لَبَن|酸奶 (优格)|ヨーグルト|요구르트|sữa chua|दही|দই|yogurt|maziwa ya mgando|yoğurt|jogurto|jogurtti|jogurt
 Yohan festa||||Saint John's Day||día de San Juan||Иванов день||||||||||||juhannus (kristillinen juhla)|dzień świętego Jana
-yong|||zho:溶 (róng), yue:溶 (jung4), jpn:溶 (yō), kor:용 (yong), vie:dung|melt|melt|derretirse|derretre|||融化|溶ける|||||||||sulaa|topnieć (upłynniać się)
-yong liga||||fusion (amalgamation)||fusión||||||||||||||fuusio (yhteensulautuminen)|fuzja (amalgamowanie, łączenie)
-yong petra||||lava|lave|lava||||熔岩|溶岩|||||||||laava|lawa
-yong safa||||smelt|fondu|||||熔炼|||||||||||topić (upłynnić, upłynniać)
+yung|||zho:溶 (róng), yue:溶 (jung4), jpn:溶 (yō), kor:용 (yong), vie:dung|melt|melt|derretirse|derretre|||融化|溶ける|||||||||sulaa|topnieć (upłynniać się)
+yung liga||||fusion (amalgamation)||fusión||||||||||||||fuusio (yhteensulautuminen)|fuzja (amalgamowanie, łączenie)
+yung petra||||lava|lave|lava||||熔岩|溶岩|||||||||laava|lawa
+yung safa||||smelt|fondu|||||熔炼|||||||||||topić (upłynnić, upłynniać)
 Yoruba|nas|||Yoruba (language and people)|||||||||||||kiyoruba|||joruban kansa ja kieli|Joruba
 yota|nomer||eng:fra:spa:por:yotta, may:yota-, zho:尧它- (yáotā-), jpn:ヨタ- (yota-), kor:요타- (yota-)|yotta-||||||||||||||||kvadriljoona (jotta-)|
 yumor|||rus:юмор (yumor), spa:eng:humor, fra:humour, jpn:ユーモア (yūmoa), kor:유머 (yumeo), zho:幽默 (yōumò)|humor||humor (gracia)||юмор|||||||||||humuro|huumori|humor
@@ -4091,7 +4091,7 @@ zoku di||||continuous (analog)|continu (analogique)|continuo (analógico)|analó
 zombi|||kon:nzambi, eng:zombie, spa:tur:zombi, por:zumbi, rus:зомби (zombi), ara:زُومْبِي‎ (zūmbī), hin:ज़ोंबी (zombī), jpn:ゾンビ (zonbi), kor:좀비 (jombi)|zombie|zombi|zombi|zumbi|||||||ज़ोंबी||||||zombi|zombie, zombi
 zona|||ell:ζώνη (zónē), eng:fra:zone, spa:por:zona, rus:зона (zona)|belt (zone)|zone|cinturón (zona)|zona|пояс (зона)|||||||||||zono|vyö|pas, strefa
 zou|||eng:fra:spa:por:may:tur:zoo-, rus:зоо- (zoo-)|animal|animal (bête)|animal (bestia)|animal (besta, bicho)|животное||动物|動物|동물|thú vật (động vật)|जानवर (हैवान)|জানোয়ার|kewan|mnyama|hayvan|besto|eläin|animal
-zou agro shuta||||animal husbandry|élevage||||||畜産|||||||||karjanhoito|hodowla zwierząt
+zou agro suta||||animal husbandry|élevage||||||畜産|||||||||karjanhoito|hodowla zwierząt
 zou bagi||||zoo (zoological garden)|zoo|zoo|zoológico|зоопарк||动物园|動物園|동물원|thảo cầm viên|चिड़ियाघर|চিড়িয়াখানা|kebun binatang|bustani ya wanyama|hayvanat bahçesi|zoo (bestoĝardeno)|eläintarha|zoo (ogród zoologiczny)
 zou fili||||zoophily||||||||||||||||eläinrakkaus|
 zou geo grafi||||zoogeography||||||||||||||||eläinmaantiede|

--- a/pandunia-loge.csv
+++ b/pandunia-loge.csv
@@ -1465,7 +1465,7 @@ gua|||ben:গুহা (guha), tha:คูหา (gūhā), tel:గుహ (guha),
 Guadelupe|desha|GP||Guadeloupe||Guadalupe||||||||||||||Guadeloupe|Gwadelupa
 guai|||zho:怪 (guài), yue:怪 (gwaai3), jpn:怪 (kai), kor:괴 (goe), vie:quái|odd (strange, weird, peculiar, bizarre)|bizarre|raro (extraño)|bizarro|странный|عَجِيب‎|奇怪|変||quái||अजीब||||stranga|outo (kummallinen)|dziwny
 Guam|desha|GU||Guam||Guam||||||||||||||Guam|Guam
-guan|||zho:官 (guăn), yue:官 (gun1), jpn:官 (kan), kor:관 (gwan), vie:quan|office (position)||cargo||||||||||||||virka (virka-asema)|urząd, pozycja, stanowisko, funkcja
+guan|||zho:官 (guān), yue:官 (gun1), jpn:官 (kan), kor:관 (gwan), vie:quan|office (position)||cargo||||||||||||||virka (virka-asema)|urząd, pozycja, stanowisko, funkcja
 guan di||||official (pertaining to public trust)||oficial||||||||||||||virallinen|oficjalny
 guan ja||||officer (bureaucrat, public servant)||funcionario||||||||||||||virkailija (virkamies)|funkcjonariusz, urzędnik
 Guangjou|site||CN|Guangzhou (Canton)||||||广州||||||||||Guangzhou (Kanton)|Kanton
@@ -2310,9 +2310,9 @@ lote|||por:spa:lote, eng:fra:lot|batch (lot)||lote (grupo)||||||||||||||erä (sa
 lotra|bio|Lutrinae|eng:otter + fra:loutre, spa:tgl:lutrino, por:lontra + rus:выдра (vydra)|otter|loutre|nutria|lontra|выдра||獭|獺||||||||||wydra
 lou|||zho:漏 (lòu), yue:漏 (lau6), jpn:漏 (rō), 루 (ru)|leak||chorrear|vazar|протекать (просочиться)||漏|漏る||||||||liki|vuotaa|przeciekać, ciec
 lou sang||||bleed||sangrar|||||||||||||sangi|vuotaa verta|krwawić
-liuka|nomer|6|zho:六 (liù), yue:六 (luk6), jpn:六 (roku), kor:육/륙 (六, yuk/ryuk), vie:lục|six (6)|six (6)|seis (6)|seis (6)|шесть (6)||六 (6)|六 (6)|||||||||kuusi (6)|sześć (6)
-liuka fase||||hexahedron (cube)||hexaedro (cubo)||||||||||||||kuutio (kuusitahokas)|sześcian (kostka)
-liuka gona||||hexagon||hexágono||||||||||||||kuusikulmio|sześciokąt (sześciobok)
+luka|nomer|6|zho:六 (liù), yue:六 (luk6), jpn:六 (roku), kor:육/륙 (六, yuk/ryuk), vie:lục|six (6)|six (6)|seis (6)|seis (6)|шесть (6)||六 (6)|六 (6)|||||||||kuusi (6)|sześć (6)
+luka fase||||hexahedron (cube)||hexaedro (cubo)||||||||||||||kuutio (kuusitahokas)|sześcian (kostka)
+luka gona||||hexagon||hexágono||||||||||||||kuusikulmio|sześciokąt (sześciobok)
 Luksemburge|desha|LU||Luxembourg||Luxemburgo||||||||||||||Luxemburg|Luksemburg
 lulu|||amh:ሉል (lul), ara:(luʾluʾa), swa:lulu, orm:lu'ulu'a, hau:lu'ulu'u, ful:luuluuri, fas:(lo'lo')|pearl||perla|||||||||||||perlo|helmi|perła
 lona|||zho:论 (lùn), yue:論 (leo6), kor:론 (ron), jpn:論 (ron), vie:luận|discussion (debate, discourse)||discusión (debate, discurso)||||论||||||||||väittely (debatti)|dyskusja, debata, dyskurs
@@ -2487,7 +2487,7 @@ mes des du|mes|||December||deciembre|||||１２月|||||||||joulukuu|kwiecień
 mes des un|mes|||November||nobiembre|||||１１月|||||||||marraskuu|marzec
 mes du|mes|||February||febrero|||||２月|||||||||helmikuu|maj
 mes lima|mes|||May||mayo|||||５月|||||||||toukokuu|sierpień
-mes liuka|mes|||June||junio|||||６月|||||||||kesäkuu|wrzesień
+mes luka|mes|||June||junio|||||６月|||||||||kesäkuu|wrzesień
 mes nelu|mes|||April||abril|||||４月|||||||||huhtikuu|lipiec
 mes tisa|mes|||September||septiembre|||||９月|||||||||syyskuu|grudzień
 mes tri|mes|||March||marzo|||||３月|||||||||maaliskuu|czerwiec
@@ -3899,7 +3899,7 @@ var|||hin:वार (vār), ben:বার (bar) + por:feira|day of the week||dí
 var cheti||||Sunday|dimanche|domingo|domingo|воскресенье|يوم الأحد|星期日 (禮拜日)|日曜日|일요일|chủ nhật|रविवार|রবিবার|minggu|jumapili|pazar|dimanĉosunnuntai|niedziela|niedziela
 var du||||Tuesday|mardi|martes|terça-feira|вторник|يوم الثلاثاء|星期二 (禮拜二)|火曜日|화요일|thứ ba|मंगलवार|মঙ্গলবার|selasa|jumanne|salı|mardo|tiistai|wtorek
 var lima||||Friday|vendredi|viernes|sexta-feira|пятница|يوم الجمعة|星期五 (禮拜五)|金曜日|금요일|thứ sáu|शुक्रवार|সুক্রবার|jumat|ijumaa|cuma|vendredo|perjantai|piątek
-var liuka||||Saturday|samedi|sábado|sábado|суббота|يَوم السبت|星期六 (礼拜六)|土曜日|토요일|thứ bảy|शनिवार|শনিবার|sabtu|jumamosi|cumartesi|sabato|lauantai|sobota
+var luka||||Saturday|samedi|sábado|sábado|суббота|يَوم السبت|星期六 (礼拜六)|土曜日|토요일|thứ bảy|शनिवार|শনিবার|sabtu|jumamosi|cumartesi|sabato|lauantai|sobota
 var nelu||||Thursday|jeudi|jueves|quinta-feira|четверг|يوم الخميس|星期四 (禮拜四)|木曜日|목요일|thứ năm|गुरुवार|বৃহস্পতিবার|kamis|alhamisi|perşembe|ĵaŭdo|torstai|czwartek
 var tri||||Wednesday|mercredi|miércoles|quarta-feira|среда|يوم الأربعاء|星期三 (禮拜三)|水曜日|수요일|thứ tư|बुधवार|বুধবার|rabu|jumatano|çarşamba|merredo|keskiviikko|środa
 var un||||Monday|lundi|lunes|segunda-feira|понедельник|يوم الإثنين|星期一 (禮拜一)|月曜日|월요일|thứ hai|सोमवार|সোমবার|senin|jumatatu|pazartesi|luno|maanantai|poniedziałek


### PR DESCRIPTION
ni tire chingo uze la masim nove kanun do fa hapu han loga.  mi no sekur rai ki pan mute si masim bon.

in particular, I think Japanese should have some say about the onset consonant.  in the words **suta** and **seng** (and maybe **sina**), mandarin uses a **sh** sound while cantonese and korean use a plain **s**, so the rules say that the Pandunia word should use **s**.  but Japanese uses **sh** for all of these words (in the case of **sina**, Japanese allophony means there's no difference between **s** and **sh**, so that one only arguably belongs in this list).  so it seems to me like the **sh** version would be more recognizable to a large number of peeple for those two words.

also, I don't think it makes sense to have the **-u** on **mangu**, **nenu**, **vanu**, and **huangu**.  these syllables cannot have tone 1, because a tone 1 word cannot start with a tenuis consonant unless it is checked.  thus, the words **mang**, **nen**, **van**, and **huang** will be unused in this system.  if the goal of the vowels is to make space for more words---not to make the vocabulary more intuitive to Chinese language speakers---then I think there's little reason not to remove the final vowels from those four words.